### PR TITLE
feat: auto-detect the DD2 save folder (first-run + manual)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ All notable changes to Savedrake are recorded here. The format is based on
   automatically just before every restore, so a restore you regret is one click to reverse. It runs through the same
   safety checks as a normal restore (and snapshots your current save first, so you can redo). The restore prompt now
   also tells you the snapshot is taken. (#48)
+- Auto-detect your save folder: on first run (when no save folder is set yet) Savedrake offers the Dragon's Dogma 2
+  save folder it finds via Steam, so new users no longer have to hunt down the cryptic `…\userdata\<id>\2054970\
+  remote\win64_save` path. If you have more than one Steam profile it picks the most recently used and tells you.
+  There is also a File > Detect save folder you can run any time. It only ever fills the folder in after you confirm. (#49)
 
 ### Fixed
 - The updater builds its download URL with `Uri.EscapeDataString` on the version segment

--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -95,6 +95,7 @@ namespace RestoreHarness
                 Test_TieredRetention();   // change-aware autobackup (PR2): tiered-retention selector (buckets/cap/idempotent)
                 Test_PinHelpers();   // change-aware autobackup (PR3): pin filename-token helpers (detect/add/remove/round-trip)
                 Test_UndoRestore();   // QoL: find the latest (Pre-Restore) checkpoint for one-click undo restore
+                Test_DetectSaveFolder();   // QoL: enumerate DD2 save folders under a Steam root (auto-detect)
                 Test_RestoreReverify();   // P1: restore re-verifies a manifest-bearing backup; legacy backups unaffected
                 Test_ClassifyBackup();   // P1 UI: full Validated/Legacy/Corrupt classification for "Validate all"
                 Test_LogRedaction();   // P2: the rolling logger redacts the Steam account id and user profile path
@@ -546,6 +547,33 @@ namespace RestoreHarness
 
             string missing = Path.Combine(work, "undo_missing_" + Guid.NewGuid().ToString("N").Substring(0, 8));
             Check("missing folder -> null (no throw)", (string)find.Invoke(null, new object[] { missing }) == null);
+            Console.WriteLine();
+        }
+
+        static void Test_DetectSaveFolder()
+        {
+            // QoL: FindDd2SaveFoldersUnder enumerates <steamRoot>\userdata\<id>\2054970\remote\win64_save, ignores other
+            // appids, finds multiple Steam profiles, and is null-safe on a missing root.
+            Console.WriteLine("== Auto-detect DD2 save folder ==");
+            var find = SM("FindDd2SaveFoldersUnder");
+            System.Func<string, System.Collections.Generic.List<string>> F =
+                r => ((System.Collections.IEnumerable)find.Invoke(null, new object[] { r })).Cast<string>().ToList();
+
+            string root = NewDir("steam");
+            Check("no userdata folder -> empty", F(root).Count == 0);
+
+            string save1 = Path.Combine(root, "userdata", "111", "2054970", "remote", "win64_save");
+            Directory.CreateDirectory(save1);
+            var one = F(root);
+            Check("finds the one DD2 save folder", one.Count == 1 && one[0] == save1, "got=" + string.Join(",", one));
+
+            Directory.CreateDirectory(Path.Combine(root, "userdata", "222", "9999999", "remote", "win64_save"));
+            Check("ignores non-DD2 appids", F(root).Count == 1);
+
+            Directory.CreateDirectory(Path.Combine(root, "userdata", "333", "2054970", "remote", "win64_save"));
+            Check("finds both DD2 Steam profiles", F(root).Count == 2);
+
+            Check("missing steam root -> empty (no throw)", F(Path.Combine(work, "no_steam_" + Guid.NewGuid().ToString("N").Substring(0, 6))).Count == 0);
             Console.WriteLine();
         }
 

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -242,6 +242,11 @@ namespace Savedrake
             undoRestoreMenuItem.Click += (s, e) => UndoLastRestore();
             fileToolStripMenuItem.DropDownItems.Add(undoRestoreMenuItem);
 
+            // File menu: "Detect save folder" (QoL) — auto-find the DD2 save folder via Steam.
+            ToolStripMenuItem detectMenuItem = new ToolStripMenuItem("Detect save folder");
+            detectMenuItem.Click += (s, e) => DetectAndOfferSaveFolder(true);
+            fileToolStripMenuItem.DropDownItems.Add(detectMenuItem);
+
             // Files > Settings: opt-in "clean up old backups" toggles (change-aware autobackup, part 2). OFF by default,
             // so existing behavior (autobackup stops at the limit) is unchanged until the user opts in. Turning it on
             // asks for confirmation because it enables automatic removal of old autobackups.
@@ -1451,6 +1456,86 @@ namespace Savedrake
         private void Button_br_1_Click(object sender, EventArgs e)
         {
             PromptForFolderSelection();
+        }
+
+        // ---- Auto-detect the DD2 save folder (QoL) ----
+        private const string Dd2AppId = "2054970";
+
+        // The Steam install root from the registry, or a common default. null if not found.
+        private static string GetSteamRoot()
+        {
+            try
+            {
+                using (var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(@"Software\Valve\Steam"))
+                {
+                    string p = key?.GetValue("SteamPath") as string;
+                    if (!string.IsNullOrEmpty(p)) { p = p.Replace('/', '\\'); if (Directory.Exists(p)) return p; }
+                }
+            }
+            catch { }
+            try
+            {
+                string def = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam");
+                if (Directory.Exists(def)) return def;
+            }
+            catch { }
+            return null;
+        }
+
+        // Existing DD2 save folders under a Steam root: <root>\userdata\<id>\2054970\remote\win64_save. Most-recently-used
+        // first. Static + parameterised so the headless harness can test it against a crafted tree.
+        private static List<string> FindDd2SaveFoldersUnder(string steamRoot)
+        {
+            var found = new List<string>();
+            try
+            {
+                string userdata = Path.Combine(steamRoot, "userdata");
+                if (!Directory.Exists(userdata)) return found;
+                foreach (string profile in Directory.GetDirectories(userdata))
+                {
+                    string save = Path.Combine(profile, Dd2AppId, "remote", "win64_save");
+                    if (Directory.Exists(save)) found.Add(save);
+                }
+            }
+            catch { }
+            found.Sort((a, b) => DirLastWriteUtc(b).CompareTo(DirLastWriteUtc(a)));
+            return found;
+        }
+
+        private static DateTime DirLastWriteUtc(string d) { try { return Directory.GetLastWriteTimeUtc(d); } catch { return DateTime.MinValue; } }
+
+        private static List<string> FindDd2SaveFolders()
+        {
+            string root = GetSteamRoot();
+            return root != null ? FindDd2SaveFoldersUnder(root) : new List<string>();
+        }
+
+        // Offer the detected DD2 save folder. 'manual' = the user clicked Detect (so we tell them when nothing is found);
+        // on first run we stay quiet if there is nothing to suggest. Only SETS the folder on a Yes (never silently).
+        private void DetectAndOfferSaveFolder(bool manual)
+        {
+            List<string> found;
+            try { found = FindDd2SaveFolders(); } catch { found = new List<string>(); }
+            if (found.Count == 0)
+            {
+                if (manual)
+                    MessageBox.Show("Savedrake could not find a Dragon's Dogma 2 save folder automatically. Make sure Steam " +
+                        "is installed and you have run the game at least once, or set the folder with Browse.",
+                        "Detect save folder", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+            string best = found[0];
+            string extra = found.Count > 1
+                ? "\n\n(" + (found.Count - 1) + " other Steam profile" + (found.Count > 2 ? "s were" : " was") + " also found; this is the most recently used.)"
+                : "";
+            DialogResult r = MessageBox.Show(
+                "Found your Dragon's Dogma 2 saves here:\n\n" + best + extra + "\n\nUse this folder?",
+                "Detect save folder", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+            if (r == DialogResult.Yes)
+            {
+                textbox1.Text = best;
+                Status.Text = "Save game folder set automatically.";
+            }
         }
 
         private void PromptForFolderSelection()
@@ -3723,6 +3808,8 @@ namespace Savedrake
         {
             isLoading = true;
             LoadSettings();
+            // First run: if no save folder is configured yet, offer to auto-detect the DD2 save folder via Steam.
+            if (string.IsNullOrWhiteSpace(textbox1.Text)) DetectAndOfferSaveFolder(false);
             //randomlyGeneratedToolStripMenuItem.Checked = true;
             LoadBackupHistory();
 


### PR DESCRIPTION
Last of the three high-impact QoL items: remove the worst onboarding friction.

## Why
The Steam save path (`…\userdata\<id>\2054970\remote\win64_save`) is cryptic and the #1 thing new users fumble. Savedrake already knows the pattern, so it can just find it.

## This PR
- `GetSteamRoot` (registry `SteamPath`, with a default fallback) + `FindDd2SaveFoldersUnder` (pure, parameterised: enumerates `userdata\*\2054970\remote\win64_save`, most-recently-used first) + `FindDd2SaveFolders`.
- **First run** (no save folder set yet): `Main_Load` offers the detected folder. With multiple Steam profiles it picks the most recently used and says so.
- **File > Detect save folder** runs it manually any time.
- It **only ever sets the folder after you confirm** (never silently), and never touches saves.

## Tests
5 new `RestoreHarness` assertions (finds one, ignores other appids, finds multiple profiles, null-safe on missing root). Harness **178 -> 183**, Release green, app smoke-launched OK (no spurious prompt when a folder is already configured).

## QoL set complete
- Undo last restore (#48) ✓
- Steam Cloud warning — already existed in the restore flow ✓
- Auto-detect save folder (this) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)