### PR TITLE
ci: build solution on windows-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Set up NuGet
+        uses: NuGet/setup-nuget@v2
+
+      - name: Restore NuGet packages
+        run: nuget restore Savedrake.sln
+
+      - name: Build solution (${{ matrix.configuration }})
+        run: msbuild Savedrake.sln /p:Configuration=${{ matrix.configuration }} /p:Platform="Any CPU" /m /verbosity:minimal
+
+      - name: Upload Release artifacts
+        if: matrix.configuration == 'Release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: savedrake-release
+          path: |
+            Savedrake v1.2.3/bin/Release/**
+            updater/bin/Release/**
+          if-no-files-found: warn
+          retention-days: 7


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds `Savedrake.sln` on every push to `master` and every pull request, on `windows-latest` with MSBuild. Matrix builds Debug and Release. Release binaries (Savedrake.exe + Savedrake-Updater.exe) are uploaded as a workflow artifact so they can be downloaded from the Actions UI without a local Visual Studio install.

The repo had no CI; once this is merged, the existing `fixes/critical` PR (and every future change) gets a build check automatically. No test step yet — codebase has no test project.

## Test plan

- [ ] Workflow appears under Actions tab and runs on this PR.
- [ ] Both Debug and Release matrix legs go green.
- [ ] `savedrake-release` artifact is downloadable and contains both .exes.