### PR TITLE
chore: remove the dead duplicate ListView context menu

### DIFF
--- a/Savedrake v1.2.3/Main.Designer.cs
+++ b/Savedrake v1.2.3/Main.Designer.cs
@@ -47,9 +47,6 @@
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolTip3 = new System.Windows.Forms.ToolTip(this.components);
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.deleteMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.renameMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.textbox3 = new System.Windows.Forms.Label();
             this.Quit = new System.Windows.Forms.ToolStripMenuItem();
             this.Show = new System.Windows.Forms.ToolStripMenuItem();
@@ -78,7 +75,6 @@
             this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.toolTip4 = new System.Windows.Forms.ToolTip(this.components);
             this.menuStrip1.SuspendLayout();
-            this.contextMenuStrip.SuspendLayout();
             this.contextMenuStrip1.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.SuspendLayout();
@@ -220,28 +216,7 @@
             this.toolTip1.InitialDelay = 100;
             this.toolTip1.ReshowDelay = 20;
             this.toolTip1.ShowAlways = true;
-            // 
-            // deleteMenuItem
-            // 
-            this.deleteMenuItem.Name = "deleteMenuItem";
-            this.deleteMenuItem.Size = new System.Drawing.Size(117, 22);
-            this.deleteMenuItem.Text = "Delete";
-            // 
-            // renameMenuItem
-            // 
-            this.renameMenuItem.Name = "renameMenuItem";
-            this.renameMenuItem.Size = new System.Drawing.Size(117, 22);
-            this.renameMenuItem.Text = "Rename";
-            // 
-            // contextMenuStrip
-            // 
-            this.contextMenuStrip.ImageScalingSize = new System.Drawing.Size(28, 28);
-            this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.renameMenuItem,
-            this.deleteMenuItem});
-            this.contextMenuStrip.Name = "contextMenuStrip";
-            this.contextMenuStrip.Size = new System.Drawing.Size(118, 48);
-            // 
+            //
             // textbox3
             // 
             this.textbox3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
@@ -600,7 +575,6 @@
             this.Load += new System.EventHandler(this.Main_Load);
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
-            this.contextMenuStrip.ResumeLayout(false);
             this.contextMenuStrip1.ResumeLayout(false);
             this.statusStrip1.ResumeLayout(false);
             this.statusStrip1.PerformLayout();
@@ -615,9 +589,6 @@
         private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
         private System.Windows.Forms.ToolTip toolTip3;
         private System.Windows.Forms.ToolTip toolTip1;
-        private System.Windows.Forms.ToolStripMenuItem deleteMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem renameMenuItem;
-        private System.Windows.Forms.ContextMenuStrip contextMenuStrip;
         private System.Windows.Forms.Label textbox3;
         private System.Windows.Forms.ToolStripMenuItem Quit;
         private new System.Windows.Forms.ToolStripMenuItem Show;

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -185,7 +185,6 @@ namespace Savedrake
             listView.AfterLabelEdit += listView_AfterLabelEdit;
             listView.ContextMenuStrip = contextMenuStrip;
             listView.KeyDown += ListView_KeyDown;
-            listView.ItemSelectionChanged += ListView_ItemSelectionChanged;
 
             #endregion
 
@@ -2628,12 +2627,6 @@ namespace Savedrake
 
         //Listview Keydown //Undetected
         #region
-        private void ListView_ItemSelectionChanged(object sender, ListViewItemSelectionChangedEventArgs e)
-        {
-            // Enable the renameMenuItem only if exactly one item is selected
-            renameMenuItem.Enabled = listView.SelectedItems.Count == 1;
-        }
-
         private void ListView_KeyDown(object sender, KeyEventArgs e)
         {
             // Check if the 'Del' key is pressed and items are selected


### PR DESCRIPTION
Follow-up cleanup flagged during the [#25](https://github.com/sammorrison9800/Savedrake/pull/25) review.

[#25](https://github.com/sammorrison9800/Savedrake/pull/25) stopped *showing* the designer-built `contextMenuStrip` (the working menu is constructed in code and assigned to `listView.ContextMenuStrip`), but the designer control and its `renameMenuItem`/`deleteMenuItem` lingered — kept alive only by `ListView_ItemSelectionChanged` toggling `renameMenuItem.Enabled`, a **no-op** since that menu is never shown.

Removed the whole dead path:
- **Main.cs**: deleted `ListView_ItemSelectionChanged` (its only statement targeted the invisible menu's item) + its event wiring.
- **Main.Designer.cs**: removed the `contextMenuStrip` / `renameMenuItem` / `deleteMenuItem` controls (declarations, creation, `Items`/`Name`/`Size`/`Text`, `SuspendLayout`/`ResumeLayout`). The separate `contextMenuStrip1` (tray Show/Quit) is untouched.

**No behavior change** — the working right-click menu (wired Rename/Delete) is unaffected.

## Verification
- Builds clean **Release + Debug**.
- Because a designer change affects `InitializeComponent` (which the reflection harness never runs), I **launched the built app** and confirmed the form constructs without error.
- `RestoreHarness` **111/111**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)