### PR TITLE
ci: add CodeQL security scanning for C#

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: codeql
+
+on:
+  push:
+    branches: [master, claude-integration]
+  pull_request:
+    branches: [master, claude-integration]
+  schedule:
+    # Weekly scan so newly published query suites catch existing code.
+    - cron: '17 9 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (csharp)
+    runs-on: windows-latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Set up NuGet
+        uses: NuGet/setup-nuget@v2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+          queries: security-and-quality
+
+      - name: Restore NuGet packages
+        run: nuget restore Savedrake.sln
+
+      - name: Build solution (Release)
+        run: msbuild Savedrake.sln /p:Configuration=Release /p:Platform="Any CPU" /m /verbosity:minimal
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:csharp"


### PR DESCRIPTION
## Summary

Adds GitHub's CodeQL analyzer to CI. Runs on every push to `master` / `claude-integration`, every PR targeting those, and once a week on a cron schedule (so newly published query suites catch existing code without a code change). Results land in the repo's **Security → Code scanning** tab.

Pinned to `windows-latest` because the project is .NET Framework 4.8 WinForms — CodeQL autobuild can't reliably build it, so we restore NuGet packages and run msbuild explicitly (same path as the build workflow).

Uses the `security-and-quality` query pack (rather than the default `security-extended`) for fuller signal on bugs and maintainability issues, given the codebase has no existing static analysis.

## What CodeQL will likely flag in this repo

Based on a manual read, expect findings around:

- The DotNetZip (Ionic.Zip) dependency — abandoned package, multiple advisories.
- Empty `catch {}` blocks scattered in `Main.cs` (CWE-390 "no error handling").
- The shell-launching `Process.Start(textbox1.Text)` in `Button_op_1_Click` / `Button_op_2_Click` (CWE-78 family — though source is a local textbox set by a file dialog, low severity).
- Zip extraction patterns even after the recent zip-slip fix in `UpdaterForm.cs` — useful sanity check.

## Test plan

- [ ] Workflow appears under Actions and runs on this PR.
- [ ] Build step succeeds.
- [ ] Analyze step succeeds and uploads SARIF.
- [ ] First findings appear under **Security → Code scanning**.