### PR TITLE
feat: re-verify backup integrity on restore (P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to Savedrake are recorded here. The format is based on
   size and checksum). Every new backup is verified against it at creation, so a backup that
   is missing a file or has silently corrupted is caught and rejected up front. The manifest
   is metadata only and is never restored into your save folder. (#36)
+- Restore now re-checks a backup against its integrity manifest before replacing your live
+  save, so a backup that has corrupted on disk since it was created is caught and the restore
+  is refused with your current save left untouched. Older backups without a manifest are
+  unaffected. (#37)
 
 ## [1.3.0] - 2026-06-17
 

--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -91,6 +91,7 @@ namespace RestoreHarness
                 Test_PreRestoreCheckpoint();   // P4: snapshot the live save before a restore so it isn't discarded
                 Test_VerifyZipRestorable();   // P1: backups are CRC-verified at creation; corrupt ones are rejected
                 Test_BackupManifest();   // P1 layer 2: in-zip manifest verify (missing/corrupt files) + restore skips it
+                Test_RestoreReverify();   // P1: restore re-verifies a manifest-bearing backup; legacy backups unaffected
             }
             catch (Exception ex)
             {
@@ -364,6 +365,37 @@ namespace RestoreHarness
             bool noManifest = !Directory.Exists(Path.Combine(stage, "_savedrake")) && !File.Exists(Path.Combine(stage, "_savedrake", "manifest.json"));
             Check("restore extracts the save files", hasSaves);
             Check("restore skips the _savedrake manifest", noManifest);
+            Console.WriteLine();
+        }
+
+        static void Test_RestoreReverify()
+        {
+            // P1 read-side gate: a manifest-bearing backup that no longer matches its hashes is blocked before a
+            // restore touches the live saves; a legacy backup (no manifest) is never blocked. Both helpers are static.
+            Console.WriteLine("== Backup integrity: re-verify on restore (P1) ==");
+            var hasMan = SM("HasManifest");
+            var blocked = SM("RestoreBlockedByManifest");
+
+            string src = NewDir("rv_src");
+            File.WriteAllBytes(Path.Combine(src, "data000.bin"), B("the-save"));
+            string manifest = (string)SM("BuildBackupManifest").Invoke(null, new object[] { src });
+
+            string good = Path.Combine(work, "rv_good.zip");
+            MakeZip(good, z => { z.AddDirectory(src); z.AddEntry("_savedrake/manifest.json", B(manifest)); });
+            string legacy = Path.Combine(work, "rv_legacy.zip");
+            MakeZip(legacy, z => { z.AddEntry("data000.bin", B("the-save")); }); // no manifest
+            string corrupt = Path.Combine(work, "rv_corrupt.zip");
+            MakeZip(corrupt, z => { z.AddEntry("data000.bin", B("TAMPERED!")); z.AddEntry("_savedrake/manifest.json", B(manifest)); });
+
+            Check("HasManifest true for a manifest backup", (bool)hasMan.Invoke(null, new object[] { good }));
+            Check("HasManifest false for a legacy backup", !(bool)hasMan.Invoke(null, new object[] { legacy }));
+
+            object[] g = { good, null };
+            Check("valid manifest backup -> NOT blocked", !(bool)blocked.Invoke(null, g) && g[1] == null, "reason=" + g[1]);
+            object[] l = { legacy, null };
+            Check("legacy backup -> NOT blocked", !(bool)blocked.Invoke(null, l) && l[1] == null, "reason=" + l[1]);
+            object[] c = { corrupt, null };
+            Check("on-disk corrupted manifest backup -> BLOCKED with reason", (bool)blocked.Invoke(null, c) && c[1] != null, "reason=" + c[1]);
             Console.WriteLine();
         }
 

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -1701,6 +1701,29 @@ namespace Savedrake
             catch (Exception ex) { reason = "the backup could not be verified against its manifest: " + ex.Message; return false; }
         }
 
+        // True if the backup zip carries an integrity manifest. Cheap: reads the zip directory only, does not hash.
+        private static bool HasManifest(string zipPath)
+        {
+            try
+            {
+                using (Ionic.Zip.ZipFile zip = Ionic.Zip.ZipFile.Read(zipPath))
+                    return zip.Entries.Any(e => string.Equals(e.FileName.Replace('\\', '/'), ManifestEntryName, StringComparison.OrdinalIgnoreCase));
+            }
+            catch { return false; }
+        }
+
+        // Read-side integrity gate for restore (P1): returns true if the restore should be BLOCKED because the backup
+        // carries a manifest that no longer matches its contents — i.e. the backup has corrupted on disk since it was
+        // created. Legacy backups (no manifest, made before this feature) are never blocked here, so old backups keep
+        // restoring exactly as before. Static + file-path-only so the headless harness can test the decision.
+        private static bool RestoreBlockedByManifest(string zipPath, out string reason)
+        {
+            reason = null;
+            if (!HasManifest(zipPath)) return false;                                        // legacy backup -> not gated
+            if (VerifyZipAgainstManifest(zipPath, out reason)) { reason = null; return false; } // matches -> allowed
+            return true;                                                                    // manifest mismatch -> block
+        }
+
 
         // Helper method to generate a unique backup file name
         private string GenerateBackupFileName(bool isAutoBackup)
@@ -1844,6 +1867,17 @@ namespace Savedrake
                 if (!ValidateBackup(filePath, out string reason))
                 {
                     MessageBox.Show(reason + "\n\nYour current save files have not been touched.",
+                        "Restore Failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return;
+                }
+
+                // STEP 3a — re-verify a manifest-bearing backup against its recorded hashes before touching live saves
+                // (P1). Catches a backup that has bit-rotted on disk since it was created. Legacy backups without a
+                // manifest are unaffected and restore as before.
+                if (RestoreBlockedByManifest(filePath, out string integrityReason))
+                {
+                    MessageBox.Show("This backup failed its integrity check (" + integrityReason + ").\n\n" +
+                        "Your current save files have not been touched.",
                         "Restore Failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }


### PR DESCRIPTION
## What

Read-side completion of P1. Before a restore replaces your live save, Savedrake re-checks a manifest-bearing backup against its recorded per-file hashes. If it no longer matches (the backup corrupted on disk since creation), the restore is refused with your current save untouched.

## Why

Creation-time verification (#35/#36) proves a backup is good when written. This adds the read-side guard: a backup can still bit-rot on disk afterward, and you do not want to discover that by overwriting your live save with it.

## How

- `HasManifest(zipPath)` — cheap zip-directory check (no hashing).
- `RestoreBlockedByManifest(zipPath, out reason)` — blocks only when a manifest is present and does not match; legacy backups (no manifest) are never blocked.
- Wired into the restore handler as STEP 3a, after `ValidateBackup` and before any destructive work.

## Tests

5 new `RestoreHarness` assertions: HasManifest detection; valid and legacy backups not blocked; on-disk-corrupted manifest backup blocked with a reason. Local Debug + Release both: **135 passed, 0 failed**.

## Remaining P1

A per-backup validated/legacy/corrupt indicator in the history list plus a "Validate all backups" action (UI work) is the only P1 item left.