### PR TITLE
feat: diagnostic logging + global crash handling (P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ All notable changes to Savedrake are recorded here. The format is based on
   checksum manifest and "Legacy" for older ones. A new right-click "Validate all backups"
   action runs a full check and marks each backup Validated, Legacy, or Corrupt, so you can
   find a bad backup before you ever need it. (#38)
+- Diagnostic logging: Savedrake now writes a rolling log to `%APPDATA%\Savedrake\Logs` (one
+  file per day, the last 14 kept) recording key events and any unexpected error, with file
+  paths and your Steam ID redacted. Crashes that used to disappear silently are now caught
+  and logged. Open the folder from Help > Open log folder. (#39)
 
 ## [1.3.0] - 2026-06-17
 

--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -93,6 +93,7 @@ namespace RestoreHarness
                 Test_BackupManifest();   // P1 layer 2: in-zip manifest verify (missing/corrupt files) + restore skips it
                 Test_RestoreReverify();   // P1: restore re-verifies a manifest-bearing backup; legacy backups unaffected
                 Test_ClassifyBackup();   // P1 UI: full Validated/Legacy/Corrupt classification for "Validate all"
+                Test_LogRedaction();   // P2: the rolling logger redacts the Steam account id and user profile path
             }
             catch (Exception ex)
             {
@@ -424,6 +425,23 @@ namespace RestoreHarness
             string notzip = Path.Combine(work, "cls_notzip.zip");
             File.WriteAllBytes(notzip, B("not a zip at all"));
             Check("non-zip file -> Corrupt", (string)classify.Invoke(null, new object[] { notzip }) == "Corrupt");
+            Console.WriteLine();
+        }
+
+        static void Test_LogRedaction()
+        {
+            // P2: the logger must strip personal data before writing. Redact is a pure function (no side effects).
+            Console.WriteLine("== Logging: redaction (P2) ==");
+            Type logT = T.Assembly.GetType("Savedrake.Log");
+            Check("Savedrake.Log type exists", logT != null);
+            if (logT == null) { Console.WriteLine(); return; }
+            var redact = logT.GetMethod("Redact", BindingFlags.Public | BindingFlags.Static);
+            Check("Log.Redact(string) exists", redact != null);
+            if (redact == null) { Console.WriteLine(); return; }
+            string r1 = (string)redact.Invoke(null, new object[] { @"C:\Program Files (x86)\Steam\userdata\1696225205\2054970\remote\win64_save" });
+            Check("Steam account id is redacted", !r1.Contains("1696225205") && r1.Contains("<redacted>"), r1);
+            string r2 = (string)redact.Invoke(null, new object[] { "nothing sensitive here" });
+            Check("plain text is unchanged", r2 == "nothing sensitive here", r2);
             Console.WriteLine();
         }
 

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -198,6 +198,15 @@ namespace Savedrake
 
             #endregion
 
+            // Help > Open log folder (P2): quick access to the diagnostic logs in %APPDATA%\Savedrake\Logs.
+            ToolStripMenuItem openLogFolderMenuItem = new ToolStripMenuItem("Open log folder");
+            openLogFolderMenuItem.Click += (s, e) =>
+            {
+                try { System.IO.Directory.CreateDirectory(Log.Directory()); System.Diagnostics.Process.Start("explorer.exe", Log.Directory()); }
+                catch (Exception ex) { Log.Error("Could not open log folder", ex); }
+            };
+            helpToolStripMenuItem.DropDownItems.Add(openLogFolderMenuItem);
+
             //tray
             #region
             // Initialize the NotifyIcon component
@@ -1584,9 +1593,11 @@ namespace Savedrake
                 LoadBackupHistory();
                 Status.Text = isAutoBackup ? $"Autobackup created at {DateTime.Now.ToString("hh:mm:ss tt")}." : "Backup created successfully.";
                 PlaySoundFromResource();
+                Log.Info("Backup created: " + Path.GetFileName(backupFileName) + (isAutoBackup ? " (auto)" : ""));
             }
             catch (Exception ex)
             {
+                Log.Error("Backup failed", ex);
                 // Clean up the partial temp file so a failed backup leaves nothing behind.
                 try { if (File.Exists(tempZip)) File.Delete(tempZip); } catch { }
                 // If an error occurs, show an error message
@@ -1955,6 +1966,7 @@ namespace Savedrake
         private bool RestoreTransactional(string filePath, string liveDir)
         {
             Status.Text = "Restore started... Please wait.";
+            Log.Info("Restore started from: " + Path.GetFileName(filePath));
             string stagingDir  = CreateSiblingTempDir(liveDir, "savedrake_stage");
             string rollbackDir = CreateSiblingTempDir(liveDir, "savedrake_rollback");
             bool stagingStarted = false; // true once T4 begins: live then holds disposable STAGED content, not originals
@@ -1976,6 +1988,7 @@ namespace Savedrake
                 try { ClearReadOnlyRecursive(liveDir); } catch { }        // T5 strip ReadOnly (R2)
 
                 Status.Text = "Restore successful.";                       // T6 commit
+                Log.Info("Restore successful from: " + Path.GetFileName(filePath));
                 MessageBox.Show("Restore successful.", "Information",
                     MessageBoxButtons.OK, MessageBoxIcon.Information);
                 return true;
@@ -2000,6 +2013,7 @@ namespace Savedrake
         private bool HandleRestoreFailure(Exception ex, string rollbackDir, string liveDir, bool stagingStarted)
         {
             bool recovered = Rollback(liveDir, rollbackDir, stagingStarted);
+            Log.Error("Restore failed (recovered=" + recovered + ")", ex);
             Status.Text = recovered
                 ? "Restore failed. Your previous save files were restored."
                 : "Restore failed. See the dialog to recover your saves.";

--- a/Savedrake v1.2.3/Program.cs
+++ b/Savedrake v1.2.3/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace Savedrake
@@ -12,6 +13,25 @@ namespace Savedrake
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+
+            // Logging + global crash handling (P2). A backup tool guarding irreplaceable saves must not crash
+            // silently, so set up the rolling log and the three WinForms exception sinks before anything else.
+            Log.Init();
+            Log.Info("Savedrake " + Assembly.GetExecutingAssembly().GetName().Version + " starting on " + Environment.OSVersion);
+            Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
+            Application.ThreadException += (s, e) =>
+            {
+                Log.Error("Unhandled UI-thread exception", e.Exception);
+                MessageBox.Show("An unexpected error occurred. Details were written to the log:\n" + Log.Directory(),
+                    "Savedrake", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            };
+            AppDomain.CurrentDomain.UnhandledException += (s, e) =>
+                Log.Error("Unhandled non-UI exception (terminating=" + e.IsTerminating + ")", e.ExceptionObject as Exception);
+            TaskScheduler.UnobservedTaskException += (s, e) =>
+            {
+                Log.Error("Unobserved task exception", e.Exception);
+                e.SetObserved(); // updater + auto-backup use Task.Run; don't let a stray task fault escalate
+            };
 
             // List of required DLLs
             string[] requiredDlls = {
@@ -56,6 +76,73 @@ namespace Savedrake
                 }
             }
             return null;
+        }
+    }
+
+    // Lightweight, dependency-free rolling logger (P2). Writes one file per day to %APPDATA%\Savedrake\Logs, keeps the
+    // most recent ~14, and NEVER throws into the app. Logs events, not save contents; personal data (the user profile
+    // path and the Steam account id in a save path) is redacted.
+    internal static class Log
+    {
+        private static readonly object _gate = new object();
+        private static string _file;
+        private static string _userProfile;
+
+        public static string Directory()
+        {
+            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Savedrake", "Logs");
+        }
+
+        public static void Init()
+        {
+            try
+            {
+                _userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                string dir = Directory();
+                System.IO.Directory.CreateDirectory(dir);
+                _file = Path.Combine(dir, "savedrake-" + DateTime.Now.ToString("yyyyMMdd") + ".log");
+                Prune(dir, 14);
+            }
+            catch { /* logging setup must never break startup */ }
+        }
+
+        public static void Info(string message) { Write("INFO", message, null); }
+        public static void Warn(string message) { Write("WARN", message, null); }
+        public static void Error(string message, Exception ex) { Write("ERROR", message, ex); }
+
+        private static void Write(string level, string message, Exception ex)
+        {
+            try
+            {
+                if (_file == null) Init();
+                string line = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss") + " [" + level + "] " + Redact(message);
+                if (ex != null) line += " | " + Redact(ex.ToString());
+                lock (_gate) File.AppendAllText(_file, line + Environment.NewLine);
+            }
+            catch { /* logging must never throw into the app */ }
+        }
+
+        // Strip personal data: the Windows user profile path and the Steam account id in a save path.
+        public static string Redact(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return s;
+            if (!string.IsNullOrEmpty(_userProfile))
+                s = s.Replace(_userProfile, "%USERPROFILE%");
+            return System.Text.RegularExpressions.Regex.Replace(
+                s, @"(userdata[\\/])\d+", "$1<redacted>", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        }
+
+        private static void Prune(string dir, int keep)
+        {
+            try
+            {
+                string[] files = System.IO.Directory.GetFiles(dir, "savedrake-*.log");
+                if (files.Length <= keep) return;
+                Array.Sort(files); // yyyyMMdd names sort chronologically
+                for (int i = 0; i < files.Length - keep; i++)
+                    try { File.Delete(files[i]); } catch { }
+            }
+            catch { }
         }
     }
 }


### PR DESCRIPTION
## What

Roadmap P2. A lightweight rolling logger plus the three WinForms exception sinks, so a crash or failed operation leaves a diagnostic trail instead of vanishing.

## How

- **Logger** (`Log` in `Program.cs`, dependency-free): one file per day in `%APPDATA%\Savedrake\Logs`, last 14 kept, thread-safe, and it never throws into the app.
- **Crash handling** in `Program.Main`: `Application.SetUnhandledExceptionMode(CatchException)` + `Application.ThreadException` (UI), `AppDomain.UnhandledException` (non-UI), and `TaskScheduler.UnobservedTaskException` (the updater and auto-backup use `Task.Run`).
- **Privacy**: logs events, not save contents; the user profile path and the Steam account id in a save path are redacted.
- **Instrumentation**: app start, backup created/failed, restore started/succeeded/failed.
- **Access**: Help > Open log folder.

## Tests

4 new `RestoreHarness` assertions for `Log.Redact` (Steam id redacted, plain text untouched). Local Debug + Release: **143 passed, 0 failed**. A launch smoke test confirms the app starts and writes `Savedrake <ver> starting on <OS>` to a fresh log file with no personal data.

## Note

This does not oversell crash recovery: for genuinely corrupted state, log-and-exit is the correct behavior. The goal is a trail, not magic recovery.