### PR TITLE
feat: change-aware autobackup, part 1 (content-fingerprint dedup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ All notable changes to Savedrake are recorded here. The format is based on
 - Disk-space preflight: before a backup or restore, Savedrake checks the target drive has room
   (including the staging copy a restore needs) and refuses up front with a clear message instead
   of failing partway through. A backup and a restore can also no longer overlap. (#41)
+- Change-aware autobackup (part 1 of 3): autobackup no longer writes a redundant identical backup when
+  your save has not changed since the last one. Each backup records a content fingerprint of the save, and
+  a timer tick that finds no change is skipped instead of consuming one of your autobackup slots. A
+  just-restored save, and a save folder that is momentarily locked or mid-write, are handled safely. (#44)
 
 ### Fixed
 - The updater builds its download URL with `Uri.EscapeDataString` on the version segment

--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -91,6 +91,7 @@ namespace RestoreHarness
                 Test_PreRestoreCheckpoint();   // P4: snapshot the live save before a restore so it isn't discarded
                 Test_VerifyZipRestorable();   // P1: backups are CRC-verified at creation; corrupt ones are rejected
                 Test_BackupManifest();   // P1 layer 2: in-zip manifest verify (missing/corrupt files) + restore skips it
+                Test_ChangeFingerprint();   // change-aware autobackup (PR1): save fingerprint is stable/changes/fail-closed
                 Test_RestoreReverify();   // P1: restore re-verifies a manifest-bearing backup; legacy backups unaffected
                 Test_ClassifyBackup();   // P1 UI: full Validated/Legacy/Corrupt classification for "Validate all"
                 Test_LogRedaction();   // P2: the rolling logger redacts the Steam account id and user profile path
@@ -368,6 +369,72 @@ namespace RestoreHarness
             bool noManifest = !Directory.Exists(Path.Combine(stage, "_savedrake")) && !File.Exists(Path.Combine(stage, "_savedrake", "manifest.json"));
             Check("restore extracts the save files", hasSaves);
             Check("restore skips the _savedrake manifest", noManifest);
+            Console.WriteLine();
+        }
+
+        static void Test_ChangeFingerprint()
+        {
+            // Change-aware autobackup (PR1): ComputeSaveFingerprint is the signal that lets the autobackup timer skip a
+            // tick when nothing changed. It must be STABLE across calls on identical content (immune to the manifest's
+            // volatile createdUtc/tool), CHANGE on any real content change, be enumeration-ORDER independent, and return
+            // null (fail-closed) for a missing / locked / no-save-data folder.
+            Console.WriteLine("== Change-aware autobackup: save fingerprint ==");
+            var fp = SM("ComputeSaveFingerprint");
+            var stable = SM("StableManifestHash");
+            var build = SM("BuildBackupManifest");
+
+            string src = NewDir("fp_src");
+            File.WriteAllBytes(Path.Combine(src, "data000.bin"), B("save-A"));
+            File.WriteAllBytes(Path.Combine(src, "system.bin"), B("sys-A"));
+
+            string f1 = (string)fp.Invoke(null, new object[] { src });
+            string f2 = (string)fp.Invoke(null, new object[] { src });
+            Check("fingerprint is non-null for a real save folder", f1 != null);
+            Check("fingerprint is stable across calls (ignores volatile manifest fields)", f1 == f2, "f1=" + f1 + " f2=" + f2);
+
+            File.WriteAllBytes(Path.Combine(src, "data000.bin"), B("save-B"));
+            string f3 = (string)fp.Invoke(null, new object[] { src });
+            Check("a content change changes the fingerprint", f3 != f1);
+            File.WriteAllBytes(Path.Combine(src, "data000.bin"), B("save-A"));
+            Check("reverting the content restores the fingerprint", (string)fp.Invoke(null, new object[] { src }) == f1);
+
+            File.WriteAllBytes(Path.Combine(src, "data001.bin"), B("save-A2"));
+            Check("adding a save file changes the fingerprint", (string)fp.Invoke(null, new object[] { src }) != f1);
+            File.Delete(Path.Combine(src, "data001.bin"));
+            Check("removing the added file restores the fingerprint", (string)fp.Invoke(null, new object[] { src }) == f1);
+
+            // StableManifestHash must ignore createdUtc/tool: two manifests of identical content hash equal.
+            string m1 = (string)build.Invoke(null, new object[] { src });
+            System.Threading.Thread.Sleep(5);
+            string m2 = (string)build.Invoke(null, new object[] { src });
+            string h1 = (string)stable.Invoke(null, new object[] { m1 });
+            Check("StableManifestHash ignores volatile createdUtc/tool", h1 != null && h1 == (string)stable.Invoke(null, new object[] { m2 }));
+
+            // Enumeration-order independence: same files created in opposite order -> identical fingerprint.
+            string oA = NewDir("fp_orderA");
+            File.WriteAllBytes(Path.Combine(oA, "data000.bin"), B("x")); File.WriteAllBytes(Path.Combine(oA, "system.bin"), B("y"));
+            string oB = NewDir("fp_orderB");
+            File.WriteAllBytes(Path.Combine(oB, "system.bin"), B("y")); File.WriteAllBytes(Path.Combine(oB, "data000.bin"), B("x"));
+            Check("fingerprint is enumeration-order independent", (string)fp.Invoke(null, new object[] { oA }) == (string)fp.Invoke(null, new object[] { oB }));
+
+            // No real save data -> null (so a wrong/empty folder reads as "not comparable" and the tick fails closed).
+            string nosave = NewDir("fp_nosave");
+            File.WriteAllText(Path.Combine(nosave, "notes.txt"), "not a save");
+            Check("folder with no DD2 save data -> null", (string)fp.Invoke(null, new object[] { nosave }) == null);
+
+            // Missing folder -> null, no throw.
+            string missing = Path.Combine(work, "fp_missing_" + Guid.NewGuid().ToString("N").Substring(0, 8));
+            Check("missing folder -> null (no throw)", (string)fp.Invoke(null, new object[] { missing }) == null);
+
+            // Locked (mid-write) file -> null (fail-closed), then recovers once unlocked.
+            string locked = NewDir("fp_locked");
+            string lf = Path.Combine(locked, "data000.bin");
+            File.WriteAllBytes(lf, B("locked-save"));
+            using (new FileStream(lf, FileMode.Open, FileAccess.Read, FileShare.None))
+            {
+                Check("a locked (mid-write) save file -> null (fail-closed)", (string)fp.Invoke(null, new object[] { locked }) == null);
+            }
+            Check("fingerprint recovers once the file is unlocked", (string)fp.Invoke(null, new object[] { locked }) != null);
             Console.WriteLine();
         }
 

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -46,6 +46,10 @@ namespace Savedrake
         private bool isAutoBackupEnabled = false; //(Autobackup feature)
         private ManagementEventWatcher _watcher; //(Autobackup feature)
         private bool isGameRunning; //(Autobackup feature)
+        // Change-aware autobackup (PR1): content fingerprint of the save folder at the last successful backup.
+        // UI-thread-only (set/read only from the marshaled timer tick, BackupOperation, restore, and the checkbox
+        // handler). null = no baseline yet, so the next eligible backup always fires.
+        private string _lastAutoBackupFingerprint;
         #endregion
 
         //Hotkey related
@@ -1029,6 +1033,9 @@ namespace Savedrake
                 Button_br_1.BackColor = Color.White;
                 Button_br_2.BackColor= Color.White;
                 Status.Text = $"Autobackup disabled";
+                // Change-aware autobackup (PR1): drop the baseline when autobackup is turned off so a later re-enable
+                // re-baselines cleanly against whatever the save folder is then (Hook C also nulls it at game-start).
+                _lastAutoBackupFingerprint = null;
             }
 
             isAutoBackupEnabled = checkbox_auto.Checked;
@@ -1060,6 +1067,11 @@ namespace Savedrake
                         // Check if the current number of backups is less than the maximum allowed
                         if (backupCount < maxBackups)
                         {
+                            // Change-aware autobackup (PR1): null the baseline at game-start so this first backup of
+                            // the session always fires (it is NOT routed through the change-aware gate) and Hook B then
+                            // establishes the real baseline from the current save. Also covers a save-folder change
+                            // made while autobackup was off (the textboxes are only editable when it is off).
+                            _lastAutoBackupFingerprint = null;
                             BackupOperation(true); // Perform the backup operation
                             // No stale increment: LoadBackupHistory (via BackupOperation) already wrote the accurate
                             // count from the files on disk; a failed backup must not advance the limit.
@@ -1172,11 +1184,29 @@ namespace Savedrake
                     // Check if the current number of backups is less than the maximum allowed
                     if (backupCount < maxBackups)
                     {
-                        BackupOperation(true); // Perform the backup operation
-                        // Do NOT increment a stale local: BackupOperation -> LoadBackupHistory already recomputed
-                        // the count from the actual autobackup files on disk and wrote it to countFilePath. Writing
-                        // backupCount+1 here clobbered that recount AND advanced the limit even when the backup
-                        // FAILED (no file created). The next tick re-reads the accurate value.
+                        // Change-aware gate (PR1): skip this tick when the save folder is unchanged since the last
+                        // backup, so the timer stops writing redundant identical zips that consume the autobackup
+                        // limit. A null fingerprint (folder missing/locked/mid-write/no save data) fails CLOSED: skip
+                        // and retry next tick rather than zip a folder we cannot fully read. A null baseline (first
+                        // eligible tick) never skips. Skipping consumes no count and writes no file; the limit/branch
+                        // logic and the _autoBackupInProgress guard are untouched.
+                        string currentFp = ComputeSaveFingerprint(textbox1.Text);
+                        if (currentFp == null)
+                        {
+                            Status.Text = "Autobackup: save folder not ready, will retry.";
+                        }
+                        else if (_lastAutoBackupFingerprint != null && currentFp == _lastAutoBackupFingerprint)
+                        {
+                            Status.Text = "Autobackup: no save changes since last backup.";
+                        }
+                        else
+                        {
+                            BackupOperation(true); // Perform the backup operation
+                            // Do NOT increment a stale local: BackupOperation -> LoadBackupHistory already recomputed
+                            // the count from the actual autobackup files on disk and wrote it to countFilePath. Writing
+                            // backupCount+1 here clobbered that recount AND advanced the limit even when the backup
+                            // FAILED (no file created). The next tick re-reads the accurate value.
+                        }
                     }
                     else
                     {
@@ -1609,6 +1639,12 @@ namespace Savedrake
 
                 // Update the status
                 LoadBackupHistory();
+                // Change-aware autobackup (PR1): refresh the content baseline from the just-published save so the next
+                // autobackup tick skips it when nothing changed. Set unconditionally (manual OR auto) so a manual
+                // backup also suppresses an immediately-following redundant autobackup. Placed inside the try after the
+                // atomic File.Move publish, so a backup that failed verification (and threw to the catch) never
+                // advances the baseline.
+                _lastAutoBackupFingerprint = ComputeSaveFingerprint(textbox1.Text);
                 Status.Text = isAutoBackup ? $"Autobackup created at {DateTime.Now.ToString("hh:mm:ss tt")}." : "Backup created successfully.";
                 PlaySoundFromResource();
                 Log.Info("Backup created: " + Path.GetFileName(backupFileName) + (isAutoBackup ? " (auto)" : ""));
@@ -1757,6 +1793,45 @@ namespace Savedrake
                 ["createdUtc"] = DateTime.UtcNow.ToString("o", System.Globalization.CultureInfo.InvariantCulture),
                 ["files"] = files
             }.ToString();
+        }
+
+        // Change-aware autobackup (PR1): a stable content fingerprint of the save folder, so the autobackup timer can
+        // skip a tick when nothing changed instead of writing a redundant identical backup that eats into the user's
+        // limit. Reuses BuildBackupManifest (the same per-file path/length/SHA-256 a backup records), then hashes only
+        // the content fields, so it is immune to the manifest's volatile createdUtc/tool stamps. Returns null (never
+        // throws) when the folder is missing/locked/unreadable or holds no real save data; callers treat null as
+        // "not safely comparable" and SKIP (fail-closed) rather than zip a folder they cannot fully read.
+        private static string ComputeSaveFingerprint(string saveDir)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(saveDir) || !Directory.Exists(saveDir)) return null;
+                // Only fingerprint a folder that actually holds DD2 save data, mirroring BackupOperation's hasSaveData gate.
+                bool hasSave = Directory.EnumerateFiles(saveDir, "*", SearchOption.AllDirectories)
+                    .Any(p => IsRealSaveEntry(Path.GetFileName(p)));
+                if (!hasSave) return null;
+                // BuildBackupManifest opens each file for read; a file the game is actively writing is exclusively
+                // locked and throws IOException, which we catch below and surface as null (skip this tick).
+                return StableManifestHash(BuildBackupManifest(saveDir));
+            }
+            catch (UnauthorizedAccessException) { return null; }
+            catch (System.IO.IOException) { return null; }
+            catch (Exception) { return null; } // never let it throw onto the UI/timer thread
+        }
+
+        // Pure: derive a content-only hash from a BuildBackupManifest JSON string, ignoring its volatile
+        // createdUtc/tool fields so identical content always yields the same fingerprint. Sort by path (Ordinal) so the
+        // result is independent of enumeration order. Returns null if the JSON carries no files[] array.
+        private static string StableManifestHash(string manifestJson)
+        {
+            JArray files = JObject.Parse(manifestJson)["files"] as JArray;
+            if (files == null) return null;
+            var rows = files
+                .Select(f => ((string)f["path"]) + "|" + (long)f["length"] + "|" + ((string)f["sha256"]))
+                .OrderBy(s => s, StringComparer.Ordinal);
+            string joined = string.Join("\n", rows);
+            using (var ms = new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(joined)))
+                return Sha256Hex(ms);
         }
 
         // Backup integrity verification, layer 2 (P1): confirm the freshly written archive contains every file the
@@ -2038,6 +2113,11 @@ namespace Savedrake
                         LoadBackupHistory();
                         SortComboBoxItems();
                         listView.Sort();
+                        // Change-aware autobackup (PR1): the live save now equals the just-restored backup. Set the
+                        // baseline to it so the next autobackup tick sees no change and does NOT redundantly re-back-up
+                        // the restored save (it is already captured by the backup it came from plus the (Pre-Restore)
+                        // checkpoint). The next real in-game save changes the fingerprint and triggers a fresh backup.
+                        _lastAutoBackupFingerprint = ComputeSaveFingerprint(textbox1.Text);
                     }
                 }
                 finally { _operationInProgress = false; }


### PR DESCRIPTION
First of three PRs implementing change-aware autobackup (the "capture real saves, not redundant ones" feature). This PR is the foundation: **content-fingerprint deduplication**.

## Problem
Autobackup zips the save folder every interval regardless of whether anything changed, so on Dragon's Dogma 2 the timer produces redundant identical backups that eat into the user's autobackup limit.

## This PR
- `ComputeSaveFingerprint(saveDir)` + `StableManifestHash(json)`: a stable content fingerprint of the save folder. Reuses `BuildBackupManifest`'s per-file path/length/SHA-256 and hashes only the content fields, so it ignores the manifest's volatile `createdUtc`/`tool` stamps. Returns `null` (never throws) for a missing/locked/mid-write/no-save-data folder.
- `_lastAutoBackupFingerprint` baseline (UI-thread only): set on every successful backup (manual or auto), nulled at game-start and when autobackup is switched off, and set to the restored save after a restore so a just-restored save is not redundantly re-backed-up.
- The change-aware gate sits inside the existing `count < max` branch of the timer tick. A skipped tick consumes no count and writes no file. **Fail-closed**: a null fingerprint skips the tick rather than zipping a folder it cannot fully read.

## Safety / edge cases
- Limit enforcement, the operation lock, game-running gating, and the re-entrancy guard are all unchanged; the gate is purely additive.
- Locked/mid-write save -> null -> skip (no half-written zip). A verification-rejected backup throws before the baseline is set, so it never advances.

## Tests
12 new `RestoreHarness` assertions (stability across calls, content-change detection, add/remove file, order independence, no-save-data/missing/locked -> null). **Harness 148 -> 160, 0 failed, on both Debug and Release.**

## Next
- Part 2: tiered retention + pinning (so frequent autosaves don't evict meaningful older restore points).
- Part 3: FileSystemWatcher + fast-poll trigger + UI controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)