### PR TITLE
feat: change-aware autobackup, part 4 (back up the moment the game saves)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to Savedrake are recorded here. The format is based on
 - Disk-space preflight: before a backup or restore, Savedrake checks the target drive has room
   (including the staging copy a restore needs) and refuses up front with a clear message instead
   of failing partway through. A backup and a restore can also no longer overlap. (#41)
-- Change-aware autobackup (part 1 of 3): autobackup no longer writes a redundant identical backup when
+- Change-aware autobackup (part 1 of 4): autobackup no longer writes a redundant identical backup when
   your save has not changed since the last one. Each backup records a content fingerprint of the save, and
   a timer tick that finds no change is skipped instead of consuming one of your autobackup slots. A
   just-restored save, and a save folder that is momentarily locked or mid-write, are handled safely. (#44)
@@ -45,10 +45,15 @@ All notable changes to Savedrake are recorded here. The format is based on
   "keep the newest N" limit loses them. Your manual backups and the pre-restore checkpoint are never removed,
   and a backup that fails its integrity check is never removed. Removed backups are deleted by default, or sent
   to the Recycle Bin if you tick the second option. (#45)
-- Pin a backup (part 3 of 3): right-click any backup and choose "Pin backup" to protect it. A pinned backup is
+- Pin a backup (part 3 of 4): right-click any backup and choose "Pin backup" to protect it. A pinned backup is
   never removed by the automatic cleanup and does not count toward your autobackup limit, so you can keep an
   important restore point (for example, before a boss) for as long as you like. Pinned backups are marked with
   "[PINNED]" in the file name, so you can see them in the folder too; right-click again to unpin. (#46)
+- Back up the moment the game saves (part 4 of 4, optional, off by default): a new Files > Settings option that
+  watches your save folder and takes an autobackup shortly after the game writes a save, instead of waiting for the
+  timer interval. The interval timer keeps running as a fallback, and the watcher pauses while you restore so it never
+  backs up the save you just restored. Combine it with the automatic cleanup above for a tidy, up-to-the-moment
+  history. (#47)
 
 ### Fixed
 - The updater builds its download URL with `Uri.EscapeDataString` on the version segment

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -55,6 +55,15 @@ namespace Savedrake
         // the extra old autobackups. _recycleMenuItem on = send removed ones to the Recycle Bin instead of deleting.
         private ToolStripMenuItem _cleanupMenuItem;
         private ToolStripMenuItem _recycleMenuItem;
+        // Change-aware autobackup, part 4 (back up the moment the game saves): a FileSystemWatcher on the save folder
+        // triggers a backup shortly after the game writes a save, instead of waiting for the interval timer. Off by
+        // default (_backupOnSaveMenuItem). _quiesceTimer debounces a burst of write events; _suppressSaveWatcher is set
+        // while WE write the save folder (restore) so our own writes never trigger a backup. The interval timer stays
+        // on as a fallback, so a missed/overflowed watcher event is still caught.
+        private ToolStripMenuItem _backupOnSaveMenuItem;
+        private FileSystemWatcher _saveWatcher;
+        private System.Windows.Forms.Timer _quiesceTimer;
+        private volatile bool _suppressSaveWatcher;
         #endregion
 
         //Hotkey related
@@ -252,6 +261,17 @@ namespace Savedrake
             ssettingsToolStripMenuItem.DropDownItems.Add(_cleanupMenuItem);
             ssettingsToolStripMenuItem.DropDownItems.Add(_recycleMenuItem);
 
+            // Files > Settings: opt-in "back up the moment the game saves" (change-aware autobackup, part 4). OFF by
+            // default. When on (and autobackup is enabled and the game is running) a FileSystemWatcher captures a backup
+            // shortly after each real save instead of waiting for the interval timer; the timer stays on as a fallback.
+            _backupOnSaveMenuItem = new ToolStripMenuItem("Back up the moment the game saves") { CheckOnClick = true };
+            _backupOnSaveMenuItem.CheckedChanged += (s, e) =>
+            {
+                if (_backupOnSaveMenuItem.Checked && checkbox_auto.Checked && isGameRunning) StartSaveWatcher();
+                else StopSaveWatcher();
+            };
+            ssettingsToolStripMenuItem.DropDownItems.Add(_backupOnSaveMenuItem);
+
             //tray
             #region
             // Initialize the NotifyIcon component
@@ -363,6 +383,9 @@ namespace Savedrake
 
             [XmlElement("RemovedToRecycleBin")]
             public bool RemovedToRecycleBin { get; set; }
+
+            [XmlElement("BackupOnSaveChange")]
+            public bool BackupOnSaveChange { get; set; }
 
 
 
@@ -502,6 +525,7 @@ namespace Savedrake
 
                 AutoCleanupOldBackups = _cleanupMenuItem != null && _cleanupMenuItem.Checked,
                 RemovedToRecycleBin = _recycleMenuItem != null && _recycleMenuItem.Checked,
+                BackupOnSaveChange = _backupOnSaveMenuItem != null && _backupOnSaveMenuItem.Checked,
                 
                 // Save the hotkey settings
                 Hotkey = new HotkeySettings
@@ -627,6 +651,7 @@ namespace Savedrake
                 _recycleMenuItem.Checked = settings.AutoCleanupOldBackups && settings.RemovedToRecycleBin;
                 _recycleMenuItem.Enabled = _cleanupMenuItem.Checked;
             }
+            if (_backupOnSaveMenuItem != null) _backupOnSaveMenuItem.Checked = settings.BackupOnSaveChange;
 
 
 
@@ -1109,6 +1134,7 @@ namespace Savedrake
                 {
                     SetAutoBackupInterval();
                     autobackupTimer.Start();
+                    StartSaveWatcher(); // part 4: also capture instantly on each save, if the user opted in
 
                     //Count's before backing up in the beginning.
                     string countFilePath = AutoBackupCountFilePath;
@@ -1156,6 +1182,7 @@ namespace Savedrake
                 else
                 {
                     autobackupTimer.Stop();
+                    StopSaveWatcher();
                     Status.Text = $"Game not running. Autobackup paused.";
                     //NotifyUser("Game not running. Autobackup will start when the game starts."); // Game is not running, wait to start autobackup.
                 }
@@ -1163,6 +1190,7 @@ namespace Savedrake
             else
             {
                 autobackupTimer.Stop(); // Auto backup checkbox is not checked, stop autobackup.
+                StopSaveWatcher();
                                         // No message is needed here as per your requirement.
             }
         }
@@ -1207,22 +1235,28 @@ namespace Savedrake
 
         private void OnAutobackupTimerElapsed(object sender, System.Timers.ElapsedEventArgs e)
         {
-            // R7a re-entrancy guard: SynchronizingObject runs this on the UI thread, but AutoReset keeps the timer
-            // firing, and any modal dialog opened below (max-reached / a BackupOperation error) pumps the message
-            // queue — which would dispatch a queued NEXT tick nested inside this one (stacked dialogs, interleaved
-            // count-file read-modify-write). Single UI thread, so a plain field flag suffices.
+            // The interval timer is now one of two triggers for a change-aware autobackup (the other is the save
+            // watcher, part 4). Both funnel through RunChangeAwareAutobackup, which carries the re-entrancy guard.
+            RunChangeAwareAutobackup();
+        }
+
+        // One change-aware autobackup attempt, shared by the interval timer and the save watcher (part 4). Must run on
+        // the UI thread (the timer marshals via SynchronizingObject; the watcher via BeginInvoke). The re-entrancy guard
+        // (R7a) keeps overlapping triggers safe: a modal dialog below pumps the message queue, and a timer tick and a
+        // settled watcher event can arrive together — the second call finds the fingerprint unchanged and skips.
+        private void RunChangeAwareAutobackup()
+        {
             if (_autoBackupInProgress) return;
             _autoBackupInProgress = true;
             try
             {
-                // R7a fallback: the registry/WMI watcher can miss a game-exit event, leaving the timer running.
-                // Re-check game state on every tick (fresh read, not the cached isGameRunning); if DD2 is no longer
-                // running, sync the flag and pause autobackup rather than backing up stale saves while the game is
-                // closed. Runs on the UI thread (SynchronizingObject), so touching the timer/Status here is safe.
+                // Re-check game state every time (fresh read, not the cached isGameRunning); if DD2 is no longer
+                // running, sync the flag and pause autobackup AND the save watcher rather than backing up stale saves.
                 if (!CheckGameRunningStatus())
                 {
                     isGameRunning = false;
                     autobackupTimer.Stop();
+                    StopSaveWatcher();
                     Status.Text = "Game not running. Autobackup paused.";
                     return;
                 }
@@ -1244,12 +1278,9 @@ namespace Savedrake
                     // otherwise the original behavior stops autobackup once the limit is reached.
                     if ((_cleanupMenuItem != null && _cleanupMenuItem.Checked) || backupCount < maxBackups)
                     {
-                        // Change-aware gate (PR1): skip this tick when the save folder is unchanged since the last
-                        // backup, so the timer stops writing redundant identical zips that consume the autobackup
-                        // limit. A null fingerprint (folder missing/locked/mid-write/no save data) fails CLOSED: skip
-                        // and retry next tick rather than zip a folder we cannot fully read. A null baseline (first
-                        // eligible tick) never skips. Skipping consumes no count and writes no file; the limit/branch
-                        // logic and the _autoBackupInProgress guard are untouched.
+                        // Change-aware gate (PR1): skip when the save folder is unchanged since the last backup. A null
+                        // fingerprint (folder missing/locked/mid-write/no save data) fails CLOSED: skip and retry. A
+                        // null baseline (first eligible attempt) never skips. Skipping consumes no count, writes no file.
                         string currentFp = ComputeSaveFingerprint(textbox1.Text);
                         if (currentFp == null)
                         {
@@ -1262,15 +1293,14 @@ namespace Savedrake
                         else
                         {
                             BackupOperation(true); // Perform the backup operation
-                            // Do NOT increment a stale local: BackupOperation -> LoadBackupHistory already recomputed
-                            // the count from the actual autobackup files on disk and wrote it to countFilePath. Writing
-                            // backupCount+1 here clobbered that recount AND advanced the limit even when the backup
-                            // FAILED (no file created). The next tick re-reads the accurate value.
+                            // BackupOperation -> LoadBackupHistory recomputes the count from the files on disk, so no
+                            // stale local increment here (which previously advanced the limit even on a failed backup).
                         }
                     }
                     else
                     {
                         autobackupTimer.Stop(); // limit reached — stop BEFORE the modal so no further tick is armed
+                        StopSaveWatcher();
                         checkbox_auto.Checked = false;
                         MessageBox.Show($"The maximum number of {maxBackups} autobackups has been reached. To change the limit go to: \"Files > Settings > Limit Autobackups\" and enter the new limit.", "Autobackup", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     }
@@ -1285,6 +1315,102 @@ namespace Savedrake
             {
                 _autoBackupInProgress = false;
             }
+        }
+
+        // ---- Part 4: save-folder watcher (instant capture). No-op unless the user opted in. The interval timer stays
+        // on as the fallback, so a missed or overflowed watcher event is still caught on the next tick. ----
+
+        private void StartSaveWatcher()
+        {
+            if (_backupOnSaveMenuItem == null || !_backupOnSaveMenuItem.Checked) return;
+            if (string.IsNullOrWhiteSpace(textbox1.Text) || !Directory.Exists(textbox1.Text)) return;
+            try
+            {
+                StopSaveWatcher(); // ensure a single clean instance (also disposes any previous quiesce timer)
+                _quiesceTimer = new System.Windows.Forms.Timer { Interval = 4000 }; // debounce: wait for writes to settle
+                _quiesceTimer.Tick += OnQuiesceElapsed;
+                _saveWatcher = new FileSystemWatcher(textbox1.Text)
+                {
+                    IncludeSubdirectories = true,
+                    NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.Size | NotifyFilters.CreationTime,
+                    InternalBufferSize = 64 * 1024
+                };
+                _saveWatcher.Changed += OnSaveChanged;
+                _saveWatcher.Created += OnSaveChanged;
+                _saveWatcher.Deleted += OnSaveChanged;
+                _saveWatcher.Renamed += OnSaveChanged;
+                _saveWatcher.Error += OnSaveWatcherError;
+                _saveWatcher.EnableRaisingEvents = true;
+            }
+            catch (Exception ex)
+            {
+                Log.Warn("Could not start the save watcher (the interval timer remains the fallback): " + ex.Message);
+                StopSaveWatcher();
+            }
+        }
+
+        private void StopSaveWatcher()
+        {
+            // Fully tear the debounce timer down (stop + unsubscribe + dispose + null) so repeated start/stop cycles
+            // don't accumulate timers or duplicate Tick handlers, and so a queued callback sees null rather than a
+            // disposed object.
+            if (_quiesceTimer != null)
+            {
+                try { _quiesceTimer.Stop(); } catch { }
+                try { _quiesceTimer.Tick -= OnQuiesceElapsed; } catch { }
+                try { _quiesceTimer.Dispose(); } catch { }
+                _quiesceTimer = null;
+            }
+            if (_saveWatcher != null)
+            {
+                try { _saveWatcher.EnableRaisingEvents = false; } catch { }
+                try
+                {
+                    _saveWatcher.Changed -= OnSaveChanged;
+                    _saveWatcher.Created -= OnSaveChanged;
+                    _saveWatcher.Deleted -= OnSaveChanged;
+                    _saveWatcher.Renamed -= OnSaveChanged;
+                    _saveWatcher.Error -= OnSaveWatcherError;
+                }
+                catch { }
+                try { _saveWatcher.Dispose(); } catch { }
+                _saveWatcher = null;
+            }
+        }
+
+        // Watcher events fire on a ThreadPool thread. Ignore our own restore writes; otherwise marshal to the UI thread
+        // and (re)start the debounce, so a burst of writes collapses into one backup once the save has settled.
+        private void OnSaveChanged(object sender, FileSystemEventArgs e)
+        {
+            if (_suppressSaveWatcher) return;
+            try { if (IsHandleCreated) BeginInvoke((MethodInvoker)RestartQuiesce); } catch { }
+        }
+
+        private void RestartQuiesce()
+        {
+            // A watcher event marshaled here can land after StopSaveWatcher disposed+nulled the timer (shutdown / game
+            // exit / toggle off). Null-check covers the nulled case; try/catch covers a queued message racing dispose.
+            if (_quiesceTimer == null) return;
+            try { _quiesceTimer.Stop(); _quiesceTimer.Start(); } catch (ObjectDisposedException) { }
+        }
+
+        private void OnQuiesceElapsed(object sender, EventArgs e)
+        {
+            if (_quiesceTimer == null) return;
+            try { _quiesceTimer.Stop(); } catch (ObjectDisposedException) { return; }
+            if (_suppressSaveWatcher) return;
+            if (!checkbox_auto.Checked) return;
+            // A backup or restore is mid-flight: wait another quiet window rather than overlapping it.
+            if (_operationInProgress) { try { _quiesceTimer.Start(); } catch (ObjectDisposedException) { } return; }
+            RunChangeAwareAutobackup();
+        }
+
+        // A watcher Error (e.g. InternalBufferOverflow) means events may have been dropped. Re-arm the watcher; the
+        // interval timer covers anything missed in the meantime.
+        private void OnSaveWatcherError(object sender, ErrorEventArgs e)
+        {
+            Log.Warn("Save watcher error, re-arming: " + (e.GetException() != null ? e.GetException().Message : "unknown"));
+            try { if (IsHandleCreated) BeginInvoke((MethodInvoker)(() => { StopSaveWatcher(); StartSaveWatcher(); })); } catch { }
         }
 
         private void combobox_auto_Validating(object sender, System.ComponentModel.CancelEventArgs e)
@@ -2304,7 +2430,12 @@ namespace Savedrake
                     }
 
                     // STEP 4 — delegate ALL destructive work (staging, swap, rollback, cleanup) to the transaction.
-                    bool ok = RestoreTransactional(filePath, textbox1.Text);
+                    // Part 4: suppress the save watcher around the restore writes so our own writes don't trigger a backup
+                    // (the _operationInProgress guard and the post-restore fingerprint baseline are independent backstops).
+                    bool ok;
+                    _suppressSaveWatcher = true;
+                    try { ok = RestoreTransactional(filePath, textbox1.Text); }
+                    finally { _suppressSaveWatcher = false; }
 
                     // STEP 5 — post-success UI. Undo is DISABLED on success: old saves went to a temp dir, not the
                     // recycle bin, so a recycle-bin Undo would silently no-op. Honest = disable it.
@@ -3612,6 +3743,7 @@ namespace Savedrake
             msgWindow.DestroyHandle(); // Clean up the message-only window
 
             autobackupTimer?.Dispose(); // R7a: the timer was previously never disposed
+            StopSaveWatcher(); // part 4: stop, unsubscribe, dispose the save watcher + the quiesce timer (nulls both)
 
             if (_watcher != null)
             {


### PR DESCRIPTION
Final part of change-aware autobackup. Adds an optional **instant-capture** trigger so a backup happens right after the game saves, instead of waiting for the interval timer.

## Behavior (opt-in, off by default)
New **Files > Settings → "Back up the moment the game saves"**. When on (and autobackup is enabled and the game is running), a `FileSystemWatcher` on the save folder captures an autobackup shortly after each real save. The interval timer keeps running as a **fallback**, so anything the watcher misses is still caught. Off = exactly the previous timer-only behavior.

## Design
- Watcher events fire on a ThreadPool thread → marshaled to the UI thread via `BeginInvoke` → (re)start a 4s **quiesce/debounce** timer so a burst of writes collapses into one backup once the save settles (and we never zip a half-written save; `ComputeSaveFingerprint` also fails closed on a locked file).
- On quiesce elapse it runs the **same gated path** as the interval tick, which I extracted into `RunChangeAwareAutobackup` (fingerprint dedup, limit, cleanup, re-entrancy guard all apply). The interval timer now just calls that method too, so its behavior is unchanged.
- **Suppressed during restore** (`_suppressSaveWatcher`) so our own restore writes don't trigger a backup; the operation lock and the post-restore fingerprint baseline are independent backstops.
- Lifecycle tied to game-running + the toggle; `Error` (buffer overflow) re-arms the watcher; everything disposed on close.

## Review
Ran a **3-lens adversarial review** (threading / lifecycle / behavior) + a verification pass. It found **5 real quiesce-timer lifecycle defects** (ObjectDisposedException races on shutdown; missing dispose/unsubscribe accumulating timers + handlers on start/stop). **All fixed** in this PR: symmetric create-on-start / full-teardown-on-stop, plus disposed-guards on the marshaled callbacks.

## Verification
Build Debug + Release clean, harness **174/174**, app smoke-launched OK.

This completes change-aware autobackup (parts 1-4: dedup, cleanup, pinning, instant capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)