### PR TITLE
feat: change-aware autobackup, part 3 (pin a backup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ All notable changes to Savedrake are recorded here. The format is based on
   "keep the newest N" limit loses them. Your manual backups and the pre-restore checkpoint are never removed,
   and a backup that fails its integrity check is never removed. Removed backups are deleted by default, or sent
   to the Recycle Bin if you tick the second option. (#45)
+- Pin a backup (part 3 of 3): right-click any backup and choose "Pin backup" to protect it. A pinned backup is
+  never removed by the automatic cleanup and does not count toward your autobackup limit, so you can keep an
+  important restore point (for example, before a boss) for as long as you like. Pinned backups are marked with
+  "[PINNED]" in the file name, so you can see them in the folder too; right-click again to unpin. (#46)
 
 ### Fixed
 - The updater builds its download URL with `Uri.EscapeDataString` on the version segment

--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -93,6 +93,7 @@ namespace RestoreHarness
                 Test_BackupManifest();   // P1 layer 2: in-zip manifest verify (missing/corrupt files) + restore skips it
                 Test_ChangeFingerprint();   // change-aware autobackup (PR1): save fingerprint is stable/changes/fail-closed
                 Test_TieredRetention();   // change-aware autobackup (PR2): tiered-retention selector (buckets/cap/idempotent)
+                Test_PinHelpers();   // change-aware autobackup (PR3): pin filename-token helpers (detect/add/remove/round-trip)
                 Test_RestoreReverify();   // P1: restore re-verifies a manifest-bearing backup; legacy backups unaffected
                 Test_ClassifyBackup();   // P1 UI: full Validated/Legacy/Corrupt classification for "Validate all"
                 Test_LogRedaction();   // P2: the rolling logger redacts the Steam account id and user profile path
@@ -494,6 +495,29 @@ namespace RestoreHarness
 
             // A future-dated backup (clock skew) is kept, as is an old one alone in its weekly bucket.
             Check("a future-dated backup is kept (treated as newest)", run(new long[] { now + TimeSpan.FromHours(1).Ticks, now - TimeSpan.FromDays(30).Ticks }, 0).Length == 0);
+            Console.WriteLine();
+        }
+
+        static void Test_PinHelpers()
+        {
+            // Change-aware autobackup (PR3): pinning is marked by a " [PINNED]" filename token. IsPinnedBackup detects
+            // it; PinnedPath/UnpinnedPath add/remove it idempotently and round-trip, and pinning must preserve the
+            // autobackup name prefix so a pinned autobackup is still recognizable (just excluded from count + cleanup).
+            Console.WriteLine("== Change-aware autobackup: pinning helpers (PR3) ==");
+            var isPinned = SM("IsPinnedBackup");
+            var pin = SM("PinnedPath");
+            var unpin = SM("UnpinnedPath");
+            Func<string, bool> P = n => (bool)isPinned.Invoke(null, new object[] { n });
+            Func<string, string> PIN = p => (string)pin.Invoke(null, new object[] { p });
+            Func<string, string> UNPIN = p => (string)unpin.Invoke(null, new object[] { p });
+
+            Check("a name with the token is pinned", P("autobackup_240620 [PINNED].zip"));
+            Check("a plain name is not pinned", !P("autobackup_240620.zip"));
+            Check("PinnedPath inserts the token before the extension", PIN("C:\\b\\foo.zip") == "C:\\b\\foo [PINNED].zip");
+            Check("PinnedPath is idempotent", PIN("C:\\b\\foo [PINNED].zip") == "C:\\b\\foo [PINNED].zip");
+            Check("UnpinnedPath strips the token", UNPIN("C:\\b\\foo [PINNED].zip") == "C:\\b\\foo.zip");
+            Check("pin keeps the autobackup name prefix", Path.GetFileName(PIN("C:\\b\\autobackup_1.zip")).StartsWith("auto"));
+            Check("pin -> unpin round-trips to the original", UNPIN(PIN("C:\\b\\(Auto) save 3.zip")) == "C:\\b\\(Auto) save 3.zip");
             Console.WriteLine();
         }
 

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -182,13 +182,24 @@ namespace Savedrake
             ContextMenuStrip contextMenuStrip = new ContextMenuStrip();
             ToolStripMenuItem renameMenultem = new ToolStripMenuItem("Rename");
             ToolStripMenuItem deleteMenuItem = new ToolStripMenuItem("Delete");
+            ToolStripMenuItem pinMenuItem = new ToolStripMenuItem("Pin backup");
             ToolStripMenuItem validateAllMenuItem = new ToolStripMenuItem("Validate all backups");
             contextMenuStrip.Items.Add(renameMenultem);
             contextMenuStrip.Items.Add(deleteMenuItem);
+            contextMenuStrip.Items.Add(pinMenuItem);
             contextMenuStrip.Items.Add(validateAllMenuItem);
             renameMenultem.Click += RenameMenultem_Click;
             deleteMenuItem.Click += DeleteMenuItem_Click;
+            pinMenuItem.Click += PinMenuItem_Click;
             validateAllMenuItem.Click += (s, e) => ValidateAllBackups();
+            // Pinning (part 3): the menu label reflects the selected backup's state, and Pin is only available for a
+            // single selection.
+            contextMenuStrip.Opening += (s, e) =>
+            {
+                bool one = listView.SelectedItems.Count == 1;
+                pinMenuItem.Enabled = one;
+                pinMenuItem.Text = (one && IsPinnedBackup(Path.GetFileName(listView.SelectedItems[0].Tag.ToString()))) ? "Unpin backup" : "Pin backup";
+            };
             listView.ContextMenuStrip = contextMenuStrip;
 
             //listView related
@@ -1962,6 +1973,7 @@ namespace Savedrake
                 {
                     string name = Path.GetFileName(file);
                     if (!(name.StartsWith("(Auto)") || name.StartsWith("auto"))) continue;
+                    if (IsPinnedBackup(name)) continue; // pinned backups (part 3) are never removed
                     files.Add(file);
                     ticks.Add(File.GetLastWriteTimeUtc(file).Ticks);
                 }
@@ -1996,6 +2008,32 @@ namespace Savedrake
                 }
             }
             catch (Exception ex) { Log.Warn("Auto-cleanup of old autobackups failed: " + ex.Message); }
+        }
+
+        // Change-aware autobackup, part 3 (pinning): a pinned backup is protected from automatic cleanup and is not
+        // counted toward the autobackup limit. Pins are marked by a " [PINNED]" token in the file name (not a sidecar
+        // or index) so they survive copy/move, are visible in Explorer and the backup list, and need no extra storage.
+        // Renaming a pinned file outside Savedrake to drop the token simply unpins it.
+        internal const string PinTag = "[PINNED]";
+
+        private static bool IsPinnedBackup(string fileName)
+        {
+            return !string.IsNullOrEmpty(fileName) && fileName.IndexOf(PinTag, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        // The pinned form of a backup path: insert " [PINNED]" before the extension. Idempotent (already-pinned -> unchanged).
+        private static string PinnedPath(string path)
+        {
+            if (IsPinnedBackup(Path.GetFileName(path))) return path;
+            return Path.Combine(Path.GetDirectoryName(path),
+                Path.GetFileNameWithoutExtension(path) + " " + PinTag + Path.GetExtension(path));
+        }
+
+        // The unpinned form of a backup path: strip the " [PINNED]" token. Idempotent.
+        private static string UnpinnedPath(string path)
+        {
+            string cleaned = Path.GetFileName(path).Replace(" " + PinTag, "").Replace(PinTag, "");
+            return Path.Combine(Path.GetDirectoryName(path), cleaned);
         }
 
         // Backup integrity verification, layer 2 (P1): confirm the freshly written archive contains every file the
@@ -2622,7 +2660,7 @@ namespace Savedrake
             listView.Refresh();
 
             // Filter the zip files to include only those with "(Auto)" or "auto" in the name
-            string[] autoBackupFiles = zipFiles.Where(file => Path.GetFileName(file).StartsWith("(Auto)") || Path.GetFileName(file).StartsWith("auto")).ToArray();
+            string[] autoBackupFiles = zipFiles.Where(file => (Path.GetFileName(file).StartsWith("(Auto)") || Path.GetFileName(file).StartsWith("auto")) && !IsPinnedBackup(Path.GetFileName(file))).ToArray();
 
             // Set the backup count to the number of autobackup files found
             backupCount = autoBackupFiles.Length;
@@ -3182,6 +3220,38 @@ namespace Savedrake
             if (listView.SelectedItems.Count == 1)
             {
                 listView.SelectedItems[0].BeginEdit();
+            }
+        }
+
+        // Pinning (part 3): toggle the selected backup's pinned state by renaming it to add/remove the " [PINNED]"
+        // token. A pinned backup is protected from automatic cleanup and is not counted toward the autobackup limit.
+        private void PinMenuItem_Click(object sender, EventArgs e)
+        {
+            if (listView.SelectedItems.Count != 1)
+            {
+                MessageBox.Show("Select one backup to pin or unpin.", "Pin backup", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+            string path;
+            try { path = listView.SelectedItems[0].Tag.ToString(); } catch { return; }
+            try
+            {
+                if (!File.Exists(path)) { LoadBackupHistory(); return; }
+                bool pinned = IsPinnedBackup(Path.GetFileName(path));
+                string target = pinned ? UnpinnedPath(path) : PinnedPath(path);
+                if (!string.Equals(target, path, StringComparison.OrdinalIgnoreCase))
+                {
+                    target = MakeUniquePath(target); // never clobber an existing backup
+                    File.Move(path, target);
+                }
+                LoadBackupHistory();
+                listView.Sort();
+                Status.Text = pinned ? "Backup unpinned." : "Backup pinned. It won't be removed by automatic cleanup.";
+            }
+            catch (Exception ex)
+            {
+                Log.Warn("Pin/unpin failed: " + ex.Message);
+                MessageBox.Show("Could not change the pinned state: " + ex.Message, "Pin backup", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 


### PR DESCRIPTION
Third of four PRs for change-aware autobackup. Adds **pinning**, the safety valve for the automatic cleanup from #45: protect a specific backup so it is never removed.

## Behavior
- Right-click a backup in the list and choose **Pin backup**. Right-click a pinned one to **Unpin** (the menu label reflects the current state; Pin is only enabled for a single selection).
- A **pinned backup is never removed by the automatic cleanup**, and it **does not count toward the autobackup limit**, so you can keep an important restore point (e.g. before a boss) indefinitely without it eating a slot or being cleaned up.
- Pins are visible: the file is marked with `[PINNED]` in its name, so you can spot pinned backups in Explorer too.

## Data model
A filename token (` [PINNED]` before the extension), per the research recommendation: survives copy/move, visible in the folder, no sidecar file or index to drift out of sync, zero extra storage. The token is appended (not prefixed) so a pinned autobackup keeps its `auto` prefix and stays classified correctly. Renaming a pinned file outside Savedrake to drop the token simply unpins it.

## Implementation
- `IsPinnedBackup` / `PinnedPath` / `UnpinnedPath`: pure static helpers (idempotent, round-trip).
- Pin toggles via `File.Move` to the tokened name, guarded by `MakeUniquePath`.
- Excluded from `CleanUpOldAutobackups` candidates and from the `LoadBackupHistory` autobackup count.
- **7 harness assertions** (detect, add/remove, idempotency, round-trip, prefix preserved). Harness **167 -> 174**, Release green, app smoke-launched OK.

## Next
- Part 4: FileSystemWatcher + fast-poll trigger + UI (instant capture on each real save).

🤖 Generated with [Claude Code](https://claude.com/claude-code)