### PR TITLE
docs: github hygiene and doc cleanup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: Bug report
+description: Report a problem with Savedrake
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. Please update to the latest release and check the
+        [FAQ](https://github.com/sammorrison9800/Savedrake/blob/master/FAQ.md) first.
+  - type: input
+    id: version
+    attributes:
+      label: Savedrake version
+      description: Shown in the window title, for example 1.3.0.
+      placeholder: "1.3.0"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you do, what did you expect, and what happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: List the steps so the problem can be reproduced.
+    validations:
+      required: false
+  - type: input
+    id: windows
+    attributes:
+      label: Windows version
+      placeholder: "Windows 11 23H2"
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I am on the latest release
+        - label: I checked the FAQ

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question or FAQ
+    url: https://github.com/sammorrison9800/Savedrake/blob/master/FAQ.md
+    about: Check the FAQ for common questions before opening an issue.
+  - name: Report a security issue
+    url: https://github.com/sammorrison9800/Savedrake/blob/master/SECURITY.md
+    about: Report security issues privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Suggest an idea for Savedrake
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the situation or pain point this would address.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like Savedrake to do?
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or workarounds
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## What does this change?
+
+## Why?
+
+## Testing
+- [ ] Builds in Debug and Release
+- [ ] RestoreHarness passes
+- [ ] Tested the affected feature manually (if applicable)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      nuget-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Code of Conduct
+
+## Our standard
+
+This project welcomes anyone who wants to use it, report issues, or contribute. Be respectful and
+constructive. Examples of behavior that keep this project healthy:
+
+- Being patient and welcoming, especially with new users.
+- Giving and accepting feedback gracefully.
+- Focusing on what is best for the project and its users.
+
+Examples of unacceptable behavior:
+
+- Harassment, insults, or personal attacks.
+- Discriminatory or sexual language or imagery.
+- Publishing other people's private information without permission.
+
+## Scope
+
+This applies to all project spaces, including issues, pull requests, and any public discussion
+about the project.
+
+## Enforcement
+
+Report unacceptable behavior to sammorrison9800@gmail.com. The maintainer will review and respond
+as needed, and may remove comments, reject contributions, or block accounts.
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to Savedrake
+
+Thanks for your interest. Savedrake is a Windows save manager for Dragon's Dogma 2, written in C#
+on .NET Framework 4.8 (WinForms).
+
+## Build and test
+
+You need Windows with Visual Studio 2022 (Community is fine) or the matching MSBuild, plus
+`nuget.exe`. The project uses `packages.config`, so restore with NuGet, not `dotnet restore`.
+
+```
+nuget restore Savedrake.sln
+msbuild Savedrake.sln -t:Build -p:Configuration=Release
+```
+
+The solution has three projects:
+
+- the app (`Savedrake v1.2.3`),
+- the updater (`updater`),
+- a reflection-based restore test harness (`RestoreHarness`).
+
+The harness loads the built app and exercises the restore, backup-naming, and interval-parsing
+helpers. Run it after building:
+
+```
+RestoreHarness\bin\RestoreHarness.exe
+```
+
+It must report all checks passing (a non-zero exit fails CI). CI runs the build in Debug and
+Release and runs the harness on every push and pull request, plus a weekly CodeQL scan.
+
+## Making changes
+
+- Branch from `master`, one change per branch.
+- Open a pull request against `master`. Keep the build green and the harness passing.
+- For changes to backup or restore, add or update a harness check where it makes sense.
+- Keep commits focused, and say what changed and why.
+
+## Reporting issues
+
+Use the issue templates for bugs and feature requests. For security issues, see
+[SECURITY.md](SECURITY.md). Please do not report vulnerabilities in public issues.

--- a/FAQ
+++ b/FAQ
@@ -1,2 +1,0 @@
-Go here:
-https://github.com/sammorrison9800/Savedrake/blob/master/FAQ.md

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,30 +1,65 @@
-### Frequently Asked Questions (FAQ)
+# Frequently Asked Questions
 
-#### Q: Where can I find my Dragon's Dogma 2 save files?
-**A:** Your Dragon's Dogma 2 save files are typically located at:
+## Where are my Dragon's Dogma 2 save files?
+
+Under your Steam install, at:
+
 ```
-C:\Program Files (x86)\Steam\userdata\{your_user_id}\2054970\remote\win64_save
+<Steam>\userdata\<your_id>\2054970\remote\win64_save
 ```
 
-#### Q: What naming convention does Savedrake use for backups?
-**A:** By default, Savedrake names backups with unique, game-related titles like "Archer Drake.zip" or "Cyclops Arisen.zip". You can customize this to use simple timestamps instead through the settings menu.
+A common path is `C:\Program Files (x86)\Steam\userdata\...`, but it depends on where Steam is
+installed. The folder holds several files (`data*.bin` and `system.bin`).
 
-#### Q: How do I customize the notification sounds in Savedrake?
-**A:** To change the notification sounds, replace the `success.wav` and `error.wav` files with your chosen audio files, making sure to rename them to match the originals.
+## How does Savedrake name backups?
 
-#### Q: Does Savedrake support managing multiple characters?
-**A:** Savedrake doesn't have a specific multi-character feature, but you can manage different characters by creating distinct backups and labeling them for each character.
+By default it uses random Dragon's Dogma themed names like "Archer Drake.zip". You can switch to
+timestamps in the settings menu. Names are made unique, so two backups never overwrite each other.
 
-#### Q: What's the best way to organize my backups in Savedrake?
-**A:** Within the app, right-click on any backup in the list to rename or delete it. You can also use the "Del" key to delete or "F2" to rename. The refresh button will update the app's current state.
+## Is restoring safe? Can it lose my save?
 
-#### Q: How do I get started with Savedrake?
-**A:** Refer to the 'Getting Started' section for a step-by-step guide.
+Restore is transactional. Savedrake extracts the backup to a staging area, checks it contains save
+data, swaps it into place, and rolls back to your previous save if any step fails. Your previous
+save is kept until the new one is provably in place.
 
-#### Q: Are there any current bugs in Savedrake I should know about?
-**A:** There are no known bugs as of version 1.2.4. If you encounter any issues, please report them.
+## Should I disable Steam Cloud when restoring?
 
-#### Q: Where can I send feedback or feature requests for Savedrake?
-**A:** For feedback or feature requests, email sammorrison9800@gmail.com or post on the Nexus forums. You can also see ongoing work at the [Savedrake GitHub repository](https://github.com/sammorrison9800/Savedrake).
+Yes. Exit Dragon's Dogma 2 and either close Steam or turn off Steam Cloud for the game before
+restoring. Otherwise Steam can re-upload the old cloud save over your restored files. If Steam
+shows a cloud conflict on the next launch, choose the local copy.
 
-#### Q: Can you summarize the main features of Savedrake?
+## Can I get banned for using Savedrake?
+
+Savedrake only copies and restores your own local saves. It does not edit save contents, pawns, or
+items. There is no official statement that backing up or restoring your own unedited saves is
+bannable. Use it on your own saves only.
+
+## Does it support multiple characters?
+
+There is no dedicated multi-character feature yet. You can keep separate, clearly named backups per
+character and restore the one you want. Planned improvements are in the [roadmap](ROADMAP.md).
+
+## How do I change the notification sounds?
+
+Replace `success.wav` and `error.wav` next to `Savedrake.exe` with your own files, keeping the same
+names.
+
+## How do I organize backups?
+
+Right-click a backup in the list to rename or delete it. F2 renames, Del deletes. Deleted backups
+go to the Recycle Bin, and the last deletion can be undone.
+
+## I updated, but the updater still seems old.
+
+The updater program cannot replace itself during an auto-update, so it stays on the version you
+installed. To get the latest updater, download the release zip and extract it over your install
+once.
+
+## How do I report a bug or request a feature?
+
+Open an issue on the [GitHub repository](https://github.com/sammorrison9800/Savedrake/issues), or
+email sammorrison9800@gmail.com. For security reports, see [SECURITY.md](SECURITY.md).
+
+## Where can I see what changed or what is planned?
+
+See [CHANGELOG.md](CHANGELOG.md) for releases and [ROADMAP.md](ROADMAP.md) for planned work.

--- a/README.md
+++ b/README.md
@@ -1,47 +1,71 @@
-                                                                
-                                                                   
-# Savedrake v1.3.0 | Easy Save Game Manager for Dragon's Dogma 2
+# Savedrake
 
-## Introduction
+A save game manager for Dragon's Dogma 2 on Windows. Savedrake backs up and restores your
+Dragon's Dogma 2 saves so a bad decision, a corrupt save, or an accidental overwrite does not
+cost you your progress.
 
-Savedrake v1.3.0 is an open-source, user-friendly, and intuitive save game manager for Dragon's Dogma 2. It simplifies the process of backing up and restoring your game saves, ensuring that your progress is always secure.
+Windows only. Built on .NET Framework 4.8 (WinForms).
+
+[![Latest release](https://img.shields.io/github/v/release/sammorrison9800/Savedrake?sort=semver)](https://github.com/sammorrison9800/Savedrake/releases/latest)
+[![Build](https://github.com/sammorrison9800/Savedrake/actions/workflows/build.yml/badge.svg)](https://github.com/sammorrison9800/Savedrake/actions/workflows/build.yml)
+[![License: MIT](https://img.shields.io/github/license/sammorrison9800/Savedrake)](LICENSE)
+
+[Download the latest release](https://github.com/sammorrison9800/Savedrake/releases/latest) ·
+[Changelog](CHANGELOG.md) · [FAQ](FAQ.md) · [Roadmap](ROADMAP.md)
 
 ## Features
 
-- **Security**: Protects against accidental deletion of your game progress.
-- **Multiple Time-Stamped Backups**: Allows for the creation of numerous backups, enabling you to revert to any stage of your game.
-- **Custom Hotkey Support**: Enables setting a hotkey for quick in-game save backups.
-- **Sound Notification**: Provides audio confirmation when backups are successfully completed.
-- **Autobackup**: Automates backups at set intervals while the game is running.
-- **Limit Autobackup**: Allows you to set a cap on the number of automatic backups.
-- **Undo Last Deletion**: Offers the ability to recover mistakenly deleted backups.
-- **Recycle Bin Integration**: Ensures deleted files are moved to the recycle bin for possible recovery.
-- **In-App File Management**: Facilitates direct management of backups within the app.
-- **Auto Update**: Keeps Savedrake up-to-date by automatically downloading updates or notifying you of new versions.
-- **System Tray Minimization**: Reduces desktop clutter by allowing the app to be minimized to the system tray.
+- Manual backups. Zip your save folder on demand, named with random Dragon's Dogma themes or with
+  timestamps. Names are made unique so backups never overwrite each other.
+- Transactional restore. A backup is staged, checked for save data, and swapped into place, and it
+  rolls back to your previous save automatically if any step fails, so a failed restore cannot
+  leave your saves half-replaced.
+- Autobackup. Take a backup on a timer while the game is running, with a cap on how many to keep.
+- Global hotkey. Trigger a backup with a key combination without leaving the game.
+- Backup history. Open, rename, or delete backups from the list. Deleted backups go to the Recycle
+  Bin, and the last deletion can be undone.
+- Sound feedback on every backup (manual, hotkey, and autobackup).
+- Minimize to the system tray.
+- Auto update. Savedrake checks GitHub for new versions and can update itself.
 
-## Getting Started
+## Install
 
-1. Download and extract the zip file.
-2. Run "Savedrake.exe" and configure your backup preferences.
-3. Ensure Savedrake is active before starting the game.
-4. Play with the assurance that your Dragon's Dogma 2 save games are secure!
+1. Download `Savedrake.v<version>.zip` from the
+   [latest release](https://github.com/sammorrison9800/Savedrake/releases/latest).
+2. Extract it anywhere.
+3. Run `Savedrake.exe`, then set your Dragon's Dogma 2 save folder and a backup folder.
+
+The build is not code-signed, so Windows SmartScreen may warn about an unknown publisher. Choose
+"More info" and then "Run anyway". Each release lists SHA-256 checksums you can verify against.
 
 ## Usage
 
-- The **Backup** button creates a zip file of the save game files in the specified backup location.
-- The **Restore** button moves current save game files to the recycle bin and places the selected backup file in the save location.
-- Set a custom hotkey by enabling the "Custom Hotkey" option and following the prompts.
-- The **Undo** button recovers the last deleted files from the recycle bin (one-time use per deletion).
-- Activate **AutoBackup** by selecting the checkbox and setting your preferred time interval.
-- Manage backups with right-click options in the list view—delete or rename as needed.
-- The **Refresh** button updates the application's state.
-- Customize notification sounds by replacing the "success.wav" and "error.wav" files, ensuring they are named correctly.
+- Backup: zips your save folder into the backup folder.
+- Restore: replaces your current save with a selected backup (staged, with automatic rollback on
+  failure).
+- Autobackup: tick the checkbox and set an interval. Backups run while the game is open.
+- Hotkey: enable "Custom Hotkey" and follow the prompts to set a key combination.
+- Undo: recovers the most recently deleted backup from the Recycle Bin (one use per deletion).
+- Right-click a backup to rename or delete it. F2 renames, Del deletes.
+- Sounds: replace `success.wav` and `error.wav` next to the exe to change them, keeping the names.
 
-## Support
+## Steam Cloud note
 
-For questions, bug reports, or feature requests, contact sammorrison9800@gmail.com or post on Nexus.
+Exit Dragon's Dogma 2 and either close Steam or turn off Steam Cloud for the game before you
+restore. Otherwise Steam can re-upload the old cloud save over your restored files. If Steam shows
+a cloud conflict on the next launch, choose the local copy. Savedrake backs up and restores your
+own local saves and does not edit save contents.
 
-## Acknowledgments
+## Reporting issues and security
 
-Special thanks to the Dragon's Dogma community for their invaluable feedback and support.
+- Bugs and feature requests: open a [GitHub issue](https://github.com/sammorrison9800/Savedrake/issues).
+- Security reports: see [SECURITY.md](SECURITY.md).
+- You can also reach the author at sammorrison9800@gmail.com or on Nexus Mods.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to build, test, and submit changes.
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported versions
+
+Savedrake is a small Windows utility distributed through GitHub Releases. Only the latest release
+gets fixes. Please update to the
+[latest release](https://github.com/sammorrison9800/Savedrake/releases/latest) before reporting.
+
+| Version        | Supported |
+|----------------|-----------|
+| Latest release | Yes       |
+| Older releases | No        |
+
+## Reporting a vulnerability
+
+Please report security issues privately. Do not open a public issue for a vulnerability.
+
+- Preferred: use GitHub private vulnerability reporting on this repository (the "Report a
+  vulnerability" button on the Security tab).
+- Or email sammorrison9800@gmail.com with "Savedrake security" in the subject.
+
+Include what you found, how to reproduce it, and the version you tested. This is a hobby project,
+so responses are best effort. Please give the maintainer a chance to release a fix before
+disclosing the issue publicly.
+
+## Scope
+
+Savedrake reads and writes save files, and it downloads and runs its own updates from GitHub
+Releases over HTTPS. Reports about the backup and restore flow, or about the auto-update flow, are
+especially welcome.
+
+Known limitation: the updater verifies that a downloaded update is a valid package containing the
+application, but it does not yet verify a cryptographic signature of the package. Signed updates
+are planned. See [ROADMAP.md](ROADMAP.md).


### PR DESCRIPTION
Adds the standard GitHub community health files and cleans up the existing docs.

### Added
- `SECURITY.md`: private vulnerability reporting, supported versions, scope. States the known limitation that the updater does not yet verify a signature.
- `CONTRIBUTING.md`: build, harness, and PR instructions.
- `CODE_OF_CONDUCT.md`: Contributor Covenant based.
- `.github/ISSUE_TEMPLATE/`: bug report and feature request forms plus `config.yml` (validated with PyYAML).
- `.github/PULL_REQUEST_TEMPLATE.md`.
- `.github/dependabot.yml`: weekly NuGet and GitHub Actions updates, grouped.

### Cleaned
- README rewritten: the restore description now reflects the transactional behavior (not "moves to the Recycle Bin"), removed marketing phrasing and an em-dash, added badges and links to the latest release, changelog, FAQ, and roadmap.
- FAQ rewritten and completed (the last question was cut off with no answer), updated for 1.3.0, and added Steam Cloud, ban-risk, and updater questions.
- Removed the stray `FAQ` file, which was only a redirect to `FAQ.md`.

Docs only. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)