### PR TITLE
Small correctness fixes: v-prefix, validator help text, settings crash

### DIFF
--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -372,67 +372,90 @@ namespace Savedrake
 
         private void LoadSettings()
         {
-            if (File.Exists("savedrake_settings.xml"))
+            if (!File.Exists("savedrake_settings.xml"))
             {
-                //wasLoaded = true;
+                return;
+            }
+
+            AppSettings settings;
+            try
+            {
                 var serializer = new XmlSerializer(typeof(AppSettings));
                 using (var reader = new StreamReader("savedrake_settings.xml"))
                 {
-                    var settings = (AppSettings)serializer.Deserialize(reader);
-
-                    //Loading Filenaming convention before
-                    try
-                    {
-                        randomlyGeneratedToolStripMenuItem.Checked = settings.BackupFileName1;
-                        timeStampedToolStripMenuItem.Checked = settings.BackupFileName2;
-                    }
-                    catch { }
-
-                    // Load combobox_auto information first
-                    combobox_auto.Items.Clear();
-                    combobox_auto.Items.AddRange(settings.ComboboxList.ToArray());
-                    combobox_auto.SelectedIndex = settings.ComboboxSelectedIndex >= 0 ? settings.ComboboxSelectedIndex : 0;
-
-                    // Load the rest of the settings
-                    this.Size = new Size(settings.WindowWidth, settings.WindowHeight);
-                    textbox1.Text = settings.Textbox1;
-                    textbox2.Text = settings.Textbox2;
-
-                    toolStripTextBox2.Text = settings.AutoBackupLimit;
-                    // Unsubscribe the event to prevent it from firing
-                    //checkbox_auto.CheckedChanged -= checkbox_auto_CheckedChanged;
-                    checkbox_auto.Checked = settings.CheckboxAuto;
-                    //checkbox_auto.CheckedChanged += checkbox_auto_CheckedChanged;
-
-                    checkbox_tray.Checked = settings.CheckboxTray;
-                    checkbox_hot.Checked = settings.CheckboxHot;
-                    textbox3.Text = settings.Textbox3 ?? " "; // Use null-coalescing operator for simplicity
-
-                    
-
-                    // Load the hotkey settings
-                    try
-                    {
-                        _currentMainKey = settings.Hotkey.MainKey;
-                        _controlPressed = settings.Hotkey.ControlPressed;
-                        _shiftPressed = settings.Hotkey.ShiftPressed;
-                        _altPressed = settings.Hotkey.AltPressed;
-                        _isRecordingHotkey = settings.Hotkey.IsRecording;
-                    }
-                    catch { }
-
-                    // Handle hotkey continuation or re-registration
-                    if (_isRecordingHotkey)
-                    {
-                        _isRecordingHotkey = true;
-                        //wasLoaded = true;
-                        checkbox_hot.Checked = false;
-                    }
-                    else if (_currentMainKey != Keys.None)
-                    {
-                        RegisterHotKeyFunction();
-                    }
+                    settings = (AppSettings)serializer.Deserialize(reader);
                 }
+            }
+            catch (Exception ex)
+            {
+                // A corrupt or partially-written settings XML used to throw out
+                // of the form constructor, which prevented the app from ever
+                // starting. Warn the user, leave the file in place so they can
+                // recover it manually, and fall through to defaults.
+                MessageBox.Show(
+                    $"Could not load saved settings (file may be corrupt). Defaults will be used.\n\n{ex.Message}",
+                    "Settings",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+                return;
+            }
+
+            if (settings == null)
+            {
+                return;
+            }
+
+            //Loading Filenaming convention before
+            try
+            {
+                randomlyGeneratedToolStripMenuItem.Checked = settings.BackupFileName1;
+                timeStampedToolStripMenuItem.Checked = settings.BackupFileName2;
+            }
+            catch { }
+
+            // Load combobox_auto information first
+            combobox_auto.Items.Clear();
+            combobox_auto.Items.AddRange(settings.ComboboxList.ToArray());
+            combobox_auto.SelectedIndex = settings.ComboboxSelectedIndex >= 0 ? settings.ComboboxSelectedIndex : 0;
+
+            // Load the rest of the settings
+            this.Size = new Size(settings.WindowWidth, settings.WindowHeight);
+            textbox1.Text = settings.Textbox1;
+            textbox2.Text = settings.Textbox2;
+
+            toolStripTextBox2.Text = settings.AutoBackupLimit;
+            // Unsubscribe the event to prevent it from firing
+            //checkbox_auto.CheckedChanged -= checkbox_auto_CheckedChanged;
+            checkbox_auto.Checked = settings.CheckboxAuto;
+            //checkbox_auto.CheckedChanged += checkbox_auto_CheckedChanged;
+
+            checkbox_tray.Checked = settings.CheckboxTray;
+            checkbox_hot.Checked = settings.CheckboxHot;
+            textbox3.Text = settings.Textbox3 ?? " "; // Use null-coalescing operator for simplicity
+
+
+
+            // Load the hotkey settings
+            try
+            {
+                _currentMainKey = settings.Hotkey.MainKey;
+                _controlPressed = settings.Hotkey.ControlPressed;
+                _shiftPressed = settings.Hotkey.ShiftPressed;
+                _altPressed = settings.Hotkey.AltPressed;
+                _isRecordingHotkey = settings.Hotkey.IsRecording;
+            }
+            catch { }
+
+            // Handle hotkey continuation or re-registration
+            if (_isRecordingHotkey)
+            {
+                _isRecordingHotkey = true;
+                //wasLoaded = true;
+                checkbox_hot.Checked = false;
+            }
+            else if (_currentMainKey != Keys.None)
+            {
+                RegisterHotKeyFunction();
             }
         }
         #endregion

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -954,7 +954,7 @@ namespace Savedrake
             // Check if the input matches the pattern
             if (!Regex.IsMatch(input, pattern))
             {
-                MessageBox.Show("Please enter the time in the correct format (e.g., '12 minutes', '1 hour', '1.5 hours', '2 hours').", "Invalid Format", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show("Please enter the time in the correct format (e.g., '12 minutes', '1 hour', '2 hours').", "Invalid Format", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 e.Cancel = true; // Prevents focus from changing
                 combobox_auto.SelectedIndex = 0;
                 return;

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -2203,6 +2203,13 @@ namespace Savedrake
                 return false;
             }
 
+            // GitHub release tags are conventionally prefixed with 'v' (e.g. "v1.2.5").
+            // Strip it so a future v-prefixed tag doesn't silently break update checks.
+            if (versionString.Length > 1 && (versionString[0] == 'v' || versionString[0] == 'V'))
+            {
+                versionString = versionString.Substring(1);
+            }
+
             string[] versionParts = versionString.Split('.');
             if (versionParts.Length < 2 || versionParts.Length > 4)
             {

--- a/updater/UpdaterForm.cs
+++ b/updater/UpdaterForm.cs
@@ -108,6 +108,13 @@ namespace updater
                 return false;
             }
 
+            // GitHub release tags are conventionally prefixed with 'v' (e.g. "v1.2.5").
+            // Strip it so a future v-prefixed tag doesn't silently break update checks.
+            if (versionString.Length > 1 && (versionString[0] == 'v' || versionString[0] == 'V'))
+            {
+                versionString = versionString.Substring(1);
+            }
+
             string[] versionParts = versionString.Split('.');
             if (versionParts.Length < 2 || versionParts.Length > 4)
             {


### PR DESCRIPTION
## Summary

Three small, independently-revertable fixes — none of these change app behaviour beyond the stated bug.

- **`fix(version)`** — `TryParseVersion` rejected any version string beginning with `v` (e.g. `v1.2.5`). Today's release tags happen to be unprefixed, but the moment any future tag is `v`-prefixed, the silent failure means update checks die forever with no surfaced error. Strip a leading `v`/`V` before parsing, in both `Main.cs` and `UpdaterForm.cs`.
- **`fix(ui)`** — The auto-backup interval validator regex (`^\d+\s(minutes|hour|hours)$`) rejected `1.5 hours`, but the error dialog explicitly listed `1.5 hours` as a valid example. Removed it from the example list. Widening the regex to accept decimals is a larger change (`ParseToTimeSpan`, `SetAutoBackupInterval`, `SortComboBoxItems` all assume integers) and is intentionally not done here.
- **`fix(settings)`** — `LoadSettings` deserialized `savedrake_settings.xml` directly inside the form constructor with no error handling. A corrupt or partially-written XML (power cut mid-save, partial write, manual edit) threw out of the ctor and the app would not start at all — the user had to find and delete the file before they could reach the UI again. Wrapped deserialization in `try`/`catch`; on failure, warn and fall back to defaults, file is left in place for manual recovery.

## Test plan

- [ ] CI green on Debug + Release.
- [ ] **fix(version):** put `v1.2.4` in `version.txt`, click Check for Update — current version parses successfully and the update flow proceeds.
- [ ] **fix(ui):** type `1.5 hours` into the autobackup interval, leave the field — error dialog no longer claims `1.5 hours` is valid.
- [ ] **fix(settings):** truncate `savedrake_settings.xml` to half a line, launch Savedrake — warning dialog shows, app starts with defaults.