### PR TITLE
feat: verify backups on creation (CRC test-extract)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to Savedrake are recorded here. The format is based on
   no longer discards the save you currently have. The snapshot is exempt from the autobackup
   limit and is never auto-pruned; if it cannot be created you are asked whether to continue
   without it. (#34)
+- Backup integrity check on creation: every backup (and pre-restore checkpoint) is now
+  verified right after it is written, by expanding and checksum-checking every file inside
+  it. A corrupt or unreadable backup is rejected with an error instead of being saved and
+  only failing later when you try to restore it. (#35)
 
 ## [1.3.0] - 2026-06-17
 

--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -89,6 +89,7 @@ namespace RestoreHarness
                 Test_SoundAssetsShipped();   // success.wav / error.wav must ship next to Savedrake.exe
                 Test_MakeUniquePath();   // backup-name collision guard (timestamp backups no longer overwrite)
                 Test_PreRestoreCheckpoint();   // P4: snapshot the live save before a restore so it isn't discarded
+                Test_VerifyZipRestorable();   // P1: backups are CRC-verified at creation; corrupt ones are rejected
             }
             catch (Exception ex)
             {
@@ -278,6 +279,46 @@ namespace RestoreHarness
             File.WriteAllBytes(Path.Combine(same, "data000.bin"), B("savedata"));
             bool ok3 = (bool)mi.Invoke(inst, new object[] { same, same });
             Check("live==backup -> skipped (no zip), returns true", ok3 && Directory.GetFiles(same, "*.zip").Length == 0);
+            Console.WriteLine();
+        }
+
+        static void Test_VerifyZipRestorable()
+        {
+            // P1 layer 1: a freshly written backup is CRC-verified (IsZipFile testExtract) before it is published;
+            // truncated/corrupt/missing archives are rejected at creation. VerifyZipRestorable(string, out string) static.
+            Console.WriteLine("== Backup integrity: verify-on-create (P1) ==");
+            var mi = SM("VerifyZipRestorable");
+
+            string good = Path.Combine(work, "verify_good.zip");
+            MakeZip(good, z => { z.AddEntry("data000.bin", B("savedata")); z.AddEntry("system.bin", B("sys")); });
+            object[] a1 = { good, null };
+            bool r1 = (bool)mi.Invoke(null, a1);
+            Check("intact backup -> verifies, no reason", r1 && a1[1] == null, "reason=" + a1[1]);
+
+            string notzip = Path.Combine(work, "verify_notzip.zip");
+            File.WriteAllBytes(notzip, B("this is plain text, definitely not a zip archive"));
+            object[] a2 = { notzip, null };
+            bool r2 = (bool)mi.Invoke(null, a2);
+            Check("non-zip bytes -> rejected with a reason", !r2 && a2[1] != null, "reason=" + a2[1]);
+
+            // High-entropy payload so it stays (near) uncompressed and the file is large enough that the midpoint
+            // lands in the entry's data. Flipping a byte there makes the extracted CRC mismatch -> testExtract fails.
+            byte[] payload = new byte[16384];
+            uint s = 0x12345678u;
+            for (int i = 0; i < payload.Length; i++) { s = s * 1664525u + 1013904223u; payload[i] = (byte)(s >> 24); }
+            string big = Path.Combine(work, "verify_big.zip");
+            MakeZip(big, z => { z.AddEntry("data000.bin", payload); });
+            byte[] cb = File.ReadAllBytes(big);
+            cb[cb.Length / 2] ^= 0xFF; // corrupt a byte in the entry data
+            string corrupt = Path.Combine(work, "verify_corrupt.zip");
+            File.WriteAllBytes(corrupt, cb);
+            object[] a3 = { corrupt, null };
+            bool r3 = (bool)mi.Invoke(null, a3);
+            Check("corrupt entry data -> rejected (CRC mismatch)", !r3 && a3[1] != null, "reason=" + a3[1]);
+
+            object[] a4 = { Path.Combine(work, "verify_missing.zip"), null };
+            bool r4 = (bool)mi.Invoke(null, a4);
+            Check("missing file -> rejected without throwing", !r4 && a4[1] != null, "reason=" + a4[1]);
             Console.WriteLine();
         }
 

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -1546,6 +1546,14 @@ namespace Savedrake
                     zip.Comment = "SamMorrison9800"; // This is the hidden comment
                     zip.Save(tempZip); // Save to the temp file first
                 }
+                // Verify-on-create (P1): a backup that fails CRC verification must never be published as if it were
+                // good. Reject it here (delete the temp, throw into the catch below) so the user is told now, while
+                // their live saves are untouched, instead of discovering it only at restore time.
+                if (!VerifyZipRestorable(tempZip, out string verifyReason))
+                {
+                    try { File.Delete(tempZip); } catch { }
+                    throw new System.IO.IOException("the backup failed verification after writing (" + verifyReason + ")");
+                }
                 File.Move(tempZip, backupFileName); // atomically publish the completed backup
 
                 // Update the status
@@ -1579,6 +1587,31 @@ namespace Savedrake
             string candidate;
             do { candidate = Path.Combine(dir, $"{name}_{n++}{ext}"); } while (File.Exists(candidate));
             return candidate;
+        }
+
+        // Backup integrity verification, layer 1 (P1): prove a freshly written archive is actually restorable before
+        // we publish or trust it. DotNetZip's IsZipFile(testExtract:true) opens the zip, reads its directory, and
+        // expands EVERY entry while checking CRCs, so truncation, bit-rot, or a half-written/locked source file is
+        // caught at creation time instead of only when the user finally needs the backup. Returns false (with a
+        // reason) on any failure. Static + file-path-only so the headless harness can test it directly.
+        private static bool VerifyZipRestorable(string zipPath, out string reason)
+        {
+            reason = null;
+            try
+            {
+                // testExtract = true: don't just check the signature, expand every entry and verify its CRC.
+                if (!Ionic.Zip.ZipFile.IsZipFile(zipPath, true))
+                {
+                    reason = "the archive is not a valid, fully readable zip (it may be truncated or corrupt)";
+                    return false;
+                }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                reason = "the archive could not be verified: " + ex.Message;
+                return false;
+            }
         }
 
 
@@ -1654,6 +1687,12 @@ namespace Savedrake
                     zip.AddDirectory(liveDir);
                     zip.Comment = "SamMorrison9800";
                     zip.Save(tempZip);
+                }
+                // Verify-on-create (P1): don't trust a checkpoint we can't prove is restorable.
+                if (!VerifyZipRestorable(tempZip, out _))
+                {
+                    try { File.Delete(tempZip); } catch { }
+                    return false;
                 }
                 File.Move(tempZip, checkpointPath); // atomically publish the completed checkpoint
                 return true;


### PR DESCRIPTION
## What

Backup integrity verification, **layer 1 of roadmap P1**. After a backup zip is written and before it is published with the atomic rename, Savedrake verifies it with DotNetZip's `IsZipFile(testExtract: true)`, which expands every entry and checks its CRC. A backup that fails verification is deleted and surfaced as an error rather than published.

## Why

A backup that looks fine but is corrupt when finally needed is the worst failure mode for a save tool. Previously a successfully-saved-but-corrupt archive would only be discovered at restore time. Now corruption is caught at creation, while the user's live saves are still untouched.

## How

- New shared static helper `VerifyZipRestorable(zipPath, out reason)`.
- Wired into both write paths: `BackupOperation` (manual/auto) rejects and reports; `CreatePreRestoreCheckpoint` returns false (caller asks the user).
- The atomic temp+rename write is preserved; verification happens on the temp file before the publish `File.Move`.

## Scope / what this does and does not catch

- Catches: CRC corruption (bit-rot, mid-write truncation), non-zip/garbage, unreadable archives.
- Does **not** catch: a zip cleanly truncated at an entry boundary (missing whole trailing files). That is layer 2's job, an in-zip `manifest.json` with the expected file list and per-file hashes, which is the next slice of P1.

## Tests

4 new `RestoreHarness` assertions: intact zip verifies; non-zip bytes rejected; corrupted entry data rejected (CRC mismatch); missing file rejected without throwing. Local Debug + Release both: **123 passed, 0 failed**.