### PR TITLE
fix: relocate version.txt + savedrake-updater.xml to %APPDATA%\Savedrake

### DIFF
--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -335,6 +335,11 @@ namespace Savedrake
 
         private static string SettingsFilePath => Path.Combine(AppDataDir, "savedrake_settings.xml");
         private static string AutoBackupCountFilePath => Path.Combine(AppDataDir, "count_of_autobackups.txt");
+        // run4: version.txt and savedrake-updater.xml used to live in the working dir (often Program Files,
+        // read-only) — moved to %APPDATA%\Savedrake alongside the settings/count files. The updater
+        // (updater/UpdaterForm.cs) reads them from the SAME path; keep these two in lockstep with it.
+        private static string VersionFilePath => Path.Combine(AppDataDir, "version.txt");
+        private static string UpdaterXmlPath => Path.Combine(AppDataDir, "savedrake-updater.xml");
 
         private static string CreateAppDataDir()
         {
@@ -349,6 +354,8 @@ namespace Savedrake
         {
             MigrateLegacyFile("savedrake_settings.xml", SettingsFilePath);
             MigrateLegacyFile("count_of_autobackups.txt", AutoBackupCountFilePath);
+            MigrateLegacyFile("version.txt", VersionFilePath);
+            MigrateLegacyFile("savedrake-updater.xml", UpdaterXmlPath);
         }
 
         // Copies a legacy file from the old working-directory location to its new
@@ -376,6 +383,28 @@ namespace Savedrake
                 catch
                 {
                     // Ignore and try the next candidate location / fall through to defaults.
+                }
+            }
+        }
+
+        // Best-effort delete of any legacy working-dir copies of a relocated state file, mirroring the
+        // locations MigrateLegacyFile reads from. Used by the reset path so a "restore defaults" isn't
+        // silently undone by the updater's transition fallback reading a surviving old copy.
+        private static void DeleteLegacyCopies(string legacyFileName)
+        {
+            foreach (string dir in new[] { Environment.CurrentDirectory, Application.StartupPath })
+            {
+                try
+                {
+                    string legacyPath = Path.Combine(dir, legacyFileName);
+                    if (File.Exists(legacyPath))
+                    {
+                        File.Delete(legacyPath);
+                    }
+                }
+                catch
+                {
+                    // Best-effort cleanup; ignore failures (locked / missing / permission).
                 }
             }
         }
@@ -2736,7 +2765,7 @@ namespace Savedrake
             try
             {
                 // Attempt to load the checkBox values from the XML file
-                XElement root = XElement.Load("savedrake-updater.xml");
+                XElement root = XElement.Load(UpdaterXmlPath);
                 checkBox1Value = bool.Parse(root.Element("CheckBox1").Value);
             }
             catch (System.IO.FileNotFoundException)
@@ -2770,7 +2799,7 @@ namespace Savedrake
             {
                 try
                 {
-                    File.WriteAllText("version.txt", parsedVersion.ToString());
+                    File.WriteAllText(VersionFilePath, parsedVersion.ToString());
                 }
                 catch
                 {
@@ -2944,9 +2973,13 @@ namespace Savedrake
                 try
                 {
                     File.Delete(SettingsFilePath);
-                    File.Delete("savedrake-updater.xml");
-                    File.Delete("version.txt");
+                    File.Delete(UpdaterXmlPath);
+                    File.Delete(VersionFilePath);
                     File.Delete(AutoBackupCountFilePath);
+                    // Also clear any legacy working-dir copies left behind by the COPY-based migration,
+                    // so the reset can't be silently undone by a fallback that still reads the old file.
+                    DeleteLegacyCopies("savedrake-updater.xml");
+                    DeleteLegacyCopies("version.txt");
                     textbox1.Text = null;
                     textbox2.Text = null;
                     checkbox_auto.Checked = false;

--- a/updater/UpdaterForm.cs
+++ b/updater/UpdaterForm.cs
@@ -31,6 +31,20 @@ namespace updater
         private const string Repo = "Savedrake";
         private const string GitHubTokenEnvironmentVariable = "GITHUB_TOKEN";
 
+        // run4: version.txt and savedrake-updater.xml now live in %APPDATA%\Savedrake — the same path the main app
+        // (Savedrake v1.2.3/Main.cs) writes them to. Computed identically so the two stay in lockstep.
+        private static readonly string AppDataDir = CreateAppDataDir();
+        private static string CreateAppDataDir()
+        {
+            string dir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "Savedrake");
+            Directory.CreateDirectory(dir); // no-op if it already exists
+            return dir;
+        }
+        private static string VersionFilePath => Path.Combine(AppDataDir, "version.txt");
+        private static string UpdaterXmlPath => Path.Combine(AppDataDir, "savedrake-updater.xml");
+
         public UpdaterForm()
         {
             // Attempt to acquire the mutex
@@ -70,7 +84,11 @@ namespace updater
                 return null;
             }
 
-            string versionFilePath = Path.Combine(extractPath, "version.txt");
+            // run4: version.txt now lives in %APPDATA%\Savedrake (written there by the main app). Fall back to the
+            // legacy install-dir copy so an updater run BEFORE the new main app has migrated it forward still works.
+            string versionFilePath = File.Exists(VersionFilePath)
+                ? VersionFilePath
+                : Path.Combine(extractPath, "version.txt");
             if (File.Exists(versionFilePath))
             {
                 return File.ReadAllText(versionFilePath).Trim();
@@ -358,7 +376,9 @@ namespace updater
             //button3.Enabled = false;
 
 
-            if (!VerifyVersionFile(Path.Combine(extractPath, "version.txt")))
+            // run4: version.txt now lives in %APPDATA% (with a legacy install-dir fallback), same as GetCurrentVersion.
+            string localVersionFile = File.Exists(VersionFilePath) ? VersionFilePath : Path.Combine(extractPath, "version.txt");
+            if (!VerifyVersionFile(localVersionFile))
             {
                 // run4: this method runs on a Task.Run pool thread, so marshal the dialog AND re-enable the button
                 // on the UI thread — otherwise the button stays stuck disabled with no way to retry but a restart.
@@ -513,11 +533,13 @@ namespace updater
                 )
             );
 
-            xmlDoc.Save("savedrake-updater.xml");
+            xmlDoc.Save(UpdaterXmlPath); // run4: write to %APPDATA%\Savedrake (read by the main app from there too)
         }
         public void LoadCheckBoxesFromXml()
         {
-            XDocument xmlDoc = XDocument.Load("savedrake-updater.xml");
+            // run4: prefer %APPDATA%\Savedrake; fall back to a legacy working-dir copy during the transition.
+            string path = File.Exists(UpdaterXmlPath) ? UpdaterXmlPath : "savedrake-updater.xml";
+            XDocument xmlDoc = XDocument.Load(path);
             XElement root = xmlDoc.Element("Root");
             bool checkBox1Value = bool.Parse(root.Element("CheckBox1").Value);
             bool checkBox2Value = bool.Parse(root.Element("CheckBox2").Value);


### PR DESCRIPTION
## Problem

The main app wrote `version.txt` and `savedrake-updater.xml` into the **working directory** — typically the install dir under `Program Files`, which is read-only for non-elevated users. So the update-check state and the auto-update-check checkbox prefs silently failed to persist (the `File.WriteAllText` / `xmlDoc.Save` threw or no-op'd). This mirrors the Bucket 1 relocation of `savedrake_settings.xml` / `count_of_autobackups.txt` to `%APPDATA%\Savedrake`.

## Change

Both files now live in `%APPDATA%\Savedrake`, in **lockstep** between the main app and the separate updater exe.

**`Savedrake v1.2.3/Main.cs`**
- `VersionFilePath` / `UpdaterXmlPath` resolve under `AppDataDir`.
- `MigrateLegacyFile` copies any existing working-dir copies forward on first run.
- All read / write / reset sites updated to the new paths.
- **Reset path** also deletes the legacy working-dir copies (new `DeleteLegacyCopies` helper, mirroring `MigrateLegacyFile`'s read locations), so "restore defaults" can't be silently undone by the updater's transition fallback reading a surviving old copy.

**`updater/UpdaterForm.cs`**
- `AppDataDir` / `VersionFilePath` / `UpdaterXmlPath` computed identically to the main app.
- `GetCurrentVersion` and the `ApplyUpdateAsync` → `VerifyVersionFile` call read from `%APPDATA%` with a legacy install-dir fallback (so an updater run *before* the new main app has migrated still works).
- `SaveCheckBoxesToXml` writes to `%APPDATA%`; `LoadCheckBoxesFromXml` prefers it with a legacy fallback.

## Verification

- Builds clean **Release + Debug** (Savedrake + Savedrake-Updater + RestoreHarness).
- `RestoreHarness` **68/68** passed.
- Adversarial multi-agent review (lockstep + transition lenses): 6 raised, 5 refuted, **1 confirmed LOW** (incomplete reset leaving legacy copies the updater could resurrect) — fixed in this PR via `DeleteLegacyCopies`.

## Notes / limitations

- Migration **copies** rather than moves, so a stale legacy copy can linger in the install dir; both the main-app reads and the updater now prefer `%APPDATA%`, and the reset path cleans up the two files that have a transition fallback.
- No crypto signature on updates (no signing key) — pre-existing, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)