### PR TITLE
feat: pre-restore safety checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Savedrake are recorded here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- Pre-restore safety checkpoint: before restoring a backup, Savedrake now automatically
+  snapshots your current save into a `(Pre-Restore)` backup first, so restoring one backup
+  no longer discards the save you currently have. The snapshot is exempt from the autobackup
+  limit and is never auto-pruned; if it cannot be created you are asked whether to continue
+  without it. (#34)
+
 ## [1.3.0] - 2026-06-17
 
 This release is a large batch of reliability and data-safety fixes on top of 1.2.4,

--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -88,6 +88,7 @@ namespace RestoreHarness
                 Test_CanonicalizeInterval();   // variant spellings collapse onto one item (no duplicate-item regression)
                 Test_SoundAssetsShipped();   // success.wav / error.wav must ship next to Savedrake.exe
                 Test_MakeUniquePath();   // backup-name collision guard (timestamp backups no longer overwrite)
+                Test_PreRestoreCheckpoint();   // P4: snapshot the live save before a restore so it isn't discarded
             }
             catch (Exception ex)
             {
@@ -236,6 +237,47 @@ namespace RestoreHarness
             File.WriteAllText(r2, "x");
             string r3 = (string)mi.Invoke(null, new object[] { p });
             Check("_2 also exists -> _3", r3 == Path.Combine(dir, "backup_250617120000_3.zip"), r3);
+            Console.WriteLine();
+        }
+
+        static void Test_PreRestoreCheckpoint()
+        {
+            // P4: before a restore deletes the current live save, snapshot it into the backup folder under a
+            // "(Pre-Restore) " name that LoadBackupHistory does NOT count as an autobackup. UI-free, so testable here.
+            Console.WriteLine("== Pre-restore safety checkpoint (P4) ==");
+            var mi = IM("CreatePreRestoreCheckpoint");
+
+            // 1) live save present -> a single (Pre-Restore) zip is created, valid, and contains the save data
+            string live = NewDir("cp_live");
+            File.WriteAllBytes(Path.Combine(live, "data000.bin"), B("savedata"));
+            File.WriteAllBytes(Path.Combine(live, "system.bin"), B("sys"));
+            string backup = NewDir("cp_backup");
+            bool ok = (bool)mi.Invoke(inst, new object[] { live, backup });
+            string[] zips = Directory.GetFiles(backup, "*.zip");
+            Check("checkpoint returns true on success", ok);
+            Check("exactly one checkpoint zip created", zips.Length == 1, "found " + zips.Length);
+            string name = zips.Length == 1 ? Path.GetFileName(zips[0]) : "";
+            Check("checkpoint uses '(Pre-Restore) ' prefix", name.StartsWith("(Pre-Restore) "), name);
+            Check("checkpoint is NOT counted as an autobackup", !name.StartsWith("(Auto)") && !name.StartsWith("auto"), name);
+            bool hasSave = false;
+            if (zips.Length == 1)
+                using (var z = Ionic.Zip.ZipFile.Read(zips[0]))
+                    hasSave = z.Entries.Any(en => IsRealSaveEntry(Path.GetFileName(en.FileName)));
+            Check("checkpoint zip contains the live save data", hasSave);
+            Check("no .savedrake.tmp left behind", Directory.GetFiles(backup, "*.savedrake.tmp").Length == 0);
+
+            // 2) live folder has no DD2 save data -> nothing to lose: skip, return true, create no zip
+            string live2 = NewDir("cp_live_nosave");
+            File.WriteAllBytes(Path.Combine(live2, "readme.txt"), B("nothing"));
+            string backup2 = NewDir("cp_backup2");
+            bool ok2 = (bool)mi.Invoke(inst, new object[] { live2, backup2 });
+            Check("no-save-data live -> skipped, returns true, no zip", ok2 && Directory.GetFiles(backup2, "*.zip").Length == 0);
+
+            // 3) live == backup folder -> refuse (can't stage into the folder being snapshotted), return true
+            string same = NewDir("cp_same");
+            File.WriteAllBytes(Path.Combine(same, "data000.bin"), B("savedata"));
+            bool ok3 = (bool)mi.Invoke(inst, new object[] { same, same });
+            Check("live==backup -> skipped (no zip), returns true", ok3 && Directory.GetFiles(same, "*.zip").Length == 0);
             Console.WriteLine();
         }
 

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -1617,6 +1617,54 @@ namespace Savedrake
         //Restore Zip Operations //Undetected
         #region Restore Operation
 
+        // Pre-restore safety checkpoint (P4). RestoreTransactional moves the current live save aside and DELETES it
+        // on success (Undo is disabled afterwards), so restoring backup A would otherwise discard the player's
+        // current state B with no way back. Snapshot the live save into the backup folder first, under a distinct
+        // "(Pre-Restore) " name so it is visible in the history list, is NOT counted as an autobackup (LoadBackupHistory
+        // only counts "(Auto)"/"auto" prefixes), and is never auto-pruned (nothing prunes). Mirrors the atomic
+        // temp+rename write used by BackupOperation. UI-free (takes explicit dirs) so the headless harness can test it.
+        // Returns true on success OR when there is nothing to snapshot; false on failure so the caller can let the
+        // user decide whether to restore without a safety net.
+        private bool CreatePreRestoreCheckpoint(string liveDir, string backupDir)
+        {
+            // Can't safely stage a zip into the very folder being snapshotted.
+            if (string.Equals(Path.GetFullPath(liveDir), Path.GetFullPath(backupDir), StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            // Nothing to lose if the live folder holds no DD2 save data — skip and let the restore proceed.
+            bool hasSaveData;
+            try
+            {
+                hasSaveData = Directory
+                    .EnumerateFiles(liveDir, "*", SearchOption.AllDirectories)
+                    .Any(p => IsRealSaveEntry(Path.GetFileName(p)));
+            }
+            catch (UnauthorizedAccessException) { hasSaveData = true; } // can't scan -> err toward making a checkpoint
+            catch (System.IO.IOException) { hasSaveData = true; }
+            if (!hasSaveData) return true;
+
+            string checkpointPath = MakeUniquePath(Path.Combine(backupDir, $"(Pre-Restore) {DateTime.Now:yyMMddHHmmss}.zip"));
+            string tempZip = checkpointPath + ".savedrake.tmp";
+            try
+            {
+                // Sweep any orphaned temp files first (same as BackupOperation); our own tempZip doesn't exist yet.
+                try { foreach (string stale in Directory.GetFiles(backupDir, "*.savedrake.tmp")) File.Delete(stale); } catch { }
+                using (Ionic.Zip.ZipFile zip = new Ionic.Zip.ZipFile())
+                {
+                    zip.AddDirectory(liveDir);
+                    zip.Comment = "SamMorrison9800";
+                    zip.Save(tempZip);
+                }
+                File.Move(tempZip, checkpointPath); // atomically publish the completed checkpoint
+                return true;
+            }
+            catch (Exception)
+            {
+                try { if (File.Exists(tempZip)) File.Delete(tempZip); } catch { }
+                return false;
+            }
+        }
+
         private void button_res_Click(object sender, EventArgs e)
         {
             // Check if the textboxes are not empty and contain valid paths
@@ -1671,6 +1719,20 @@ namespace Savedrake
                     MessageBox.Show(reason + "\n\nYour current save files have not been touched.",
                         "Restore Failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
+                }
+
+                // STEP 3b — pre-restore safety checkpoint (P4). RestoreTransactional deletes the current live save on
+                // success, so snapshot it first into a "(Pre-Restore)" backup the user can roll back to. If the
+                // snapshot can't be made, let the user decide rather than silently proceeding without a safety net.
+                Status.Text = "Creating pre-restore checkpoint...";
+                if (!CreatePreRestoreCheckpoint(textbox1.Text, textbox2.Text))
+                {
+                    DialogResult proceed = MessageBox.Show(
+                        "Savedrake could not create a safety snapshot of your current save before restoring.\n\n" +
+                        "If you continue, your current save will be replaced and its current state will be lost.\n\n" +
+                        "Restore anyway?",
+                        "Pre-Restore Checkpoint Failed", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+                    if (proceed != DialogResult.Yes) { Status.Text = "Restore cancelled."; return; }
                 }
 
                 // STEP 4 — delegate ALL destructive work (staging, swap, rollback, cleanup) to the transaction.


### PR DESCRIPTION
## What

Adds a **pre-restore safety checkpoint** (roadmap item P4). Before a restore replaces the current live save, Savedrake snapshots that live save into the backup folder under a distinct `(Pre-Restore)` name, so restoring backup A no longer discards the save the player currently has.

## Why

The transactional restore moves the live save aside and **deletes it on success** (Undo is disabled afterwards), so restoring backup A silently discarded the player's current state B unless they remembered to back it up first. This is the confirmed real data-loss gap documented in `ROADMAP.md`.

## How

- New UI-free `CreatePreRestoreCheckpoint(liveDir, backupDir)` in `Main.cs`, called from `button_res_Click` after validation (STEP 3) and before the destructive transaction (STEP 4).
- Reuses `BackupOperation`'s atomic temp+rename write and the same zip comment.
- Named `(Pre-Restore) <timestamp>.zip` via `MakeUniquePath`, so it is visible in history, is **not** counted as an autobackup (`LoadBackupHistory` only counts `(Auto)`/`auto` prefixes), and is never auto-pruned (nothing prunes).
- Skipped when the live folder has no DD2 save data (nothing to lose) and when live == backup (can't stage into the folder being snapshotted).
- If the snapshot fails, the user is asked whether to restore without a safety net rather than proceeding silently.

## Tests

8 new `RestoreHarness` assertions (creation, naming/exemption, zip validity + contents, no temp left behind, no-save-data skip, live==backup skip). Local Debug + Release both: **119 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)