### PR TITLE
feat: disk-space preflight + operation lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ All notable changes to Savedrake are recorded here. The format is based on
   file per day, the last 14 kept) recording key events and any unexpected error, with file
   paths and your Steam ID redacted. Crashes that used to disappear silently are now caught
   and logged. Open the folder from Help > Open log folder. (#39)
+- Disk-space preflight: before a backup or restore, Savedrake checks the target drive has room
+  (including the staging copy a restore needs) and refuses up front with a clear message instead
+  of failing partway through. A backup and a restore can also no longer overlap. (#41)
 
 ### Fixed
 - The updater builds its download URL with `Uri.EscapeDataString` on the version segment

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,11 @@
 # Savedrake Roadmap
 
-> **Status:** planning only — nothing in this document is implemented yet.
-> The items here are *enhancements*, not bug fixes. The known defects were already fixed
+> **Status (updated 2026-06-17):** Most of Phase 1 (data-safety) plus the P2 logging item are now **implemented
+> on `master`** in PRs #34–#41: pre-restore safety checkpoint, verify-on-create, an in-zip integrity manifest,
+> re-verify on restore, the backup-integrity UI ("Validate all backups"), logging + global crash handling, the
+> `Uri.EscapeDataString` updater fix, and disk-space preflight + operation lock. **These are not yet released —
+> they ship at the next major release.** The remaining items below are not yet started.
+> The items here are *enhancements*, not bug fixes. The known defects were already fixed earlier
 > in PRs #13–#27 (transactional restore, hook/timer lifecycle, updater hardening, the full
 > code audit, and dead-code cleanup); the restore/update **core is considered solid** and
 > should be preserved.

--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -94,6 +94,7 @@ namespace RestoreHarness
                 Test_RestoreReverify();   // P1: restore re-verifies a manifest-bearing backup; legacy backups unaffected
                 Test_ClassifyBackup();   // P1 UI: full Validated/Legacy/Corrupt classification for "Validate all"
                 Test_LogRedaction();   // P2: the rolling logger redacts the Steam account id and user profile path
+                Test_DiskPreflight();   // disk-space preflight helpers (size math + free-space check, fail-open)
             }
             catch (Exception ex)
             {
@@ -442,6 +443,40 @@ namespace RestoreHarness
             Check("Steam account id is redacted", !r1.Contains("1696225205") && r1.Contains("<redacted>"), r1);
             string r2 = (string)redact.Invoke(null, new object[] { "nothing sensitive here" });
             Check("plain text is unchanged", r2 == "nothing sensitive here", r2);
+            Console.WriteLine();
+        }
+
+        static void Test_DiskPreflight()
+        {
+            // Disk-space preflight helpers. GetDirectorySize / GetZipUncompressedSize are pure size math;
+            // HasFreeSpaceFor checks the volume and FAILS OPEN when the volume can't be determined.
+            Console.WriteLine("== Disk-space preflight ==");
+            var dirSize = SM("GetDirectorySize");
+            var zipSize = SM("GetZipUncompressedSize");
+            var hasSpace = SM("HasFreeSpaceFor");
+
+            string d = NewDir("ds");
+            File.WriteAllBytes(Path.Combine(d, "a.bin"), new byte[1000]);
+            File.WriteAllBytes(Path.Combine(d, "b.bin"), new byte[2500]);
+            long size = (long)dirSize.Invoke(null, new object[] { d });
+            Check("GetDirectorySize sums file lengths", size == 3500, "got " + size);
+
+            string z = Path.Combine(work, "ds.zip");
+            MakeZip(z, x => { x.AddEntry("data000.bin", new byte[4096]); x.AddEntry("system.bin", new byte[1024]); });
+            long unz = (long)zipSize.Invoke(null, new object[] { z });
+            Check("GetZipUncompressedSize sums uncompressed entry sizes", unz == 4096 + 1024, "got " + unz);
+
+            object[] a1 = { work, 0L, null };
+            bool r1 = (bool)hasSpace.Invoke(null, a1);
+            Check("0 bytes needed -> has space (true)", r1 && a1[2] == null);
+
+            object[] a2 = { work, long.MaxValue / 2, null };
+            bool r2 = (bool)hasSpace.Invoke(null, a2);
+            Check("absurd requirement -> false with reason", !r2 && a2[2] != null, "reason=" + a2[2]);
+
+            object[] a3 = { @"\\nonexistent-share-xyz\nope", 1000L, null };
+            bool r3 = (bool)hasSpace.Invoke(null, a3);
+            Check("undeterminable volume -> fails open (true)", r3);
             Console.WriteLine();
         }
 

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -42,6 +42,7 @@ namespace Savedrake
         #region
         private System.Timers.Timer autobackupTimer; //(Autobackup feature)
         private bool _autoBackupInProgress; // R7a: re-entrancy guard for OnAutobackupTimerElapsed (UI-thread only)
+        private bool _operationInProgress;  // operation lock: a backup or restore is mid-flight (UI-thread only)
         private bool isAutoBackupEnabled = false; //(Autobackup feature)
         private ManagementEventWatcher _watcher; //(Autobackup feature)
         private bool isGameRunning; //(Autobackup feature)
@@ -1557,11 +1558,28 @@ namespace Savedrake
                 backupFileName = MakeUniquePath(Path.Combine(textbox2.Text, $"{autoPrefix}backup_{DateTime.Now:yyMMddHHmmss}.zip"));
             }
 
+            // Disk-space preflight: refuse before writing if the backup volume can't hold the data (+ headroom). A
+            // disk-full mid-write only leaves a temp file (cleaned up below), but checking first avoids the wasted
+            // work and a confusing partial failure.
+            long sourceSize = GetDirectorySize(textbox1.Text);
+            if (!HasFreeSpaceFor(textbox2.Text, sourceSize, out string backupSpaceReason))
+            {
+                if (checkbox_auto.Checked) checkbox_auto.Checked = false;
+                Status.Text = "Backup skipped: low disk space.";
+                MessageBox.Show("Cannot create the backup: " + backupSpaceReason + ".", "Low Disk Space", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            // Operation lock: the UI thread serializes operations, but a modal dialog pumps the message queue, so a
+            // queued autobackup tick or click could otherwise re-enter while a backup/restore is mid-flight.
+            if (_operationInProgress) { Status.Text = "Please wait, another operation is already running."; return; }
+
             // Build the zip into a temp file in the SAME directory, then publish it with an atomic rename. A
             // failure mid-Save (disk full, a source save file locked/removed) then leaves only the temp file
             // (cleaned up below) — never a partial/corrupt .zip at the real backup path, and never an existing
             // good backup overwritten by a truncated stub.
             string tempZip = backupFileName + ".savedrake.tmp";
+            _operationInProgress = true;
             try
             {
                 // Sweep any orphaned temp files left by a previous backup that was hard-killed mid-write (a graceful
@@ -1609,6 +1627,7 @@ namespace Savedrake
                 Status.Text = "Backup failed.";
                 MessageBox.Show($"An error occurred while creating the backup: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
+            finally { _operationInProgress = false; }
         }
 
         // Returns fullPath if it is free, otherwise the first "name_N.ext" variant that does not exist.
@@ -1622,6 +1641,55 @@ namespace Savedrake
             string candidate;
             do { candidate = Path.Combine(dir, $"{name}_{n++}{ext}"); } while (File.Exists(candidate));
             return candidate;
+        }
+
+        // Disk-space preflight headroom: never plan an operation that would leave the volume essentially full.
+        private const long SafetyMarginBytes = 64L * 1024 * 1024; // 64 MB
+
+        // Total size of all files under a directory (recursive). Best-effort: unreadable files are skipped, not fatal.
+        private static long GetDirectorySize(string dir)
+        {
+            long total = 0;
+            try
+            {
+                foreach (string f in Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories))
+                    try { total += new FileInfo(f).Length; } catch { }
+            }
+            catch { }
+            return total;
+        }
+
+        // Sum of the UNCOMPRESSED sizes of a zip's entries (read from the central directory; does not extract). This
+        // is how much space a restore's staging extraction needs on the save volume.
+        private static long GetZipUncompressedSize(string zipPath)
+        {
+            try
+            {
+                using (Ionic.Zip.ZipFile zip = Ionic.Zip.ZipFile.Read(zipPath))
+                    return zip.Entries.Where(e => !e.IsDirectory).Sum(e => e.UncompressedSize);
+            }
+            catch { return 0; }
+        }
+
+        // Disk-space preflight: is there room on targetDir's volume for requiredBytes plus a safety margin? Fails OPEN
+        // (returns true) if free space can't be determined (e.g. a network path), so a space-check error never blocks
+        // an otherwise-legitimate operation.
+        private static bool HasFreeSpaceFor(string targetDir, long requiredBytes, out string reason)
+        {
+            reason = null;
+            try
+            {
+                DriveInfo drive = new DriveInfo(Path.GetPathRoot(Path.GetFullPath(targetDir)));
+                long needed = requiredBytes + SafetyMarginBytes;
+                if (drive.AvailableFreeSpace < needed)
+                {
+                    reason = "not enough free space on " + drive.Name + " (about " + (needed / (1024 * 1024)) +
+                             " MB needed, " + (drive.AvailableFreeSpace / (1024 * 1024)) + " MB free)";
+                    return false;
+                }
+                return true;
+            }
+            catch (Exception) { return true; } // can't determine -> don't block a legitimate operation
         }
 
         // Backup integrity verification, layer 1 (P1): prove a freshly written archive is actually restorable before
@@ -1923,33 +1991,56 @@ namespace Savedrake
                     return;
                 }
 
-                // STEP 3b — pre-restore safety checkpoint (P4). RestoreTransactional deletes the current live save on
-                // success, so snapshot it first into a "(Pre-Restore)" backup the user can roll back to. If the
-                // snapshot can't be made, let the user decide rather than silently proceeding without a safety net.
-                Status.Text = "Creating pre-restore checkpoint...";
-                if (!CreatePreRestoreCheckpoint(textbox1.Text, textbox2.Text))
+                // STEP 3c — disk-space preflight: the restore extracts the backup into a staging folder on the save
+                // volume before swapping it in. Refuse up front if that volume can't hold it (+ headroom), with the
+                // live saves untouched, instead of failing partway through the extraction.
+                long restoreNeeded = GetZipUncompressedSize(filePath);
+                if (!HasFreeSpaceFor(textbox1.Text, restoreNeeded, out string restoreSpaceReason))
                 {
-                    DialogResult proceed = MessageBox.Show(
-                        "Savedrake could not create a safety snapshot of your current save before restoring.\n\n" +
-                        "If you continue, your current save will be replaced and its current state will be lost.\n\n" +
-                        "Restore anyway?",
-                        "Pre-Restore Checkpoint Failed", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
-                    if (proceed != DialogResult.Yes) { Status.Text = "Restore cancelled."; return; }
+                    MessageBox.Show("Cannot restore: " + restoreSpaceReason + ".\n\nYour current save files have not been touched.",
+                        "Low Disk Space", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
                 }
 
-                // STEP 4 — delegate ALL destructive work (staging, swap, rollback, cleanup) to the transaction.
-                bool ok = RestoreTransactional(filePath, textbox1.Text);
-
-                // STEP 5 — post-success UI. Undo is DISABLED on success: old saves went to a temp dir, not the
-                // recycle bin, so a recycle-bin Undo would silently no-op. Honest = disable it.
-                if (ok)
+                // Operation lock: don't begin destructive restore work while a backup/restore is already running.
+                if (_operationInProgress)
                 {
-                    deletedFiles.Clear();
-                    UpdateUndoButtonState();
-                    LoadBackupHistory();
-                    SortComboBoxItems();
-                    listView.Sort();
+                    MessageBox.Show("Please wait, another operation is already running.", "Busy", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    return;
                 }
+
+                _operationInProgress = true;
+                try
+                {
+                    // STEP 3b — pre-restore safety checkpoint (P4). RestoreTransactional deletes the current live save
+                    // on success, so snapshot it first into a "(Pre-Restore)" backup the user can roll back to. If the
+                    // snapshot can't be made, let the user decide rather than silently proceeding without a safety net.
+                    Status.Text = "Creating pre-restore checkpoint...";
+                    if (!CreatePreRestoreCheckpoint(textbox1.Text, textbox2.Text))
+                    {
+                        DialogResult proceed = MessageBox.Show(
+                            "Savedrake could not create a safety snapshot of your current save before restoring.\n\n" +
+                            "If you continue, your current save will be replaced and its current state will be lost.\n\n" +
+                            "Restore anyway?",
+                            "Pre-Restore Checkpoint Failed", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+                        if (proceed != DialogResult.Yes) { Status.Text = "Restore cancelled."; return; }
+                    }
+
+                    // STEP 4 — delegate ALL destructive work (staging, swap, rollback, cleanup) to the transaction.
+                    bool ok = RestoreTransactional(filePath, textbox1.Text);
+
+                    // STEP 5 — post-success UI. Undo is DISABLED on success: old saves went to a temp dir, not the
+                    // recycle bin, so a recycle-bin Undo would silently no-op. Honest = disable it.
+                    if (ok)
+                    {
+                        deletedFiles.Clear();
+                        UpdateUndoButtonState();
+                        LoadBackupHistory();
+                        SortComboBoxItems();
+                        listView.Sort();
+                    }
+                }
+                finally { _operationInProgress = false; }
             }
             else if (listView.SelectedItems.Count > 1)
             {


### PR DESCRIPTION
## What

Two operational guardrails the roadmap flagged: a **disk-space preflight** before backup/restore, and an **operation lock** so those operations can't overlap.

## Why

Transactional safety is only as good as the preflight: a disk-full midway through staging is a worse, more confusing failure than refusing up front. And while a single UI thread serializes operations, a modal dialog pumps the message queue, so a queued autobackup tick or click could re-enter while a backup/restore is mid-flight.

## How

- **Preflight** (new static helpers `GetDirectorySize`, `GetZipUncompressedSize`, `HasFreeSpaceFor`):
  - Backup: requires ~the source-save size (+64 MB margin) on the backup volume.
  - Restore: requires the backup's uncompressed size on the save volume (for the staging extraction).
  - Fails **open** if free space can't be determined (e.g. a network path), so it never blocks a legitimate operation. On failure it refuses with a clear message and leaves the live saves untouched.
- **Operation lock** (`_operationInProgress`): a backup and a restore can't run concurrently; the destructive sections are guarded and cleared in `finally`.
- Also refreshes the stale `ROADMAP.md` status line (Phase 1 + P2 logging are implemented on master but unreleased).

## Tests

5 new `RestoreHarness` assertions (directory-size + zip-uncompressed-size math; has-space true for 0 bytes; false for an absurd requirement; fail-open on an undeterminable volume). Local Debug + Release both: **148 passed, 0 failed**. Startup smoke test passes. (The operation lock is UI-coupled and not harness-testable; the destructive sections are guarded with try/finally.)