### PR TITLE
feat: change-aware autobackup, part 2 (clean up old autobackups)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ All notable changes to Savedrake are recorded here. The format is based on
   your save has not changed since the last one. Each backup records a content fingerprint of the save, and
   a timer tick that finds no change is skipped instead of consuming one of your autobackup slots. A
   just-restored save, and a save folder that is momentarily locked or mid-write, are handled safely. (#44)
+- Automatically clean up old autobackups (optional, off by default): a new Files > Settings option that, once
+  turned on, keeps all of your recent autobackups and a spread of older ones and removes the extra older
+  autobackups so they no longer just stop at the limit and so old restore points are not lost the way a plain
+  "keep the newest N" limit loses them. Your manual backups and the pre-restore checkpoint are never removed,
+  and a backup that fails its integrity check is never removed. Removed backups are deleted by default, or sent
+  to the Recycle Bin if you tick the second option. (#45)
 
 ### Fixed
 - The updater builds its download URL with `Uri.EscapeDataString` on the version segment

--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -92,6 +92,7 @@ namespace RestoreHarness
                 Test_VerifyZipRestorable();   // P1: backups are CRC-verified at creation; corrupt ones are rejected
                 Test_BackupManifest();   // P1 layer 2: in-zip manifest verify (missing/corrupt files) + restore skips it
                 Test_ChangeFingerprint();   // change-aware autobackup (PR1): save fingerprint is stable/changes/fail-closed
+                Test_TieredRetention();   // change-aware autobackup (PR2): tiered-retention selector (buckets/cap/idempotent)
                 Test_RestoreReverify();   // P1: restore re-verifies a manifest-bearing backup; legacy backups unaffected
                 Test_ClassifyBackup();   // P1 UI: full Validated/Legacy/Corrupt classification for "Validate all"
                 Test_LogRedaction();   // P2: the rolling logger redacts the Steam account id and user profile path
@@ -435,6 +436,64 @@ namespace RestoreHarness
                 Check("a locked (mid-write) save file -> null (fail-closed)", (string)fp.Invoke(null, new object[] { locked }) == null);
             }
             Check("fingerprint recovers once the file is unlocked", (string)fp.Invoke(null, new object[] { locked }) != null);
+            Console.WriteLine();
+        }
+
+        static void Test_TieredRetention()
+        {
+            // Change-aware autobackup (PR2): SelectAutobackupsToThin is the pure tiered-retention selector. It must keep
+            // all recent backups, keep the newest per widening time bucket, honor the count cap by thinning oldest
+            // survivors, be idempotent, and keep future-dated (clock-skew) backups.
+            Console.WriteLine("== Change-aware autobackup: tiered retention (PR2) ==");
+            var thin = SM("SelectAutobackupsToThin");
+            long now = DateTime.UtcNow.Ticks;
+            Func<long[], int, int[]> run = (ticks, cap) => (int[])thin.Invoke(null, new object[] { ticks, now, cap });
+
+            Check("empty input -> nothing thinned", run(new long[0], 0).Length == 0);
+            Check("single backup -> kept", run(new long[] { now - TimeSpan.FromHours(3).Ticks }, 0).Length == 0);
+
+            long[] recent = {
+                now - TimeSpan.FromMinutes(5).Ticks,
+                now - TimeSpan.FromMinutes(20).Ticks,
+                now - TimeSpan.FromMinutes(45).Ticks,
+            };
+            Check("all backups within the last hour are kept", run(recent, 0).Length == 0);
+
+            // Three in the same 30-minute bucket (1-6h tier) -> keep only the newest (index 0).
+            long[] bucket = {
+                now - TimeSpan.FromHours(2).Ticks,
+                now - (TimeSpan.FromHours(2).Ticks + TimeSpan.FromMinutes(5).Ticks),
+                now - (TimeSpan.FromHours(2).Ticks + TimeSpan.FromMinutes(20).Ticks),
+            };
+            int[] d = run(bucket, 0);
+            Check("a 30-min bucket keeps only the newest (2 of 3 thinned)", d.Length == 2 && !d.Contains(0), "deleted=" + string.Join(",", d));
+
+            // Five recent (all kept by schedule), cap=3 -> the 2 oldest are thinned.
+            long[] five = {
+                now - TimeSpan.FromMinutes(5).Ticks,
+                now - TimeSpan.FromMinutes(15).Ticks,
+                now - TimeSpan.FromMinutes(25).Ticks,
+                now - TimeSpan.FromMinutes(35).Ticks,
+                now - TimeSpan.FromMinutes(50).Ticks,
+            };
+            int[] capped = run(five, 3);
+            Check("count cap thins the oldest survivors (2 thinned to reach 3)", capped.Length == 2 && capped.Contains(3) && capped.Contains(4), "deleted=" + string.Join(",", capped));
+
+            // Idempotency: thin once, drop the deleted, re-run -> nothing more.
+            long[] across = {
+                now - TimeSpan.FromMinutes(10).Ticks,
+                now - TimeSpan.FromHours(2).Ticks,
+                now - (TimeSpan.FromHours(2).Ticks + TimeSpan.FromMinutes(10).Ticks),
+                now - TimeSpan.FromHours(10).Ticks,
+                now - TimeSpan.FromDays(3).Ticks,
+                now - TimeSpan.FromDays(20).Ticks,
+            };
+            int[] first = run(across, 0);
+            long[] survivors = Enumerable.Range(0, across.Length).Where(i => !first.Contains(i)).Select(i => across[i]).ToArray();
+            Check("re-running on survivors thins nothing (idempotent)", run(survivors, 0).Length == 0, "first=" + string.Join(",", first));
+
+            // A future-dated backup (clock skew) is kept, as is an old one alone in its weekly bucket.
+            Check("a future-dated backup is kept (treated as newest)", run(new long[] { now + TimeSpan.FromHours(1).Ticks, now - TimeSpan.FromDays(30).Ticks }, 0).Length == 0);
             Console.WriteLine();
         }
 

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -1834,6 +1834,62 @@ namespace Savedrake
                 return Sha256Hex(ms);
         }
 
+        // Change-aware autobackup, part 2 (tiered retention): pure selection of which autobackups to THIN (delete),
+        // given the UTC tick timestamps of the THINNABLE autobackups only (the caller excludes manual backups, pinned
+        // ones, the (Pre-Restore) checkpoint, and corrupt backups, which are never thinned). Tiered time-bucket policy
+        // (Borg/restic style): keep EVERY backup in the last hour, then the NEWEST per bucket as buckets widen — one
+        // per 30 min to 6h, per hour to 24h, per day to 7d, per week beyond. After bucketing, if more than maxKeep
+        // survive (maxKeep <= 0 means no cap), the OLDEST survivors are thinned too until maxKeep remain. Deterministic,
+        // idempotent (re-running at the same 'now' on the survivors thins nothing more), and independent of input order.
+        // Returns the indices INTO candidateTicksUtc of the entries to delete.
+        private static int[] SelectAutobackupsToThin(long[] candidateTicksUtc, long nowTicksUtc, int maxKeep)
+        {
+            if (candidateTicksUtc == null || candidateTicksUtc.Length == 0) return new int[0];
+
+            long H = TimeSpan.FromHours(1).Ticks;
+            long D = TimeSpan.FromDays(1).Ticks;
+            long[] tierMaxAge = { 1 * H, 6 * H, 24 * H, 7 * D, long.MaxValue };
+            long[] tierInterval = { 0L, TimeSpan.FromMinutes(30).Ticks, H, D, 7 * D };
+
+            var keep = new HashSet<int>();
+            var bucketBest = new Dictionary<string, int>(); // "tier:bucket" -> index of the newest candidate so far
+
+            for (int i = 0; i < candidateTicksUtc.Length; i++)
+            {
+                long age = nowTicksUtc - candidateTicksUtc[i];
+                if (age < 0) age = 0; // clock skew / future-dated backup -> treat as newest, keep it
+
+                int t = 0;
+                while (t < tierMaxAge.Length && age > tierMaxAge[t]) t++;
+                if (t >= tierMaxAge.Length) t = tierMaxAge.Length - 1;
+
+                if (tierInterval[t] == 0) { keep.Add(i); continue; } // recent tier: keep all
+
+                long tierStart = t == 0 ? 0 : tierMaxAge[t - 1];
+                long bucket = (age - tierStart) / tierInterval[t];
+                string key = t + ":" + bucket;
+                if (!bucketBest.TryGetValue(key, out int cur)) bucketBest[key] = i;
+                else
+                {
+                    long a = candidateTicksUtc[i], b = candidateTicksUtc[cur];
+                    if (a > b || (a == b && i > cur)) bucketBest[key] = i; // keep newest; deterministic tie-break
+                }
+            }
+            foreach (var kv in bucketBest) keep.Add(kv.Value);
+
+            // Hard cap: if more than the user's "max autobackups" still survive, thin the OLDEST survivors until maxKeep remain.
+            if (maxKeep > 0 && keep.Count > maxKeep)
+            {
+                var keptOldestFirst = keep.OrderBy(i => candidateTicksUtc[i]).ThenBy(i => i).ToList();
+                int toRemove = keep.Count - maxKeep;
+                for (int k = 0; k < toRemove; k++) keep.Remove(keptOldestFirst[k]);
+            }
+
+            var del = new List<int>();
+            for (int i = 0; i < candidateTicksUtc.Length; i++) if (!keep.Contains(i)) del.Add(i);
+            return del.ToArray();
+        }
+
         // Backup integrity verification, layer 2 (P1): confirm the freshly written archive contains every file the
         // manifest declares, each with the recorded length + SHA-256. Catches a backup missing whole files (e.g. a zip
         // truncated at an entry boundary, which the layer-1 CRC test-extract can miss) and per-file bit-rot. Returns

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -50,6 +50,11 @@ namespace Savedrake
         // UI-thread-only (set/read only from the marshaled timer tick, BackupOperation, restore, and the checkbox
         // handler). null = no baseline yet, so the next eligible backup always fires.
         private string _lastAutoBackupFingerprint;
+        // Change-aware autobackup, part 2 (clean up old backups): two opt-in toggles under Files > Settings, OFF by
+        // default. _cleanupMenuItem on = after each autobackup, keep recent backups + a spread of older ones and remove
+        // the extra old autobackups. _recycleMenuItem on = send removed ones to the Recycle Bin instead of deleting.
+        private ToolStripMenuItem _cleanupMenuItem;
+        private ToolStripMenuItem _recycleMenuItem;
         #endregion
 
         //Hotkey related
@@ -212,6 +217,30 @@ namespace Savedrake
             };
             helpToolStripMenuItem.DropDownItems.Add(openLogFolderMenuItem);
 
+            // Files > Settings: opt-in "clean up old backups" toggles (change-aware autobackup, part 2). OFF by default,
+            // so existing behavior (autobackup stops at the limit) is unchanged until the user opts in. Turning it on
+            // asks for confirmation because it enables automatic removal of old autobackups.
+            _cleanupMenuItem = new ToolStripMenuItem("Automatically clean up old autobackups");
+            _recycleMenuItem = new ToolStripMenuItem("Send removed backups to the Recycle Bin") { CheckOnClick = true, Enabled = false };
+            _cleanupMenuItem.Click += (s, e) =>
+            {
+                if (!_cleanupMenuItem.Checked)
+                {
+                    DialogResult r = MessageBox.Show(
+                        "Savedrake will keep all your recent autobackups and a spread of older ones, then remove the " +
+                        "extra older autobackups so they don't pile up. Your manual backups and pinned backups are never removed.\n\n" +
+                        "Turn this on?",
+                        "Automatically clean up old autobackups", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                    if (r != DialogResult.Yes) return;
+                    _cleanupMenuItem.Checked = true;
+                }
+                else _cleanupMenuItem.Checked = false;
+                _recycleMenuItem.Enabled = _cleanupMenuItem.Checked;
+                if (!_cleanupMenuItem.Checked) _recycleMenuItem.Checked = false;
+            };
+            ssettingsToolStripMenuItem.DropDownItems.Add(_cleanupMenuItem);
+            ssettingsToolStripMenuItem.DropDownItems.Add(_recycleMenuItem);
+
             //tray
             #region
             // Initialize the NotifyIcon component
@@ -318,7 +347,13 @@ namespace Savedrake
             [XmlElement("BackupFileName2")]
             public bool BackupFileName2 { get; set; }
 
-            
+            [XmlElement("AutoCleanupOldBackups")]
+            public bool AutoCleanupOldBackups { get; set; }
+
+            [XmlElement("RemovedToRecycleBin")]
+            public bool RemovedToRecycleBin { get; set; }
+
+
 
             // Include HotkeySettings property
             [XmlElement("Hotkey")]
@@ -453,6 +488,9 @@ namespace Savedrake
                 Textbox3 = textbox3.Text,
                 BackupFileName1 = randomlyGeneratedToolStripMenuItem.Checked,
                 BackupFileName2 = timeStampedToolStripMenuItem.Checked,
+
+                AutoCleanupOldBackups = _cleanupMenuItem != null && _cleanupMenuItem.Checked,
+                RemovedToRecycleBin = _recycleMenuItem != null && _recycleMenuItem.Checked,
                 
                 // Save the hotkey settings
                 Hotkey = new HotkeySettings
@@ -568,6 +606,16 @@ namespace Savedrake
             checkbox_tray.Checked = settings.CheckboxTray;
             checkbox_hot.Checked = settings.CheckboxHot;
             textbox3.Text = settings.Textbox3 ?? " "; // Use null-coalescing operator for simplicity
+
+            // Change-aware autobackup, part 2: restore the "clean up old backups" toggles. Recycle is only meaningful
+            // (and only enabled) while cleanup is on. Setting .Checked here does not fire the user-confirmation dialog,
+            // which lives in the Click handler, not CheckedChanged.
+            if (_cleanupMenuItem != null)
+            {
+                _cleanupMenuItem.Checked = settings.AutoCleanupOldBackups;
+                _recycleMenuItem.Checked = settings.AutoCleanupOldBackups && settings.RemovedToRecycleBin;
+                _recycleMenuItem.Enabled = _cleanupMenuItem.Checked;
+            }
 
 
 
@@ -1064,8 +1112,8 @@ namespace Savedrake
                     // Parse the integer value from toolStripTextBox1
                     if (int.TryParse(toolStripTextBox2.Text, out int maxBackups))
                     {
-                        // Check if the current number of backups is less than the maximum allowed
-                        if (backupCount < maxBackups)
+                        // Clean-up on -> keep backing up (cleanup enforces the limit); off -> original stop-at-limit.
+                        if ((_cleanupMenuItem != null && _cleanupMenuItem.Checked) || backupCount < maxBackups)
                         {
                             // Change-aware autobackup (PR1): null the baseline at game-start so this first backup of
                             // the session always fires (it is NOT routed through the change-aware gate) and Hook B then
@@ -1181,8 +1229,9 @@ namespace Savedrake
                 // Parse the integer value from toolStripTextBox1
                 if (int.TryParse(toolStripTextBox2.Text, out int maxBackups))
                 {
-                    // Check if the current number of backups is less than the maximum allowed
-                    if (backupCount < maxBackups)
+                    // When "clean up old autobackups" is on, autobackup keeps running (cleanup enforces the limit);
+                    // otherwise the original behavior stops autobackup once the limit is reached.
+                    if ((_cleanupMenuItem != null && _cleanupMenuItem.Checked) || backupCount < maxBackups)
                     {
                         // Change-aware gate (PR1): skip this tick when the save folder is unchanged since the last
                         // backup, so the timer stops writing redundant identical zips that consume the autobackup
@@ -1648,6 +1697,9 @@ namespace Savedrake
                 Status.Text = isAutoBackup ? $"Autobackup created at {DateTime.Now.ToString("hh:mm:ss tt")}." : "Backup created successfully.";
                 PlaySoundFromResource();
                 Log.Info("Backup created: " + Path.GetFileName(backupFileName) + (isAutoBackup ? " (auto)" : ""));
+                // Change-aware autobackup, part 2: after a successful AUTObackup, if the user opted in, keep recent
+                // backups + a spread of older ones and remove the extra old autobackups.
+                if (isAutoBackup && _cleanupMenuItem != null && _cleanupMenuItem.Checked) CleanUpOldAutobackups();
             }
             catch (Exception ex)
             {
@@ -1888,6 +1940,62 @@ namespace Savedrake
             var del = new List<int>();
             for (int i = 0; i < candidateTicksUtc.Length; i++) if (!keep.Contains(i)) del.Add(i);
             return del.ToArray();
+        }
+
+        // Change-aware autobackup, part 2: after a successful autobackup, keep recent backups and a spread of older
+        // ones and remove the extra OLD autobackups (chosen by SelectAutobackupsToThin). Only autobackups are eligible;
+        // manual backups and the "(Pre-Restore)" checkpoint (different name prefixes) are never removed, and a corrupt
+        // backup is skipped so a possibly-recoverable archive is never auto-deleted. Removed backups go to the Recycle
+        // Bin when the user chose that, otherwise they are deleted. UI-thread only; best-effort (errors are logged,
+        // never thrown onto the timer).
+        private void CleanUpOldAutobackups()
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(textbox2.Text) || !Directory.Exists(textbox2.Text)) return;
+
+                // Eligible = autobackups only ("(Auto)"/"auto" prefix). Manual backups (no prefix) and the
+                // "(Pre-Restore)" checkpoint are excluded here, so they are never removed.
+                var files = new List<string>();
+                var ticks = new List<long>();
+                foreach (string file in Directory.GetFiles(textbox2.Text, "*.zip"))
+                {
+                    string name = Path.GetFileName(file);
+                    if (!(name.StartsWith("(Auto)") || name.StartsWith("auto"))) continue;
+                    files.Add(file);
+                    ticks.Add(File.GetLastWriteTimeUtc(file).Ticks);
+                }
+                if (files.Count == 0) return;
+
+                int maxKeep = (int.TryParse(toolStripTextBox2.Text, out int m) && m > 0) ? m : 0;
+                int[] toRemove = SelectAutobackupsToThin(ticks.ToArray(), DateTime.UtcNow.Ticks, maxKeep);
+
+                bool toRecycle = _recycleMenuItem != null && _recycleMenuItem.Checked;
+                int removed = 0;
+                foreach (int i in toRemove)
+                {
+                    try
+                    {
+                        if (ClassifyBackupFully(files[i]) == "Corrupt") continue; // never auto-remove a corrupt backup
+                        if (toRecycle)
+                            Microsoft.VisualBasic.FileIO.FileSystem.DeleteFile(files[i],
+                                Microsoft.VisualBasic.FileIO.UIOption.OnlyErrorDialogs,
+                                Microsoft.VisualBasic.FileIO.RecycleOption.SendToRecycleBin);
+                        else
+                            File.Delete(files[i]);
+                        removed++;
+                    }
+                    catch (Exception ex) { Log.Warn("Could not remove old autobackup " + Path.GetFileName(files[i]) + ": " + ex.Message); }
+                }
+
+                if (removed > 0)
+                {
+                    LoadBackupHistory(); // refresh the list and recompute the autobackup count from disk
+                    Status.Text = removed == 1 ? "Removed 1 old autobackup." : ("Removed " + removed + " old autobackups.");
+                    Log.Info("Auto-cleanup removed " + removed + " old autobackup(s)" + (toRecycle ? " (to Recycle Bin)" : ""));
+                }
+            }
+            catch (Exception ex) { Log.Warn("Auto-cleanup of old autobackups failed: " + ex.Message); }
         }
 
         // Backup integrity verification, layer 2 (P1): confirm the freshly written archive contains every file the


### PR DESCRIPTION
Second of three PRs for change-aware autobackup. Part 1 (#44) stopped redundant identical backups. **This PR adds optional cleanup of old autobackups** so that, when enabled, autobackup keeps a smart spread of restore points instead of just stopping at the limit.

## Behavior (opt-in, off by default)
Two new **Files > Settings** options:
- **"Automatically clean up old autobackups"** (off by default). Turning it on asks for confirmation, since it enables automatic removal. When on, after each autobackup Savedrake keeps **all recent backups and a spread of older ones** and removes the extra old autobackups.
- **"Send removed backups to the Recycle Bin"** (off by default; only enabled while cleanup is on). Default is permanent delete; tick this to recycle instead.

When cleanup is **off**, behavior is exactly as before (autobackup stops at the limit, nothing is ever auto-removed).

## What is never removed
Manual backups, the `(Pre-Restore)` checkpoint (different name prefixes), and any backup that fails its integrity check (`ClassifyBackupFully == "Corrupt"`). The pure selector also keeps future-dated backups and the newest per time bucket.

## Selection logic
`SelectAutobackupsToThin` (added as a savepoint commit): a pure, deterministic, idempotent tiered time-bucket selector (Borg/restic style) — keep all in the last hour, newest per 30m to 6h, hourly to 24h, daily to 7d, weekly beyond; then the existing "max autobackups" applies as a cap on what survives. **7 harness assertions** cover buckets, the cap, idempotency, and clock-skew. Harness **160 -> 167**, Debug + Release green, app smoke-launched OK.

## Wiring
`CleanUpOldAutobackups()` runs after a successful autobackup when the toggle is on; the stop-at-limit guard in the timer tick and at game-start is bypassed only when cleanup is on.

## Next
- Part 3: pinning (`[PINNED]` token, right-click Pin/Unpin, excluded from count + cleanup).
- Part 4: FileSystemWatcher + fast-poll trigger + UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)