### PR TITLE
feat: backup integrity manifest (P1 layer 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to Savedrake are recorded here. The format is based on
   verified right after it is written, by expanding and checksum-checking every file inside
   it. A corrupt or unreadable backup is rejected with an error instead of being saved and
   only failing later when you try to restore it. (#35)
+- Backups now carry an internal integrity manifest (the list of save files with each one's
+  size and checksum). Every new backup is verified against it at creation, so a backup that
+  is missing a file or has silently corrupted is caught and rejected up front. The manifest
+  is metadata only and is never restored into your save folder. (#36)
 
 ## [1.3.0] - 2026-06-17
 

--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -90,6 +90,7 @@ namespace RestoreHarness
                 Test_MakeUniquePath();   // backup-name collision guard (timestamp backups no longer overwrite)
                 Test_PreRestoreCheckpoint();   // P4: snapshot the live save before a restore so it isn't discarded
                 Test_VerifyZipRestorable();   // P1: backups are CRC-verified at creation; corrupt ones are rejected
+                Test_BackupManifest();   // P1 layer 2: in-zip manifest verify (missing/corrupt files) + restore skips it
             }
             catch (Exception ex)
             {
@@ -319,6 +320,50 @@ namespace RestoreHarness
             object[] a4 = { Path.Combine(work, "verify_missing.zip"), null };
             bool r4 = (bool)mi.Invoke(null, a4);
             Check("missing file -> rejected without throwing", !r4 && a4[1] != null, "reason=" + a4[1]);
+            Console.WriteLine();
+        }
+
+        static void Test_BackupManifest()
+        {
+            // P1 layer 2: backups carry an in-zip integrity manifest (path/length/sha256 per file). Verify catches a
+            // missing or corrupted file; restore must SKIP the manifest so it never lands in the live save folder.
+            Console.WriteLine("== Backup integrity: manifest verify (P1 layer 2) ==");
+            var build = SM("BuildBackupManifest");
+            var verify = SM("VerifyZipAgainstManifest");
+            var extract = IM("ExtractZipToStaging");
+
+            string src = NewDir("man_src");
+            File.WriteAllBytes(Path.Combine(src, "data000.bin"), B("save-A-contents"));
+            File.WriteAllBytes(Path.Combine(src, "system.bin"), B("system-contents"));
+            string manifest = (string)build.Invoke(null, new object[] { src });
+            Check("manifest lists both source files", manifest.Contains("data000.bin") && manifest.Contains("system.bin"));
+
+            string good = Path.Combine(work, "man_good.zip");
+            MakeZip(good, z => { z.AddDirectory(src); z.AddEntry("_savedrake/manifest.json", B(manifest)); });
+            object[] a1 = { good, null };
+            Check("intact backup verifies against its manifest", (bool)verify.Invoke(null, a1) && a1[1] == null, "reason=" + a1[1]);
+
+            string missing = Path.Combine(work, "man_missing.zip");
+            MakeZip(missing, z => { z.AddEntry("data000.bin", B("save-A-contents")); z.AddEntry("_savedrake/manifest.json", B(manifest)); });
+            object[] a2 = { missing, null };
+            Check("missing declared file -> rejected", !(bool)verify.Invoke(null, a2) && a2[1] != null, "reason=" + a2[1]);
+
+            string tampered = Path.Combine(work, "man_tampered.zip");
+            MakeZip(tampered, z => { z.AddEntry("data000.bin", B("DIFFERENT-contents!")); z.AddEntry("system.bin", B("system-contents")); z.AddEntry("_savedrake/manifest.json", B(manifest)); });
+            object[] a3 = { tampered, null };
+            Check("tampered file content -> rejected", !(bool)verify.Invoke(null, a3) && a3[1] != null, "reason=" + a3[1]);
+
+            string nomani = Path.Combine(work, "man_none.zip");
+            MakeZip(nomani, z => { z.AddEntry("data000.bin", B("x")); });
+            object[] a4 = { nomani, null };
+            Check("no manifest -> rejected", !(bool)verify.Invoke(null, a4) && a4[1] != null, "reason=" + a4[1]);
+
+            string stage = NewDir("man_stage");
+            extract.Invoke(inst, new object[] { good, stage });
+            bool hasSaves = File.Exists(Path.Combine(stage, "data000.bin")) && File.Exists(Path.Combine(stage, "system.bin"));
+            bool noManifest = !Directory.Exists(Path.Combine(stage, "_savedrake")) && !File.Exists(Path.Combine(stage, "_savedrake", "manifest.json"));
+            Check("restore extracts the save files", hasSaves);
+            Check("restore skips the _savedrake manifest", noManifest);
             Console.WriteLine();
         }
 

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -1543,13 +1543,17 @@ namespace Savedrake
                 {
                     Status.Text = "Backup started... Please wait.";
                     zip.AddDirectory(textbox1.Text); // Add the directory to the zip
+                    // Integrity manifest (P1 layer 2): record every source file's path/length/SHA-256 inside the zip
+                    // so we can prove on create (and re-check later) that the backup is complete and uncorrupted.
+                    zip.AddEntry(ManifestEntryName, System.Text.Encoding.UTF8.GetBytes(BuildBackupManifest(textbox1.Text)));
                     zip.Comment = "SamMorrison9800"; // This is the hidden comment
                     zip.Save(tempZip); // Save to the temp file first
                 }
-                // Verify-on-create (P1): a backup that fails CRC verification must never be published as if it were
-                // good. Reject it here (delete the temp, throw into the catch below) so the user is told now, while
-                // their live saves are untouched, instead of discovering it only at restore time.
-                if (!VerifyZipRestorable(tempZip, out string verifyReason))
+                // Verify-on-create: a backup that fails verification must never be published as if it were good. Reject
+                // it here (delete the temp, throw into the catch below) so the user is told now, while their live saves
+                // are untouched, instead of discovering it only at restore time. Layer 1 = CRC test-extract of every
+                // entry; layer 2 = every file present with the manifest's recorded length + SHA-256.
+                if (!VerifyZipRestorable(tempZip, out string verifyReason) || !VerifyZipAgainstManifest(tempZip, out verifyReason))
                 {
                     try { File.Delete(tempZip); } catch { }
                     throw new System.IO.IOException("the backup failed verification after writing (" + verifyReason + ")");
@@ -1612,6 +1616,89 @@ namespace Savedrake
                 reason = "the archive could not be verified: " + ex.Message;
                 return false;
             }
+        }
+
+        // Name of the integrity manifest written inside every new backup zip (P1 layer 2). Lives under a reserved
+        // "_savedrake" folder so the restore can recognise and SKIP it — it must never be extracted into the live save
+        // folder. Legacy backups made before this change simply have no manifest and are treated as unverified.
+        private const string ManifestEntryName = "_savedrake/manifest.json";
+
+        // True for any zip entry under Savedrake's reserved "_savedrake" metadata folder (the integrity manifest), at
+        // the archive root or under any nesting. Such entries are skipped on restore.
+        private static bool IsManifestEntry(string entryFileName)
+        {
+            string p = "/" + (entryFileName ?? "").Replace('\\', '/');
+            return p.IndexOf("/_savedrake/", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        private static string Sha256Hex(System.IO.Stream content)
+        {
+            using (var sha = System.Security.Cryptography.SHA256.Create())
+                return BitConverter.ToString(sha.ComputeHash(content)).Replace("-", "").ToLowerInvariant();
+        }
+
+        // Build the integrity manifest for a backup: one record per source file (path relative to the save folder,
+        // byte length, SHA-256). Written inside the zip and verified against the zip's actual contents at creation, so
+        // a backup missing a file or with silent bit-rot is detected up front instead of only failing at restore time.
+        private static string BuildBackupManifest(string sourceDir)
+        {
+            string baseDir = Path.GetFullPath(sourceDir).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var files = new JArray();
+            foreach (string file in Directory.EnumerateFiles(baseDir, "*", SearchOption.AllDirectories))
+            {
+                string rel = Path.GetFullPath(file).Substring(baseDir.Length + 1).Replace('\\', '/');
+                string sha;
+                using (var fs = File.OpenRead(file)) sha = Sha256Hex(fs);
+                files.Add(new JObject { ["path"] = rel, ["length"] = new FileInfo(file).Length, ["sha256"] = sha });
+            }
+            return new JObject
+            {
+                ["manifestVersion"] = 1,
+                ["tool"] = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(),
+                ["createdUtc"] = DateTime.UtcNow.ToString("o", System.Globalization.CultureInfo.InvariantCulture),
+                ["files"] = files
+            }.ToString();
+        }
+
+        // Backup integrity verification, layer 2 (P1): confirm the freshly written archive contains every file the
+        // manifest declares, each with the recorded length + SHA-256. Catches a backup missing whole files (e.g. a zip
+        // truncated at an entry boundary, which the layer-1 CRC test-extract can miss) and per-file bit-rot. Returns
+        // false (with a reason) on any missing/mismatched file or a missing/garbled manifest.
+        private static bool VerifyZipAgainstManifest(string zipPath, out string reason)
+        {
+            reason = null;
+            try
+            {
+                using (Ionic.Zip.ZipFile zip = Ionic.Zip.ZipFile.Read(zipPath))
+                {
+                    Ionic.Zip.ZipEntry manifestEntry = zip.Entries.FirstOrDefault(e =>
+                        string.Equals(e.FileName.Replace('\\', '/'), ManifestEntryName, StringComparison.OrdinalIgnoreCase));
+                    if (manifestEntry == null) { reason = "the backup has no integrity manifest"; return false; }
+
+                    string json;
+                    using (var ms = new System.IO.MemoryStream()) { manifestEntry.Extract(ms); json = System.Text.Encoding.UTF8.GetString(ms.ToArray()); }
+                    JArray files = JObject.Parse(json)["files"] as JArray;
+                    if (files == null) { reason = "the integrity manifest is unreadable"; return false; }
+
+                    var byPath = zip.Entries.Where(e => !e.IsDirectory && !IsManifestEntry(e.FileName))
+                        .ToDictionary(e => e.FileName.Replace('\\', '/'), e => e, StringComparer.OrdinalIgnoreCase);
+
+                    foreach (JToken ft in files)
+                    {
+                        string rel = (string)ft["path"];
+                        if (rel == null || !byPath.TryGetValue(rel, out Ionic.Zip.ZipEntry e))
+                        { reason = "a file recorded in the manifest is missing from the backup: " + rel; return false; }
+                        if (e.UncompressedSize != (long)ft["length"])
+                        { reason = "a file's size does not match the manifest: " + rel; return false; }
+                        string actual;
+                        using (var ms = new System.IO.MemoryStream()) { e.Extract(ms); ms.Position = 0; actual = Sha256Hex(ms); }
+                        if (!string.Equals(actual, (string)ft["sha256"], StringComparison.OrdinalIgnoreCase))
+                        { reason = "a file's contents do not match the manifest (corrupt): " + rel; return false; }
+                    }
+                    return true;
+                }
+            }
+            catch (Exception ex) { reason = "the backup could not be verified against its manifest: " + ex.Message; return false; }
         }
 
 
@@ -1685,11 +1772,12 @@ namespace Savedrake
                 using (Ionic.Zip.ZipFile zip = new Ionic.Zip.ZipFile())
                 {
                     zip.AddDirectory(liveDir);
+                    zip.AddEntry(ManifestEntryName, System.Text.Encoding.UTF8.GetBytes(BuildBackupManifest(liveDir)));
                     zip.Comment = "SamMorrison9800";
                     zip.Save(tempZip);
                 }
-                // Verify-on-create (P1): don't trust a checkpoint we can't prove is restorable.
-                if (!VerifyZipRestorable(tempZip, out _))
+                // Verify-on-create (P1): don't trust a checkpoint we can't prove is restorable (CRC + manifest).
+                if (!VerifyZipRestorable(tempZip, out _) || !VerifyZipAgainstManifest(tempZip, out _))
                 {
                     try { File.Delete(tempZip); } catch { }
                     return false;
@@ -1925,6 +2013,9 @@ namespace Savedrake
                         throw new System.IO.IOException(
                             "Backup contains an unsafe path entry: '" + entry.FileName + "'. Restore aborted.");
                     if (entry.IsDirectory) continue;
+                    // Skip Savedrake's own integrity manifest — it lives inside the zip for verification but must NOT
+                    // be restored into the live save folder (it is metadata, not a game save file).
+                    if (IsManifestEntry(entry.FileName)) continue;
                     // Use ONLY this DotNetZip overload (same engine the old ExtractAll used). NOT OpenReader/stream-copy,
                     // NOT ExtractToFile (System.IO.Compression only). Ionic recreates parent subdirs automatically.
                     entry.Extract(stagingDir, Ionic.Zip.ExtractExistingFileAction.OverwriteSilently);


### PR DESCRIPTION
## What

Layer 2 of roadmap P1. Every new backup now carries a small integrity manifest inside the zip (`_savedrake/manifest.json`: each save file's relative path, byte length, and SHA-256). The freshly written archive is verified against that manifest before it is published.

## Why

Layer 1 (#35, `IsZipFile(testExtract)`) catches CRC corruption but can miss a zip cleanly truncated at an entry boundary (whole trailing files gone). The manifest records the expected file set and per-file hashes, so a backup that is missing a file or has silently bit-rotted is caught at creation instead of only failing at restore.

## How

- `BuildBackupManifest(sourceDir)` enumerates the save files and records path/length/SHA-256 as JSON (Newtonsoft, already referenced).
- The manifest is added as `_savedrake/manifest.json` before `zip.Save`.
- `VerifyZipAgainstManifest(zipPath, out reason)` confirms every declared file is present with the recorded length + SHA-256. Wired in alongside the layer-1 check in both `BackupOperation` and `CreatePreRestoreCheckpoint`.
- `ExtractZipToStaging` skips `_savedrake/` entries, so the manifest is never restored into the live save folder.
- Legacy backups (no manifest) restore exactly as before; the manifest check only runs on creation.

## Tests

7 new `RestoreHarness` assertions: manifest lists the files; intact backup verifies; missing declared file rejected; tampered file content rejected; no-manifest rejected; restore extracts the saves and skips the manifest. Local Debug + Release both: **130 passed, 0 failed** (existing restore tests unchanged).

## Follow-ups (rest of P1)

A per-backup validated/legacy/corrupt state in the history list + a "Validate all backups" action, and re-verifying the manifest on restore before commit.