### PR TITLE
fix: locale-tolerant, unified autobackup interval parsing

### DIFF
--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -84,6 +84,8 @@ namespace RestoreHarness
                 Test_HappyPathSequence();   // T1->T6 end-to-end at the file level using the real compiled helpers
                 Test_DataLoss_Repro();   // the critical one: proves/refutes the finally + Rollback behavior
                 Test_PartialT4_NoDataLoss();   // forces a partial T4 failure; asserts surviving originals == 2
+                Test_TryParseInterval();   // locale-tolerant autobackup-interval parser (single source of truth)
+                Test_CanonicalizeInterval();   // variant spellings collapse onto one item (no duplicate-item regression)
             }
             catch (Exception ex)
             {
@@ -123,6 +125,17 @@ namespace RestoreHarness
 
         static bool IsRealSaveEntry(string n) { return (bool)SM("IsRealSaveEntry").Invoke(null, new object[] { n }); }
 
+        // private static bool TryParseInterval(string, out TimeSpan) — read the out-param back from the args array.
+        static bool TryParseInterval(string input, out TimeSpan interval)
+        {
+            object[] a = { input, null };
+            bool ok = (bool)SM("TryParseInterval").Invoke(null, a);
+            interval = a[1] == null ? TimeSpan.Zero : (TimeSpan)a[1];
+            return ok;
+        }
+
+        static string CanonicalizeInterval(string input) { return (string)SM("CanonicalizeInterval").Invoke(null, new object[] { input }); }
+
         // ---- tests ----
         static void Test_IsRealSaveEntry()
         {
@@ -139,6 +152,72 @@ namespace RestoreHarness
             Check("notdata.bin is NOT save", !IsRealSaveEntry("notdata.bin"));
             Check("mydata000.bin is NOT save", !IsRealSaveEntry("mydata000.bin"));
             Check("datax.txtbin is NOT save", !IsRealSaveEntry("datax.txtbin"));
+            Console.WriteLine();
+        }
+
+        static void Test_TryParseInterval()
+        {
+            Console.WriteLine("== TryParseInterval (locale-tolerant) ==");
+
+            // Canonical forms still parse exactly as before.
+            Check("'5 minutes' -> 5 min", TryParseInterval("5 minutes", out var t1) && t1 == TimeSpan.FromMinutes(5));
+            Check("'1 hour' -> 60 min", TryParseInterval("1 hour", out var t2) && t2 == TimeSpan.FromHours(1));
+            Check("'2 hours' -> 120 min", TryParseInterval("2 hours", out var t3) && t3 == TimeSpan.FromHours(2));
+
+            // Case-insensitive (was rejected before: the old regex was case-sensitive).
+            Check("'5 Minutes' (case)", TryParseInterval("5 Minutes", out var t4) && t4 == TimeSpan.FromMinutes(5));
+            Check("'1 HOUR' (case)", TryParseInterval("1 HOUR", out var t5) && t5 == TimeSpan.FromHours(1));
+
+            // Whitespace tolerance (single-space-only was required before).
+            Check("'5  minutes' (2 spaces)", TryParseInterval("5  minutes", out var t6) && t6 == TimeSpan.FromMinutes(5));
+            Check("'5minutes' (no space)", TryParseInterval("5minutes", out var t7) && t7 == TimeSpan.FromMinutes(5));
+            Check("'  10 minutes  ' (padded)", TryParseInterval("  10 minutes  ", out var t8) && t8 == TimeSpan.FromMinutes(10));
+
+            // Synonyms / abbreviations.
+            Check("'30 min'", TryParseInterval("30 min", out var t9) && t9 == TimeSpan.FromMinutes(30));
+            Check("'30 mins'", TryParseInterval("30 mins", out var t10) && t10 == TimeSpan.FromMinutes(30));
+            Check("'1 minute'", TryParseInterval("1 minute", out var t11) && t11 == TimeSpan.FromMinutes(1));
+            Check("'2 hr'", TryParseInterval("2 hr", out var t12) && t12 == TimeSpan.FromHours(2));
+            Check("'3 hrs'", TryParseInterval("3 hrs", out var t13) && t13 == TimeSpan.FromHours(3));
+
+            // Rejections (return false, never throw).
+            Check("'' -> false", !TryParseInterval("", out _));
+            Check("null -> false", !TryParseInterval(null, out _));
+            Check("'abc' -> false", !TryParseInterval("abc", out _));
+            Check("'minutes' (no number) -> false", !TryParseInterval("minutes", out _));
+            Check("'5' (no unit) -> false", !TryParseInterval("5", out _));
+            Check("'5 seconds' (unknown unit) -> false", !TryParseInterval("5 seconds", out _));
+            Check("'5 days' (unknown unit) -> false", !TryParseInterval("5 days", out _));
+            Check("'5.5 minutes' (decimal) -> false", !TryParseInterval("5.5 minutes", out _));
+            Check("'-5 minutes' (sign) -> false", !TryParseInterval("-5 minutes", out _));
+
+            // Out-of-range values reject cleanly instead of throwing / overflowing (old int*int math).
+            Check("'999999999 hours' (TimeSpan overflow) -> false, no throw", !TryParseInterval("999999999 hours", out _));
+            Check("'99999999999 minutes' (> int) -> false", !TryParseInterval("99999999999 minutes", out _));
+
+            Console.WriteLine();
+        }
+
+        static void Test_CanonicalizeInterval()
+        {
+            // Guards the dedup fix: the broadened grammar accepts variant spellings, so they must canonicalize
+            // onto one item (e.g. built-in "5 minutes") rather than persist as duplicate ComboBox entries.
+            Console.WriteLine("== CanonicalizeInterval (collapse variants onto one canonical item) ==");
+            Check("'5min' -> '5 minutes'", CanonicalizeInterval("5min") == "5 minutes");
+            Check("'5 Minutes' -> '5 minutes'", CanonicalizeInterval("5 Minutes") == "5 minutes");
+            Check("'5  minutes' -> '5 minutes'", CanonicalizeInterval("5  minutes") == "5 minutes");
+            Check("'30 mins' -> '30 minutes'", CanonicalizeInterval("30 mins") == "30 minutes");
+            Check("'1 Hr' -> '1 hour'", CanonicalizeInterval("1 Hr") == "1 hour");
+            Check("'2 hr' -> '2 hours'", CanonicalizeInterval("2 hr") == "2 hours");
+            Check("'2 HOURS' -> '2 hours'", CanonicalizeInterval("2 HOURS") == "2 hours");
+            // Unit preserved (no minutes<->hours conversion), matching the prior app convention.
+            Check("'120 minutes' stays '120 minutes'", CanonicalizeInterval("120 minutes") == "120 minutes");
+            // Idempotent on the canonical/default forms so existing list items are never rewritten.
+            Check("idempotent: '5 minutes'", CanonicalizeInterval("5 minutes") == "5 minutes");
+            Check("idempotent: '1 hour'", CanonicalizeInterval("1 hour") == "1 hour");
+            Check("idempotent: '2 hours'", CanonicalizeInterval("2 hours") == "2 hours");
+            // Non-interval text passes through untouched.
+            Check("non-interval passes through", CanonicalizeInterval("not a time") == "not a time");
             Console.WriteLine();
         }
 

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.Drawing;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Management;
@@ -718,15 +719,68 @@ namespace Savedrake
             SortComboBoxItems();
         }
 
+        // Single source of truth for interpreting an autobackup interval string, shared by validation,
+        // sorting, and timer setup so they can never disagree. Locale-robust by design:
+        //  - case-insensitive + CultureInvariant unit matching (no Turkish-I / casing surprises),
+        //  - tolerant grammar: optional surrounding whitespace, no space required before the unit, and
+        //    common synonyms/abbreviations ("min"/"mins"/"minute(s)", "hr"/"hrs"/"hour(s)"),
+        //  - the number is parsed with InvariantCulture over ASCII [0-9] only, so a non-US Windows
+        //    locale (different digit grouping / digit script) can't make int parsing throw or misread.
+        // Returns false (rather than throwing) for anything unrecognized or out of TimeSpan range.
+        private static readonly Regex IntervalRegex = new Regex(
+            @"^\s*(?<num>[0-9]+)\s*(?<unit>minutes|minute|mins|min|hours|hour|hrs|hr)\s*$",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+        private static bool TryParseInterval(string input, out TimeSpan interval)
+        {
+            interval = TimeSpan.Zero;
+            if (string.IsNullOrWhiteSpace(input))
+                return false;
+
+            Match m = IntervalRegex.Match(input);
+            if (!m.Success)
+                return false;
+
+            // NumberStyles.None: the regex already isolated bare ASCII digits, so disallow sign/whitespace.
+            if (!int.TryParse(m.Groups["num"].Value, NumberStyles.None, CultureInfo.InvariantCulture, out int value))
+                return false; // too many digits to fit an int, etc.
+
+            bool isHours = m.Groups["unit"].Value.ToLowerInvariant()[0] == 'h';
+            try
+            {
+                interval = isHours ? TimeSpan.FromHours(value) : TimeSpan.FromMinutes(value);
+            }
+            catch (OverflowException)
+            {
+                interval = TimeSpan.Zero;
+                return false; // absurdly large value that overflows TimeSpan
+            }
+            return true;
+        }
+
+        // Canonical spelling for a recognized interval, PRESERVING the user's unit (no minutes<->hours
+        // conversion): "5min"/"5 Minutes"/"5  minutes" -> "5 minutes", "1 Hr" -> "1 hour", "2 hr" -> "2 hours".
+        // Lets the broadened input grammar collapse case/abbreviation/spacing variants onto a single list item
+        // instead of accumulating semantic duplicates. Returns the input unchanged if it isn't an interval.
+        private static string CanonicalizeInterval(string input)
+        {
+            Match m = IntervalRegex.Match(input ?? string.Empty);
+            if (!m.Success)
+                return input;
+            if (!int.TryParse(m.Groups["num"].Value, NumberStyles.None, CultureInfo.InvariantCulture, out int value))
+                return input;
+
+            bool isHours = m.Groups["unit"].Value.ToLowerInvariant()[0] == 'h';
+            if (isHours)
+                return value == 1 ? "1 hour" : value + " hours";
+            return value == 1 ? "1 minute" : value + " minutes";
+        }
+
         private TimeSpan ParseToTimeSpan(string s)
         {
-            int value = int.Parse(new string(s.Where(char.IsDigit).ToArray()));
-            if (s.Contains("min") || s.Contains("mins") || s.Contains("minutes"))
-                return TimeSpan.FromMinutes(value);
-            if (s.Contains("hour") || s.Contains("hours"))
-                return TimeSpan.FromHours(value);
-            // Add more conditions if there are other time units like "seconds", "days", etc.
-            return TimeSpan.Zero; // Default case
+            // Unrecognized items sort first (TimeSpan.Zero), matching the previous default-case behavior —
+            // but without throwing on malformed strings the way the old int.Parse did.
+            return TryParseInterval(s, out TimeSpan interval) ? interval : TimeSpan.Zero;
         }
 
         private void SortComboBoxItems()
@@ -768,6 +822,14 @@ namespace Savedrake
 
         private string ProcessText(string text)
         {
+            // Collapse case/abbreviation/spacing variants of a recognized interval onto one canonical spelling
+            // ("5min"/"5 Minutes" -> "5 minutes", "1 Hr" -> "1 hour"). Without this, the broadened input
+            // grammar accepted by combobox_auto_Validating would let those forms be added as permanent
+            // duplicate ComboBox items (persisted via ComboboxList). Units are preserved; non-interval text
+            // falls through to the legacy word-level normalization below.
+            if (IntervalRegex.IsMatch(text ?? string.Empty))
+                return CanonicalizeInterval(text);
+
             // Replace whole word "min" with "minutes"
             text = Regex.Replace(text, @"\bmin\b", "minutes");
 
@@ -1022,27 +1084,14 @@ namespace Savedrake
         private void SetAutoBackupInterval()
         {
             combobox_auto_Validating(combobox_auto, new System.ComponentModel.CancelEventArgs());
-            if (combobox_auto.SelectedItem != null)
+            // Drive the timer from the same parser that validated the input, so the milliseconds always
+            // match what the user saw — and so units/abbreviations stay consistent across the app. Using a
+            // TimeSpan avoids the old int*int milliseconds computation that could overflow on large values.
+            if (combobox_auto.SelectedItem != null
+                && TryParseInterval(combobox_auto.SelectedItem.ToString(), out TimeSpan interval)
+                && interval >= TimeSpan.FromMinutes(5))
             {
-                string interval = combobox_auto.SelectedItem.ToString();
-                int timeValue = 0; // Initialize timeValue to zero
-                int multiplier;
-
-                // Check if the interval is in hours or minutes
-                if (interval.ToLower().Contains("hour") || interval.ToLower().Contains("hours"))
-                {
-                    // Extract the number of hours and convert to milliseconds
-                    timeValue = int.Parse(interval.Split(' ')[0]);
-                    multiplier = 60 * 60 * 1000; // 1 hour = 60 minutes = 3600 seconds = 3600000 milliseconds
-                }
-                else
-                {
-                    // Extract the number of minutes and convert to milliseconds
-                    timeValue = int.Parse(interval.Split(' ')[0]);
-                    multiplier = 60 * 1000; // 1 minute = 60 seconds = 60000 milliseconds
-                }
-
-                autobackupTimer.Interval = timeValue * multiplier;
+                autobackupTimer.Interval = interval.TotalMilliseconds;
             }
             else
             {
@@ -1118,12 +1167,12 @@ namespace Savedrake
 
         private void combobox_auto_Validating(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            // Regular expression pattern to match "x min", "x hour", or "xx hours"
-            string pattern = @"^\d+\s(minutes|hour|hours)$";
             string input = combobox_auto.Text;
 
-            // Check if the input matches the pattern
-            if (!Regex.IsMatch(input, pattern))
+            // Accepts e.g. "12 minutes", "1 hour", "2 hours" — and now, case-insensitively and with flexible
+            // spacing, "12 Minutes", "5min", "1 Hr", "2 hrs". TryParseInterval is the same parser used to
+            // drive the timer and sort the list, so what validates here is exactly what those will accept.
+            if (!TryParseInterval(input, out TimeSpan interval))
             {
                 MessageBox.Show("Please enter the time in the correct format (e.g., '12 minutes', '1 hour', '2 hours').", "Invalid Format", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 e.Cancel = true; // Prevents focus from changing
@@ -1131,23 +1180,8 @@ namespace Savedrake
                 return;
             }
 
-            // Parse the number from the input
-            int timeValue1 = int.Parse(Regex.Match(input, @"\d+").Value);
-            int timeValue2 = int.Parse(Regex.Match(input, @"\d+").Value);
-
-            // Convert hours to minutes
-            timeValue2 *= 60;
-
-            string timeUnit = Regex.Match(input, @"(minutes|hour|hours)").Value;
-
-            // Check if the time is less than 5 minutes
-            if ((timeUnit == "minutes") && timeValue1 < 5)
-            {
-                MessageBox.Show("The time interval cannot be less than 5 minutes.", "Invalid Time", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                e.Cancel = true; // Prevents focus from changing
-                combobox_auto.SelectedIndex = 0;
-            }
-            else if ((timeUnit == "hour" || timeUnit == "hours") && timeValue2 < 0.0833)
+            // Enforce the 5-minute floor uniformly, whether the interval was given in minutes or hours.
+            if (interval < TimeSpan.FromMinutes(5))
             {
                 MessageBox.Show("The time interval cannot be less than 5 minutes.", "Invalid Time", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 e.Cancel = true; // Prevents focus from changing


### PR DESCRIPTION
## Problem

The autobackup interval string was interpreted by **three independent parsers** that could disagree, each using culture-sensitive `int.Parse` / `.ToLower()`:

- `combobox_auto_Validating` — regex `^\d+\s(minutes|hour|hours)$`: **case-sensitive**, single-space only, English plural words only. Rejected `"5 Minutes"`, `"5  minutes"`, `"5min"`, `"1 Hr"`.
- `ParseToTimeSpan` (sorting) — `int.Parse(char.IsDigit chars)` + `Contains` checks; threw on malformed items.
- `SetAutoBackupInterval` (timer) — `ToLower().Contains("hour")` + `int * int` milliseconds that could **overflow** on large values.

## Change

One parser as the single source of truth — `TryParseInterval(string, out TimeSpan)`:

- static `IntervalRegex` with `IgnoreCase | CultureInvariant`: accepts `"5 minutes"`, `"12 Minutes"`, `"5min"`, `"1 Hr"`, `"2 hrs"`, `"30 mins"`, flexible whitespace.
- number parsed with `int.TryParse(NumberStyles.None, InvariantCulture)` over ASCII `[0-9]` only — a non-US Windows locale can't make it throw or misread; oversized values are rejected, not crashed.
- `TimeSpan.From*` guarded against `OverflowException`.

All three sites delegate to it. The **5-minute floor** is enforced uniformly via `TimeSpan`, and `SetAutoBackupInterval` gained a `>= 5 min` guard so a tampered saved `ComboboxList` can't set `autobackupTimer.Interval <= 0` (`ArgumentException`).

## Adversarial review → one MEDIUM fixed

A 3-lens review (regression / locale / integration) with per-finding verification surfaced **1 confirmed MEDIUM**: the broadened grammar let variant spellings pass validation while `ProcessText` (still case-sensitive/whole-word) left them un-normalized, so they were added as **permanent duplicate ComboBox items** (e.g. built-in `"5 minutes"` + user-created `"5min"` + `"5 Minutes"`), persisted via `ComboboxList` across restarts.

Fixed by adding `CanonicalizeInterval` (unit-preserving: `"5min"`/`"5 Minutes"` → `"5 minutes"`, `"1 Hr"` → `"1 hour"`, no minutes↔hours conversion) and having `ProcessText` return the canonical spelling for recognized intervals, so variants collapse onto one list item. A follow-up verification confirmed no duplicate persists and the canonicalizer is idempotent on the default items.

> Known cosmetic: re-entering a variant of an *existing* interval can still show a `"Custom interval … added"` dialog even though nothing was added — harmless (no item/selection/persistence change), left as-is to keep the change focused.

## Verification

- Builds clean **Release + Debug** (Savedrake + Savedrake-Updater + RestoreHarness).
- `RestoreHarness` **104/104** — added 24 `TryParseInterval` assertions (canonical forms, casing, spacing, abbreviations, rejections, overflow safety) + 12 `CanonicalizeInterval` assertions (variant collapse, unit preservation, idempotency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)