### PR TITLE
fix: use Uri.EscapeDataString for the updater download URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ All notable changes to Savedrake are recorded here. The format is based on
   paths and your Steam ID redacted. Crashes that used to disappear silently are now caught
   and logged. Open the folder from Help > Open log folder. (#39)
 
+### Fixed
+- The updater builds its download URL with `Uri.EscapeDataString` on the version segment
+  instead of the obsolete `Uri.EscapeUriString` (which can corrupt URLs). No change for
+  normal version tags. (#40)
+
 ## [1.3.0] - 2026-06-17
 
 This release is a large batch of reliability and data-safety fixes on top of 1.2.4,

--- a/updater/UpdaterForm.cs
+++ b/updater/UpdaterForm.cs
@@ -78,7 +78,10 @@ namespace updater
             // that 404s on Start Update. Leave downloadUrl null; ApplyUpdateAsync bails out cleanly on null.
             if (!string.IsNullOrEmpty(latestVersion))
             {
-                downloadUrl = Uri.EscapeUriString($"https://github.com/{Owner}/{Repo}/releases/download/{latestVersion}/update.zip");
+                // Escape only the variable version segment with Uri.EscapeDataString. Uri.EscapeUriString is obsolete
+                // and can corrupt a URL (it leaves some unsafe characters and can double-encode). Owner/Repo are fixed
+                // safe constants; latestVersion is the only runtime-variable path segment (a release tag, e.g. "1.3.0").
+                downloadUrl = $"https://github.com/{Owner}/{Repo}/releases/download/{Uri.EscapeDataString(latestVersion)}/update.zip";
             }
         }
 


### PR DESCRIPTION
## What

Replace the obsolete `Uri.EscapeUriString` in the updater's download-URL construction with `Uri.EscapeDataString` on the variable version segment.

## Why

`Uri.EscapeUriString` is marked obsolete and can corrupt a URL (it leaves some unsafe characters unescaped and can double-encode). The roadmap flagged it under Polish.

## How

`Owner`/`Repo` are fixed, safe constants; the release tag (`latestVersion`) is the only runtime-variable path segment, so it is the only thing that needs escaping. The resulting URL is identical for normal version tags like `1.3.0`; the fix just removes the deprecated API and is correct for any edge-case characters.

Builds clean on Debug + Release; restore harness unchanged at **143/0** (this does not touch the main app).