### PR TITLE
feat: backup integrity indicator in the UI (P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to Savedrake are recorded here. The format is based on
   save, so a backup that has corrupted on disk since it was created is caught and the restore
   is refused with your current save left untouched. Older backups without a manifest are
   unaffected. (#37)
+- The backup list now has an Integrity column: "Protected" for backups that carry the new
+  checksum manifest and "Legacy" for older ones. A new right-click "Validate all backups"
+  action runs a full check and marks each backup Validated, Legacy, or Corrupt, so you can
+  find a bad backup before you ever need it. (#38)
 
 ## [1.3.0] - 2026-06-17
 

--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -92,6 +92,7 @@ namespace RestoreHarness
                 Test_VerifyZipRestorable();   // P1: backups are CRC-verified at creation; corrupt ones are rejected
                 Test_BackupManifest();   // P1 layer 2: in-zip manifest verify (missing/corrupt files) + restore skips it
                 Test_RestoreReverify();   // P1: restore re-verifies a manifest-bearing backup; legacy backups unaffected
+                Test_ClassifyBackup();   // P1 UI: full Validated/Legacy/Corrupt classification for "Validate all"
             }
             catch (Exception ex)
             {
@@ -396,6 +397,33 @@ namespace RestoreHarness
             Check("legacy backup -> NOT blocked", !(bool)blocked.Invoke(null, l) && l[1] == null, "reason=" + l[1]);
             object[] c = { corrupt, null };
             Check("on-disk corrupted manifest backup -> BLOCKED with reason", (bool)blocked.Invoke(null, c) && c[1] != null, "reason=" + c[1]);
+            Console.WriteLine();
+        }
+
+        static void Test_ClassifyBackup()
+        {
+            // P1 UI: full classification used by "Validate all backups" -> "Validated" / "Legacy" / "Corrupt".
+            Console.WriteLine("== Backup integrity: full classification (P1 UI) ==");
+            var classify = SM("ClassifyBackupFully");
+            string src = NewDir("cls_src");
+            File.WriteAllBytes(Path.Combine(src, "data000.bin"), B("the-save"));
+            string manifest = (string)SM("BuildBackupManifest").Invoke(null, new object[] { src });
+
+            string good = Path.Combine(work, "cls_good.zip");
+            MakeZip(good, z => { z.AddDirectory(src); z.AddEntry("_savedrake/manifest.json", B(manifest)); });
+            Check("manifest-valid backup -> Validated", (string)classify.Invoke(null, new object[] { good }) == "Validated");
+
+            string legacy = Path.Combine(work, "cls_legacy.zip");
+            MakeZip(legacy, z => { z.AddEntry("data000.bin", B("the-save")); });
+            Check("no-manifest backup -> Legacy", (string)classify.Invoke(null, new object[] { legacy }) == "Legacy");
+
+            string corrupt = Path.Combine(work, "cls_corrupt.zip");
+            MakeZip(corrupt, z => { z.AddEntry("data000.bin", B("TAMPERED!")); z.AddEntry("_savedrake/manifest.json", B(manifest)); });
+            Check("tampered manifest backup -> Corrupt", (string)classify.Invoke(null, new object[] { corrupt }) == "Corrupt");
+
+            string notzip = Path.Combine(work, "cls_notzip.zip");
+            File.WriteAllBytes(notzip, B("not a zip at all"));
+            Check("non-zip file -> Corrupt", (string)classify.Invoke(null, new object[] { notzip }) == "Corrupt");
             Console.WriteLine();
         }
 

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -172,10 +172,13 @@ namespace Savedrake
             ContextMenuStrip contextMenuStrip = new ContextMenuStrip();
             ToolStripMenuItem renameMenultem = new ToolStripMenuItem("Rename");
             ToolStripMenuItem deleteMenuItem = new ToolStripMenuItem("Delete");
+            ToolStripMenuItem validateAllMenuItem = new ToolStripMenuItem("Validate all backups");
             contextMenuStrip.Items.Add(renameMenultem);
             contextMenuStrip.Items.Add(deleteMenuItem);
+            contextMenuStrip.Items.Add(validateAllMenuItem);
             renameMenultem.Click += RenameMenultem_Click;
             deleteMenuItem.Click += DeleteMenuItem_Click;
+            validateAllMenuItem.Click += (s, e) => ValidateAllBackups();
             listView.ContextMenuStrip = contextMenuStrip;
 
             //listView related
@@ -185,6 +188,13 @@ namespace Savedrake
             listView.AfterLabelEdit += listView_AfterLabelEdit;
             listView.ContextMenuStrip = contextMenuStrip;
             listView.KeyDown += ListView_KeyDown;
+
+            // Integrity column (P1): per-backup state. On load it shows "Protected"/"Legacy" (cheap manifest-presence
+            // check); the right-click "Validate all backups" action runs the full hash check and marks each row
+            // "Validated"/"Legacy"/"Corrupt".
+            if (listView.Columns.Count < 3)
+                listView.Columns.Add("Integrity");
+            listViewColumnResize();
 
             #endregion
 
@@ -1387,6 +1397,16 @@ namespace Savedrake
 
         private void listViewColumnResize()
         {
+            if (listView.Columns.Count >= 3)
+            {
+                // File Name | Date & Time | Integrity. Give Integrity a fixed slice and split the rest ~55/45.
+                int integrity = 72;
+                int rest = Math.Max(0, listView.Width - integrity);
+                listView.Columns[0].Width = (int)(rest * 0.55);
+                listView.Columns[1].Width = rest - listView.Columns[0].Width;
+                listView.Columns[2].Width = integrity;
+                return;
+            }
             listView.Columns[0].Width = listView.Width / 2;
             // Set the width of the second column (Column 1) to be 50% of the ListView's width
             listView.Columns[1].Width = listView.Width / 2;
@@ -1722,6 +1742,16 @@ namespace Savedrake
             if (!HasManifest(zipPath)) return false;                                        // legacy backup -> not gated
             if (VerifyZipAgainstManifest(zipPath, out reason)) { reason = null; return false; } // matches -> allowed
             return true;                                                                    // manifest mismatch -> block
+        }
+
+        // Full integrity classification for the "Validate all backups" action (P1): "Validated" (CRC ok + manifest
+        // matches), "Legacy" (no manifest — predates the feature), or "Corrupt" (CRC fails, or a manifest is present
+        // but does not match). Hashes the archive, so it is on-demand only, never on a list refresh. Static for tests.
+        private static string ClassifyBackupFully(string zipPath)
+        {
+            if (!VerifyZipRestorable(zipPath, out _)) return "Corrupt";
+            if (!HasManifest(zipPath)) return "Legacy";
+            return VerifyZipAgainstManifest(zipPath, out _) ? "Validated" : "Corrupt";
         }
 
 
@@ -2210,7 +2240,15 @@ namespace Savedrake
                         // R6: list every readable backup zip. The "SamMorrison9800" comment is treated as a
                         // provenance tag, not a hard filter — DotNetZip 1.16 can't store a comment on a 0-entry
                         // zip, so empty backups used to be invisible (and so couldn't be seen or deleted).
-                        ListViewItem item = new ListViewItem(new[] { fileInfo.Name, fileInfo.CreationTime.ToString() });
+                        // Cheap integrity hint (P1): "Protected" if the backup carries an integrity manifest, else
+                        // "Legacy". Reuses the zip already open here (no extra read). The full hash check that yields
+                        // "Validated"/"Corrupt" runs only on demand via the "Validate all backups" right-click action,
+                        // because hashing every backup on every refresh would be slow.
+                        bool hasManifest = zip.Entries.Any(en => IsManifestEntry(en.FileName));
+                        ListViewItem item = new ListViewItem(new[] { fileInfo.Name, fileInfo.CreationTime.ToString(),
+                            hasManifest ? "Protected" : "Legacy" });
+                        item.UseItemStyleForSubItems = false;
+                        item.SubItems[2].ForeColor = hasManifest ? System.Drawing.Color.SteelBlue : System.Drawing.Color.Gray;
                         item.Tag = fileInfo; // Store the FileInfo object in the Tag property
                         listView.Items.Add(item);
                         listView.Sort();
@@ -2242,6 +2280,44 @@ namespace Savedrake
 
             // Write the new count back to the file
             File.WriteAllText(countFilePath, backupCount.ToString());
+        }
+
+        // Right-click "Validate all backups" action (P1): run the FULL integrity check on every listed backup and mark
+        // each row in the Integrity column — green "Validated", gray "Legacy", red "Corrupt"/"Missing". This hashes
+        // every backup, so it can take a moment on large folders; the cheap "Protected"/"Legacy" hint is what shows on
+        // load. Read-only: it never modifies, deletes, or touches a backup.
+        private void ValidateAllBackups()
+        {
+            if (listView.Items.Count == 0)
+            {
+                MessageBox.Show("There are no backups to validate.", "Validate Backups", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+            Cursor previous = Cursor.Current;
+            Cursor.Current = Cursors.WaitCursor;
+            Status.Text = "Validating backups...";
+            int validated = 0, legacy = 0, failed = 0;
+            try
+            {
+                foreach (ListViewItem item in listView.Items)
+                {
+                    FileInfo fi = item.Tag as FileInfo;
+                    string path = fi != null ? fi.FullName : Path.Combine(textbox2.Text, item.Text);
+                    string state = File.Exists(path) ? ClassifyBackupFully(path) : "Missing";
+                    while (item.SubItems.Count < 3) item.SubItems.Add(string.Empty);
+                    item.UseItemStyleForSubItems = false;
+                    item.SubItems[2].Text = state;
+                    if (state == "Validated") { validated++; item.SubItems[2].ForeColor = System.Drawing.Color.ForestGreen; }
+                    else if (state == "Legacy") { legacy++; item.SubItems[2].ForeColor = System.Drawing.Color.Gray; }
+                    else { failed++; item.SubItems[2].ForeColor = System.Drawing.Color.Firebrick; }
+                }
+            }
+            finally { Cursor.Current = previous; }
+            listView.Refresh();
+            Status.Text = $"Validated {listView.Items.Count} backups: {validated} OK, {legacy} legacy, {failed} failed.";
+            if (failed > 0)
+                MessageBox.Show(failed + " backup(s) failed validation and may not be restorable. They are marked in red in the Integrity column.",
+                    "Validation", MessageBoxButtons.OK, MessageBoxIcon.Warning);
         }
 
         #endregion


### PR DESCRIPTION
## What

The UI tail of P1. The backup list gains an **Integrity** column, and a right-click **"Validate all backups"** action.

- On load (cheap, no hashing): each backup shows **Protected** (carries a manifest) or **Legacy** (older backup).
- "Validate all backups" runs the full check (`ClassifyBackupFully`) and marks each row **Validated** (green), **Legacy** (gray), or **Corrupt** (red), so a bad backup is found proactively rather than only at restore.

## How

- Column and context-menu item added programmatically in the constructor (no `Main.Designer.cs` changes); `listViewColumnResize` now lays out three columns.
- `LoadBackupHistory` fills the cheap state by reusing the zip it already opens.
- `ValidateAllBackups` is strictly read-only: it never modifies, renames, or deletes a backup.

## Tests

4 new `RestoreHarness` assertions for `ClassifyBackupFully` (Validated / Legacy / Corrupt / non-zip). Local Debug + Release: **139 passed, 0 failed**. A launch smoke test confirms the constructor changes do not crash on startup. (The headless harness cannot exercise WinForms rendering; the validate action is read-only so it cannot affect saved data.)

## Phase 1 complete

This is the last P1 item. Data-safety core was #34 (pre-restore checkpoint), #35 (verify-on-create), #36 (integrity manifest), #37 (re-verify on restore); this adds the visibility layer.