### PR TITLE
feat: undo last restore (one-click rollback to the pre-restore snapshot)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ All notable changes to Savedrake are recorded here. The format is based on
   timer interval. The interval timer keeps running as a fallback, and the watcher pauses while you restore so it never
   backs up the save you just restored. Combine it with the automatic cleanup above for a tidy, up-to-the-moment
   history. (#47)
+- Undo last restore: a new File > Undo last restore that rolls your save back to the snapshot Savedrake takes
+  automatically just before every restore, so a restore you regret is one click to reverse. It runs through the same
+  safety checks as a normal restore (and snapshots your current save first, so you can redo). The restore prompt now
+  also tells you the snapshot is taken. (#48)
 
 ### Fixed
 - The updater builds its download URL with `Uri.EscapeDataString` on the version segment

--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -94,6 +94,7 @@ namespace RestoreHarness
                 Test_ChangeFingerprint();   // change-aware autobackup (PR1): save fingerprint is stable/changes/fail-closed
                 Test_TieredRetention();   // change-aware autobackup (PR2): tiered-retention selector (buckets/cap/idempotent)
                 Test_PinHelpers();   // change-aware autobackup (PR3): pin filename-token helpers (detect/add/remove/round-trip)
+                Test_UndoRestore();   // QoL: find the latest (Pre-Restore) checkpoint for one-click undo restore
                 Test_RestoreReverify();   // P1: restore re-verifies a manifest-bearing backup; legacy backups unaffected
                 Test_ClassifyBackup();   // P1 UI: full Validated/Legacy/Corrupt classification for "Validate all"
                 Test_LogRedaction();   // P2: the rolling logger redacts the Steam account id and user profile path
@@ -518,6 +519,33 @@ namespace RestoreHarness
             Check("UnpinnedPath strips the token", UNPIN("C:\\b\\foo [PINNED].zip") == "C:\\b\\foo.zip");
             Check("pin keeps the autobackup name prefix", Path.GetFileName(PIN("C:\\b\\autobackup_1.zip")).StartsWith("auto"));
             Check("pin -> unpin round-trips to the original", UNPIN(PIN("C:\\b\\(Auto) save 3.zip")) == "C:\\b\\(Auto) save 3.zip");
+            Console.WriteLine();
+        }
+
+        static void Test_UndoRestore()
+        {
+            // Undo-restore (QoL): FindLatestPreRestoreCheckpoint returns the NEWEST "(Pre-Restore)" backup, ignoring
+            // other backups, and null when there is none or the folder is missing.
+            Console.WriteLine("== Undo last restore: latest pre-restore checkpoint ==");
+            var find = SM("FindLatestPreRestoreCheckpoint");
+            string dir = NewDir("undo");
+            Check("empty folder -> null", (string)find.Invoke(null, new object[] { dir }) == null);
+
+            File.WriteAllText(Path.Combine(dir, "backup_1.zip"), "x");
+            File.WriteAllText(Path.Combine(dir, "(Auto) backup_2.zip"), "x");
+            Check("no pre-restore among other backups -> null", (string)find.Invoke(null, new object[] { dir }) == null);
+
+            string older = Path.Combine(dir, "(Pre-Restore) 240619120000.zip");
+            File.WriteAllText(older, "x");
+            File.SetLastWriteTimeUtc(older, DateTime.UtcNow.AddHours(-2));
+            string newer = Path.Combine(dir, "(Pre-Restore) 240620120000.zip");
+            File.WriteAllText(newer, "x");
+            File.SetLastWriteTimeUtc(newer, DateTime.UtcNow.AddMinutes(-1));
+            string found = (string)find.Invoke(null, new object[] { dir });
+            Check("returns the newest (Pre-Restore) checkpoint", found != null && Path.GetFileName(found) == "(Pre-Restore) 240620120000.zip", "found=" + found);
+
+            string missing = Path.Combine(work, "undo_missing_" + Guid.NewGuid().ToString("N").Substring(0, 8));
+            Check("missing folder -> null (no throw)", (string)find.Invoke(null, new object[] { missing }) == null);
             Console.WriteLine();
         }
 

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -237,6 +237,11 @@ namespace Savedrake
             };
             helpToolStripMenuItem.DropDownItems.Add(openLogFolderMenuItem);
 
+            // File menu: "Undo last restore" (QoL) — roll the live save back to the automatic pre-restore snapshot.
+            ToolStripMenuItem undoRestoreMenuItem = new ToolStripMenuItem("Undo last restore");
+            undoRestoreMenuItem.Click += (s, e) => UndoLastRestore();
+            fileToolStripMenuItem.DropDownItems.Add(undoRestoreMenuItem);
+
             // Files > Settings: opt-in "clean up old backups" toggles (change-aware autobackup, part 2). OFF by default,
             // so existing behavior (autobackup stops at the limit) is unchanged until the user opts in. Turning it on
             // asks for confirmation because it enables automatic removal of old autobackups.
@@ -2327,6 +2332,65 @@ namespace Savedrake
             }
         }
 
+        // Undo-restore (QoL): the newest "(Pre-Restore)" checkpoint in the backup folder — the automatic snapshot
+        // Savedrake takes of the live save just before each restore. Returns null if there is none, or the folder is
+        // unreadable. Static + folder-parameterised so the headless harness can test it.
+        private static string FindLatestPreRestoreCheckpoint(string backupDir)
+        {
+            try
+            {
+                return Directory.GetFiles(backupDir, "*.zip")
+                    .Where(f => Path.GetFileName(f).StartsWith("(Pre-Restore)", StringComparison.OrdinalIgnoreCase))
+                    .OrderByDescending(f => File.GetLastWriteTimeUtc(f))
+                    .FirstOrDefault();
+            }
+            catch { return null; }
+        }
+
+        // Undo-restore (QoL): roll the live save back to the snapshot taken just before the last restore. Instead of
+        // duplicating the (high-stakes) restore flow, this selects that checkpoint in the list and invokes the normal
+        // restore, so it inherits the game-running guard, the Steam Cloud warning, validation, AND a fresh pre-restore
+        // snapshot of the CURRENT state (so the undo is itself undoable / redoable).
+        private void UndoLastRestore()
+        {
+            if (string.IsNullOrWhiteSpace(textbox2.Text) || !Directory.Exists(textbox2.Text))
+            {
+                MessageBox.Show("Please set your backup folder first.", "Undo last restore", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+            LoadBackupHistory(); // make sure the list matches what's on disk before we pick from it
+            string checkpoint = FindLatestPreRestoreCheckpoint(textbox2.Text);
+            if (checkpoint == null)
+            {
+                MessageBox.Show("There is no snapshot to undo. Savedrake automatically saves a snapshot of your current " +
+                    "save each time you restore a backup, so an undo only becomes available after a restore.",
+                    "Nothing to undo", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+            string when = Path.GetFileNameWithoutExtension(checkpoint).Replace("(Pre-Restore)", "").Trim();
+            DialogResult r = MessageBox.Show(
+                "This rolls your save back to the snapshot Savedrake took just before your last restore" +
+                (when.Length > 0 ? " (" + when + ")" : "") + ".\n\n" +
+                "Your current save is snapshotted first, so you can redo. You'll be reminded about Steam next.\n\n" +
+                "Undo the last restore?",
+                "Undo last restore", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+            if (r != DialogResult.Yes) return;
+
+            string fileName = Path.GetFileName(checkpoint);
+            ListViewItem target = null;
+            foreach (ListViewItem it in listView.Items)
+                if (string.Equals(it.Text, fileName, StringComparison.OrdinalIgnoreCase)) { target = it; break; }
+            if (target == null)
+            {
+                MessageBox.Show("Could not find the snapshot in the backup list.", "Undo last restore", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+            listView.SelectedItems.Clear();
+            target.Selected = true;
+            target.Focused = true;
+            button_res_Click(this, EventArgs.Empty); // reuse the full restore flow (cloud warning, checkpoint, transaction)
+        }
+
         private void button_res_Click(object sender, EventArgs e)
         {
             // Check if the textboxes are not empty and contain valid paths
@@ -2371,6 +2435,7 @@ namespace Savedrake
                 DialogResult cloud = MessageBox.Show(
                     "Before restoring, fully EXIT Steam (or disable Dragon's Dogma 2 Cloud Saves in " +
                     "Steam > Properties). Otherwise Steam may re-upload your OLD save and overwrite this restore." +
+                    "\n\nSavedrake snapshots your current save first, so you can undo this from File > Undo last restore." +
                     "\n\nContinue with the restore?",
                     "Exit Steam Before Restoring", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
                 if (cloud != DialogResult.Yes) { Status.Text = "Restore cancelled."; return; }


### PR DESCRIPTION
First of the high-impact QoL items: make restore feel safe to use.

## Why
Restore is the scary, destructive action. Savedrake already snapshots your live save into a `(Pre-Restore)` checkpoint before every restore, but there was no obvious way to use it, so a restore you regret felt irreversible.

## This PR
- **File > Undo last restore**: finds the newest `(Pre-Restore)` snapshot, confirms (naming the snapshot), and restores it.
- It does this by selecting that checkpoint and invoking the **normal restore flow**, so undo inherits every safety step (game-running guard, Steam Cloud warning, integrity validation) and a **fresh pre-restore snapshot of the current state**, meaning the undo is itself undoable / redoable. The high-stakes restore transaction is untouched.
- The restore prompt now also reassures the user that their current save is snapshotted first.
- `FindLatestPreRestoreCheckpoint`: a pure static helper (newest `(Pre-Restore)` or null).

Note: the **Steam Cloud warning** (one of the three QoL items) already existed in the restore flow, so it's left as is; this PR just adds a one-line reassurance about the snapshot.

## Tests
4 new `RestoreHarness` assertions (newest-checkpoint selection, ignores other backups, null on none/missing). Harness **174 -> 178**, Release green, app smoke-launched OK.

## Next
Auto-detect the DD2 save folder on first run (the other high-impact QoL item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)