### PR TITLE
docs: describe updates as manual, not auto-update

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -51,7 +51,7 @@ go to the Recycle Bin, and the last deletion can be undone.
 
 ## I updated, but the updater still seems old.
 
-The updater program cannot replace itself during an auto-update, so it stays on the version you
+The updater program cannot replace itself while it applies an update, so it stays on the version you
 installed. To get the latest updater, download the release zip and extract it over your install
 once.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Windows only. Built on .NET Framework 4.8 (WinForms).
   Bin, and the last deletion can be undone.
 - Sound feedback on every backup (manual, hotkey, and autobackup).
 - Minimize to the system tray.
-- Auto update. Savedrake checks GitHub for new versions and can update itself.
+- Update checks. Savedrake can check GitHub for new releases and notify you. Downloading and
+  installing an update is manual: you choose when, and confirm before any file is replaced.
 
 ## Install
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,9 +25,9 @@ disclosing the issue publicly.
 
 ## Scope
 
-Savedrake reads and writes save files, and it downloads and runs its own updates from GitHub
-Releases over HTTPS. Reports about the backup and restore flow, or about the auto-update flow, are
-especially welcome.
+Savedrake reads and writes save files, and it can download and install updates from GitHub
+Releases over HTTPS when you choose to update. Reports about the backup and restore flow, or about
+the update flow, are especially welcome.
 
 Known limitation: the updater verifies that a downloaded update is a valid package containing the
 application, but it does not yet verify a cryptographic signature of the package. Signed updates


### PR DESCRIPTION
The README/FAQ/SECURITY described the update feature as an "auto update" that "can update itself." That is inaccurate: Savedrake checks GitHub for new versions and notifies you, but downloading and installing an update is manual and requires an explicit click plus a Yes/No confirmation (see `updater/UpdaterForm.cs` button3_Click). Reworded the user-facing docs so the only automatic part (the version check) is described accurately.

Docs-only; no behavior change.

Left untouched on purpose:
- `CHANGELOG.md` 1.3.0 entries (released history)
- `ROADMAP.md` ("auto-updater" used as a component name in the threat model)
- the in-app `"Automatic Update:"` label in the updater window (that is a binary change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)