### PR TITLE
Critical fixes: data-loss, crash, and updater zip-slip

### DIFF
--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -2088,35 +2088,32 @@ namespace Savedrake
 
                 if (confirmResult == DialogResult.Yes)
                 {
-                    // Indicate that a new deletion action has started
+                    // Snapshot the selected file paths before mutating the ListView.
+                    // LoadBackupHistory() clears listView.Items, so iterating
+                    // SelectedItems directly and refreshing inside the loop would
+                    // throw or skip files on multi-select delete.
+                    List<string> filesToDelete = listView.SelectedItems
+                        .Cast<ListViewItem>()
+                        .Select(item => Path.Combine(textbox2.Text, item.Text))
+                        .ToList();
+
                     bool isNewDel = true;
                     try
                     {
-                        foreach (ListViewItem item in listView.SelectedItems)
+                        foreach (string filePath in filesToDelete)
                         {
-                            // Get the full path of the selected file
-                            string filePath = Path.Combine(textbox2.Text, item.Text);
-
-                            // Record the deletion
                             RecordDeletion(filePath, isNewDel);
-
-                            // Subsequent deletions in the loop are part of the same action
                             isNewDel = false;
 
-                            // Move the file to the Recycle Bin
                             Microsoft.VisualBasic.FileIO.FileSystem.DeleteFile(filePath,
                                 Microsoft.VisualBasic.FileIO.UIOption.OnlyErrorDialogs,
                                 Microsoft.VisualBasic.FileIO.RecycleOption.SendToRecycleBin);
-
-                            // Optionally, remove the item from the ListView after moving it to the Recycle Bin
-                            //listView.Items.Remove(item);
-                            LoadBackupHistory();
-                            listView.Sort();
-                            Status.Text = "Backup(s) deleted sucessfully.";
-
-                            // Update the undo button state after the operation
-                            UpdateUndoButtonState();
                         }
+
+                        LoadBackupHistory();
+                        listView.Sort();
+                        Status.Text = "Backup(s) deleted sucessfully.";
+                        UpdateUndoButtonState();
                     }
                     catch (Exception ex)
                     {

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -1312,10 +1312,8 @@ namespace Savedrake
                 {
                     checkbox_auto.Checked = false;
                 }
+                Status.Text = "Backup failed.";
                 MessageBox.Show($"An error occurred while creating the backup: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-
-                Environment.Exit(0);
-                //HATSPATS This error is being trigerre saying combobox_auto is being assessed from nother thread it was created in 
             }
         }
 

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -178,7 +178,6 @@ namespace Savedrake
             listView.MouseDoubleClick += listView_MouseDoubleClick;
             listView.MouseClick += listView_MouseClick;
             listView.AfterLabelEdit += listView_AfterLabelEdit;
-            listView.AfterLabelEdit += new LabelEditEventHandler(listView_AfterLabelEdit);
             listView.ContextMenuStrip = contextMenuStrip;
             listView.KeyDown += ListView_KeyDown;
             listView.ItemSelectionChanged += ListView_ItemSelectionChanged;
@@ -193,7 +192,6 @@ namespace Savedrake
             trayIcon.Visible = false; // Hide the icon initially
             trayIcon.DoubleClick += TrayIcon_DoubleClick; // Event handler for double-clicking the icon
             trayIcon.Text = "Savedrake v1.2.4";
-            this.Resize += new System.EventHandler(this.Main_Resize);
             // Initialize the ContextMenuStrip
             trayMenu = new ContextMenuStrip();
             ToolStripMenuItem showItem = new ToolStripMenuItem("Show");
@@ -212,7 +210,6 @@ namespace Savedrake
             //Combobox
             this.combobox_auto.Leave += new System.EventHandler(this.combobox_auto_Leave);
             this.combobox_auto.KeyDown += new KeyEventHandler(combobox_auto_KeyDown);
-            this.combobox_auto.Validating += new System.ComponentModel.CancelEventHandler(combobox_auto_Validating);
 
             //ToolStripTextBox2 Autobackup Limnit
             //this.toolStripTextBox2.Leave += new EventHandler(toolStripTextBox2_Leave);

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -1372,15 +1372,36 @@ namespace Savedrake
             // Check if exactly one item is selected in the ListView
             if (listView.SelectedItems.Count == 1)
             {
-                // Move all files from the directory in textbox1 to the Recycle Bin
-                MoveFilesToRecycleBin(textbox1.Text);
-
                 // Get the selected file name
                 string fileName = listView.SelectedItems[0].Text;
 
                 // Combine the source directory with the file name to get the full file path
                 string filePath = Path.Combine(textbox2.Text, fileName);
 
+                // Validate the backup is readable BEFORE touching the live saves, so a
+                // corrupt or missing zip can't strand the user with no save game.
+                if (!File.Exists(filePath))
+                {
+                    MessageBox.Show("The selected Backup file no longer exists on disk.", "Restore Failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    LoadBackupHistory();
+                    return;
+                }
+                try
+                {
+                    using (Ionic.Zip.ZipFile probe = Ionic.Zip.ZipFile.Read(filePath))
+                    {
+                        // Touch the entry list to force header parsing; dispose immediately.
+                        int _ = probe.Count;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show($"The Backup file is not a valid zip and cannot be restored: {ex.Message}\n\nYour current save files have not been touched.", "Restore Failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return;
+                }
+
+                // Move all files from the directory in textbox1 to the Recycle Bin
+                MoveFilesToRecycleBin(textbox1.Text);
 
                 // Unzip the file to the target directory using DotNetZip
                 Status.Text = "Restore started... Please wait.";

--- a/updater/UpdaterForm.cs
+++ b/updater/UpdaterForm.cs
@@ -300,7 +300,7 @@ namespace updater
             linkLabel1.Invoke((MethodInvoker)(() => linkLabel1.Visible = true)); // Make sure the linkLabel is visible
         }
         #endregion
-        private string tempDownloadPath = Path.GetTempFileName();
+        private string tempDownloadPath;
         private async Task ApplyUpdateAsync()
         {
             // Declare tempDownloadPath at the beginning of the method
@@ -336,8 +336,11 @@ namespace updater
                 //MessageBox.Show("The update will download and apply the latest version of the application.");
 
                 // Show a message to the user that the update is starting
-                
-                string tempDownloadPath = Path.GetTempFileName();
+
+                // Assign to the field (no local shadow) so the temp file we
+                // actually download to is the same one referenced elsewhere
+                // in this type, and is properly cleaned up.
+                tempDownloadPath = Path.GetTempFileName();
 
                 // Download the update package
                 using (HttpClient client = new HttpClient())
@@ -346,6 +349,15 @@ namespace updater
                     response.EnsureSuccessStatusCode();
                     byte[] updateBytes = await response.Content.ReadAsByteArrayAsync();
                     File.WriteAllBytes(tempDownloadPath, updateBytes);
+                }
+
+                // Compute the install root once, with a trailing separator, so the
+                // zip-slip check below cannot be bypassed by a sibling-prefix path
+                // like "<extractPath>-evil\..." matching StartsWith(extractPath).
+                string installRoot = Path.GetFullPath(extractPath);
+                if (!installRoot.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+                {
+                    installRoot += Path.DirectorySeparatorChar;
                 }
 
                 // Extract the update package
@@ -364,8 +376,8 @@ namespace updater
                             continue;
                         }
 
-                        string destinationPath = Path.GetFullPath(Path.Combine(extractPath, entry.FullName));
-                        if (destinationPath.StartsWith(extractPath, StringComparison.Ordinal))
+                        string destinationPath = Path.GetFullPath(Path.Combine(installRoot, entry.FullName));
+                        if (destinationPath.StartsWith(installRoot, StringComparison.OrdinalIgnoreCase))
                         {
                             entry.ExtractToFile(destinationPath, true);
                         }


### PR DESCRIPTION
## Summary

Five surgical fixes for genuine data-loss / crash bugs and one updater security hole. Each fix is its own commit so any can be reverted independently. No refactors, no behavioural changes beyond the stated bug.

## Commits

- **`fix(backup)`** — `BackupOperation` catch called `Environment.Exit(0)`, so a single failed backup (file lock, disk full) terminated the entire app. Autobackups firing on a worker thread silently killed the process. Removed the Exit; existing checkbox-disable and error dialog stay, and the status bar now shows the failure after the dialog closes.

- **`fix(restore)`** — `button_res_Click` recycled the live save folder *before* opening the zip. A corrupt/missing backup left users with no live saves at all. The zip is now opened (entries parsed, handle disposed) before any deletion; missing-file is handled explicitly.

- **`fix(ui)`** — Three event handlers were subscribed twice in the `Main` ctor: `listView.AfterLabelEdit`, `this.Resize`, and `combobox_auto.Validating`. Every rename triggered two `File.Move` calls (the second on stale paths). Dropped the duplicate subscriptions.

- **`fix(delete)`** — `DeleteMenuItem_Click` iterated `listView.SelectedItems` while calling `LoadBackupHistory()` (which clears `listView.Items`) inside the loop. Multi-select delete threw or skipped files. Snapshotted file paths into a `List<string>` first; refresh once at the end.

- **`fix(updater)`** — Two bugs in `ApplyUpdateAsync`:
  - Zip-slip guard `StartsWith(extractPath, Ordinal)` would pass for sibling-prefix paths like `<root>-evil\payload.exe` because `extractPath` had no trailing separator. Normalised the install root with a trailing separator and switched to a case-insensitive compare (Windows FS).
  - `tempDownloadPath` was both a field initialised with `Path.GetTempFileName()` (creating an empty temp file per form construction) *and* a local of the same name inside `try` (shadowing the field). The field's file leaked every launch. Removed the field initialiser and made the local assign to the field instead of shadowing.

## Out of scope (deliberately, for follow-up PRs)

- Cross-thread UI access from the autobackup timer / WMI watcher
- Fake `VerifyUpdatePackage` / `VerifyVersionFile` stubs (and that they run *before* the download)
- Updater `Process.Kill`-ing Savedrake instead of graceful close
- DotNetZip migration to `System.IO.Compression`
- Global LL keyboard hook installed at startup (and re-installed on toggle, leaking the previous handle)

## Test plan

- [ ] Build the solution in Visual Studio (.NET Framework 4.8) — both `Savedrake` and `Savedrake-Updater` projects.
- [ ] **Fix 1:** Point Backup location at a path that triggers an error (e.g. a read-only drive); click Backup. App should show the error dialog, status bar should read "Backup failed.", and the app should stay open.
- [ ] **Fix 2:** With the Backup location set, manually corrupt a `.zip` in that folder (truncate it). Select it, click Restore. Should get a "Restore Failed" dialog, and the live save folder should be untouched.
- [ ] **Fix 3:** Set a breakpoint in `listView_AfterLabelEdit`. Rename a backup. Breakpoint should hit once, not twice.
- [ ] **Fix 4:** Select 3+ backups, press Delete, confirm. All selected files should be in the Recycle Bin; ListView should refresh once.
- [ ] **Fix 5:** Run the updater twice without applying any update; `%TEMP%` should not accumulate empty `tmp*.tmp` files (one per launch in the old behaviour).