### PR TITLE
release: bump version to 1.3.0 and add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to Savedrake are recorded here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows
+[Semantic Versioning](https://semver.org/).
+
+## [1.3.0] - 2026-06-17
+
+This release is a large batch of reliability and data-safety fixes on top of 1.2.4,
+plus a few small features. The backup and restore flows are now transactional, and
+the auto-updater installs updates safely with rollback.
+
+### Added
+- Settings, the version file, and updater data are now stored in
+  `%APPDATA%\Savedrake`, so they save correctly even when Savedrake is installed in a
+  read-only folder such as Program Files. Existing files are migrated automatically. (#18)
+- Backup success and error sounds now play for every backup (manual, hotkey, and
+  autobackup), not only hotkey backups. (#20)
+- A restore regression test that runs in CI on every change. (#13)
+- `ROADMAP.md` describing planned work, and this `CHANGELOG.md`. (#28)
+
+### Changed
+- Restore is now transactional. It extracts the backup to a staging area, checks it
+  contains save data, swaps it into place, and rolls back automatically if any step
+  fails, so a failed restore can no longer leave your saves half-replaced. (#13)
+- The auto-updater installs updates transactionally. It downloads and verifies the
+  package first, then replaces files one at a time while keeping a backup of each,
+  rolls back on any failure, and relaunches the app. (#17, #21)
+- Autobackup intervals accept more input. Entries like "5 min", "1 Hr", and "2 hrs"
+  are now valid, and parsing no longer depends on your Windows display language. (#19)
+- "Check for Updates" now runs an in-app version check and tells you when you are
+  already up to date, instead of always launching the updater. (#24)
+
+### Fixed
+- Data loss: a failed restore could delete the only copy of your saves while trying to
+  recover. Restore now keeps your originals until the new save is provably in place. (#13)
+- A timestamped backup could overwrite an existing backup made in the same second.
+  Backup names are now made unique. (#22)
+- A backup interrupted partway through could leave a corrupt `.zip`. Backups are now
+  written to a temporary file and renamed into place only after they finish. (#22)
+- The autobackup limit counter no longer drifts. A failed backup no longer counts
+  toward the limit, and the count tracks the real number of backups on disk. (#22)
+- Settings could be corrupted if the app was closed while saving them. Settings are now
+  written atomically. (#23)
+- "Restore Default" now clears all settings reliably and reports if a file could not be
+  removed, instead of always claiming success. (#23)
+- The global hotkey and the autobackup timer are now set up and cleaned up correctly
+  across the app's lifetime. (#14, #16)
+- Fixed several crashes: an empty interval list, a double-click in empty space in the
+  backup list, and a stale right-click menu. (#25)
+- Combobox selection and backup listing handle more edge cases. (#15)
+- The updater is launched by its full path, and the update check no longer hangs or
+  shows an unexpected error when you are offline. (#24)
+- Fixed resource leaks in the sound player and the recycle-bin undo. (#25)
+
+### Removed
+- Dead code and unused files left over from earlier versions. (#26, #27)
+
+## [1.2.4] - 2024-05-10
+
+Previous release. Earlier history is not tracked in this file.
+
+[1.3.0]: https://github.com/sammorrison9800/Savedrake/compare/1.2.4...1.3.0
+[1.2.4]: https://github.com/sammorrison9800/Savedrake/releases/tag/1.2.4

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
                                                                 
                                                                    
-# Savedrake v1.2.4 | Easy Save Game Manager for Dragon's Dogma 2
+# Savedrake v1.3.0 | Easy Save Game Manager for Dragon's Dogma 2
 
 ## Introduction
 
-Savedrake v1.2.4 is an open-source, user-friendly, and intuitive save game manager for Dragon's Dogma 2. It simplifies the process of backing up and restoring your game saves, ensuring that your progress is always secure.
+Savedrake v1.3.0 is an open-source, user-friendly, and intuitive save game manager for Dragon's Dogma 2. It simplifies the process of backing up and restoring your game saves, ensuring that your progress is always secure.
 
 ## Features
 

--- a/Savedrake v1.2.3/Main.Designer.cs
+++ b/Savedrake v1.2.3/Main.Designer.cs
@@ -571,7 +571,7 @@
             this.Name = "Main";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Savedrake v.1.2.4";
+            this.Text = "Savedrake v.1.3.0";
             this.Load += new System.EventHandler(this.Main_Load);
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -195,7 +195,7 @@ namespace Savedrake
             trayIcon.Icon = this.Icon; // Set the icon
             trayIcon.Visible = false; // Hide the icon initially
             trayIcon.DoubleClick += TrayIcon_DoubleClick; // Event handler for double-clicking the icon
-            trayIcon.Text = "Savedrake v1.2.4";
+            trayIcon.Text = "Savedrake v1.3.0";
             // Initialize the ContextMenuStrip
             trayMenu = new ContextMenuStrip();
             ToolStripMenuItem showItem = new ToolStripMenuItem("Show");

--- a/Savedrake v1.2.3/Properties/AssemblyInfo.cs
+++ b/Savedrake v1.2.3/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Save Game Manager for Dragon's Dogma 2")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("sammorrison9800")]
-[assembly: AssemblyProduct("Savedrake v1.2.4")]
+[assembly: AssemblyProduct("Savedrake v1.3.0")]
 [assembly: AssemblyCopyright("Copyright ©  2024")]
 [assembly: AssemblyTrademark("Savedrake")]
 [assembly: AssemblyCulture("")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.4.0")]
-[assembly: AssemblyFileVersion("1.2.4.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]


### PR DESCRIPTION
Prepares the 1.3.0 release.

- Bumps `AssemblyVersion`, `AssemblyFileVersion`, and `AssemblyProduct` to 1.3.0.
- Updates the window title, tray text, and README to v1.3.0.
- Adds `CHANGELOG.md` (Keep a Changelog format) covering the work merged since 1.2.4 (PRs #13 to #28): transactional restore, transactional auto-update, atomic backup writes, settings persistence, the locale-tolerant interval parser, backup sounds for all backups, crash and leak fixes, and dead-code cleanup.

Builds clean Release and Debug. RestoreHarness 111/111. The built exe reports FileVersion 1.3.0.0.

After this merges, the 1.3.0 GitHub release will be cut from master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)