### PR TITLE
feat: QoL polish - friendly backup times + backup-location warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ All notable changes to Savedrake are recorded here. The format is based on
   save folder it finds via Steam, so new users no longer have to hunt down the cryptic `…\userdata\<id>\2054970\
   remote\win64_save` path. If you have more than one Steam profile it picks the most recently used and tells you.
   There is also a File > Detect save folder you can run any time. It only ever fills the folder in after you confirm. (#49)
+- The backup list now shows friendly times ("just now", "5 min ago", "yesterday", "3 days ago") instead of a raw
+  timestamp; older backups still show the date. Sorting by date is unchanged. (#50)
+- Backup-location heads-up: when you pick a backup folder that is in a cloud-synced folder (OneDrive, Dropbox, etc.)
+  or on the same drive as your saves, Savedrake now gives a one-time, non-blocking note about the trade-off. (#50)
 
 ### Fixed
 - The updater builds its download URL with `Uri.EscapeDataString` on the version segment

--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -96,6 +96,8 @@ namespace RestoreHarness
                 Test_PinHelpers();   // change-aware autobackup (PR3): pin filename-token helpers (detect/add/remove/round-trip)
                 Test_UndoRestore();   // QoL: find the latest (Pre-Restore) checkpoint for one-click undo restore
                 Test_DetectSaveFolder();   // QoL: enumerate DD2 save folders under a Steam root (auto-detect)
+                Test_FriendlyTime();   // QoL: friendly relative time in the backup list
+                Test_BackupLocationWarning();   // QoL: cloud-synced / same-drive backup-location warning
                 Test_RestoreReverify();   // P1: restore re-verifies a manifest-bearing backup; legacy backups unaffected
                 Test_ClassifyBackup();   // P1 UI: full Validated/Legacy/Corrupt classification for "Validate all"
                 Test_LogRedaction();   // P2: the rolling logger redacts the Steam account id and user profile path
@@ -574,6 +576,39 @@ namespace RestoreHarness
             Check("finds both DD2 Steam profiles", F(root).Count == 2);
 
             Check("missing steam root -> empty (no throw)", F(Path.Combine(work, "no_steam_" + Guid.NewGuid().ToString("N").Substring(0, 6))).Count == 0);
+            Console.WriteLine();
+        }
+
+        static void Test_FriendlyTime()
+        {
+            // QoL: FriendlyTime renders a backup's age as a human phrase, falling back to an absolute date for old ones.
+            Console.WriteLine("== QoL: friendly relative time ==");
+            var ft = SM("FriendlyTime");
+            System.Func<DateTime, string> F = d => (string)ft.Invoke(null, new object[] { d });
+            Check("recent -> 'just now'", F(DateTime.Now.AddSeconds(-5)) == "just now");
+            Check("minutes -> 'N min ago'", F(DateTime.Now.AddMinutes(-5)).EndsWith("min ago"));
+            Check("hours -> 'N hours ago'", F(DateTime.Now.AddHours(-3)) == "3 hours ago");
+            Check("one hour -> singular", F(DateTime.Now.AddMinutes(-61)) == "1 hour ago");
+            Check("a day -> 'yesterday'", F(DateTime.Now.AddHours(-25)) == "yesterday");
+            Check("several days -> 'N days ago'", F(DateTime.Now.AddDays(-3)) == "3 days ago");
+            Check("old -> absolute date (no 'ago')", !F(DateTime.Now.AddDays(-30)).Contains("ago"));
+            Console.WriteLine();
+        }
+
+        static void Test_BackupLocationWarning()
+        {
+            // QoL: BackupLocationWarning advises (returns a string) for risky backup folders, null when fine.
+            Console.WriteLine("== QoL: backup-location warning ==");
+            var w = SM("BackupLocationWarning");
+            System.Func<string, string, string> W = (s, b) => (string)w.Invoke(null, new object[] { s, b });
+            Check("different local drive -> no warning", W(@"C:\Saves", @"D:\Backups") == null);
+            Check("backup inside save -> warned", W(@"C:\Saves", @"C:\Saves\backups") != null);
+            Check("backup == save -> warned", W(@"C:\Saves", @"C:\Saves") != null);
+            string cloud = W(@"C:\Saves", @"C:\Users\x\OneDrive\Backups");
+            Check("OneDrive folder -> cloud warning", cloud != null && cloud.ToLower().Contains("cloud"));
+            string sameDrive = W(@"C:\Saves", @"C:\Other\Backups");
+            Check("same drive -> drive warning", sameDrive != null && sameDrive.ToLower().Contains("drive"));
+            Check("empty inputs -> null", W("", "") == null);
             Console.WriteLine();
         }
 

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -1538,6 +1538,49 @@ namespace Savedrake
             }
         }
 
+        // QoL: a human-friendly relative time for the backup list ("just now", "5 min ago", "2 hours ago", "yesterday",
+        // "3 days ago", else an absolute date). DISPLAY ONLY — the list still sorts by the FileInfo in each row's Tag
+        // (ListViewItemDateComparer), so changing this text never affects ordering.
+        private static string FriendlyTime(DateTime when)
+        {
+            TimeSpan ago = DateTime.Now - when;
+            if (ago < TimeSpan.Zero) return when.ToString("MMM d, h:mm tt");
+            if (ago.TotalSeconds < 45) return "just now";
+            if (ago.TotalMinutes < 60) return (int)Math.Round(ago.TotalMinutes) + " min ago";
+            if (ago.TotalHours < 24) { int h = (int)Math.Round(ago.TotalHours); return h + (h == 1 ? " hour ago" : " hours ago"); }
+            if (ago.TotalDays < 2) return "yesterday";
+            if (ago.TotalDays < 8) return (int)ago.TotalDays + " days ago";
+            return when.ToString("MMM d, h:mm tt");
+        }
+
+        // QoL: a one-line caution about a chosen backup folder, or null if it's fine. Advisory, not blocking. Flags a
+        // backup folder inside the save folder, in a cloud-synced folder (OneDrive/Dropbox/Google Drive — sync churn),
+        // or on the same drive as the saves (one disk failure loses both). Pure/static so the harness can test it.
+        private static string BackupLocationWarning(string saveDir, string backupDir)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(saveDir) || string.IsNullOrWhiteSpace(backupDir)) return null;
+                string save = Path.GetFullPath(saveDir).TrimEnd('\\', '/');
+                string backup = Path.GetFullPath(backupDir).TrimEnd('\\', '/');
+
+                if (string.Equals(backup, save, StringComparison.OrdinalIgnoreCase) ||
+                    backup.StartsWith(save + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+                    return "Your backup folder is inside your save folder. Pick a separate folder so backups don't pile up inside your saves.";
+
+                string lower = "\\" + backup.ToLowerInvariant() + "\\";
+                if (lower.Contains("\\onedrive") || lower.Contains("\\dropbox") || lower.Contains("\\google drive") || lower.Contains("\\googledrive"))
+                    return "Your backup folder is in a cloud-synced folder (OneDrive, Dropbox, etc.). That works, but cloud sync can be slow or conflict during a backup. A plain local folder is more reliable.";
+
+                string sroot = Path.GetPathRoot(save), broot = Path.GetPathRoot(backup);
+                if (!string.IsNullOrEmpty(sroot) && string.Equals(sroot, broot, StringComparison.OrdinalIgnoreCase))
+                    return "Your backups are on the same drive as your saves. If that drive fails you would lose both. A different drive (or an extra copy elsewhere) is safer.";
+
+                return null;
+            }
+            catch { return null; }
+        }
+
         private void PromptForFolderSelection()
         {
             using (var dialog = new CommonOpenFileDialog())
@@ -1642,6 +1685,10 @@ namespace Savedrake
                     else
                     {
                         textbox2.Text = selectedPath; // Set the selected folder path to textbox2
+                        // QoL: advise (don't block) if the chosen folder is cloud-synced or on the same drive as saves.
+                        string locWarn = BackupLocationWarning(textbox1.Text, selectedPath);
+                        if (locWarn != null)
+                            MessageBox.Show(locWarn, "Backup location", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     }
                 }
             }
@@ -2913,7 +2960,7 @@ namespace Savedrake
                         // "Validated"/"Corrupt" runs only on demand via the "Validate all backups" right-click action,
                         // because hashing every backup on every refresh would be slow.
                         bool hasManifest = zip.Entries.Any(en => IsManifestEntry(en.FileName));
-                        ListViewItem item = new ListViewItem(new[] { fileInfo.Name, fileInfo.CreationTime.ToString(),
+                        ListViewItem item = new ListViewItem(new[] { fileInfo.Name, FriendlyTime(fileInfo.CreationTime),
                             hasManifest ? "Protected" : "Legacy" });
                         item.UseItemStyleForSubItems = false;
                         item.SubItems[2].ForeColor = hasManifest ? System.Drawing.Color.SteelBlue : System.Drawing.Color.Gray;


### PR DESCRIPTION
Two more QoL improvements from the polish list.

## Friendly times in the backup list
The list showed a raw timestamp (`6/20/2026 2:32:05 PM`); it now shows **"just now" / "5 min ago" / "yesterday" / "3 days ago"**, with an absolute date for older backups. Sorting by date is **unchanged** because the list sorts by the `FileInfo` stored in each row's `Tag`, not the displayed text, so `FriendlyTime` is purely cosmetic.

## Backup-location heads-up
When you pick a backup folder that's **in a cloud-synced folder** (OneDrive, Dropbox, Google Drive) or **on the same drive as your saves**, Savedrake now shows a one-time, **non-blocking** note about the trade-off (cloud sync can conflict during a backup; same-drive means one disk failure loses both). It never blocks, and inside-the-save-folder was already prevented at Browse time.

## Tests
`FriendlyTime` and `BackupLocationWarning` are pure static helpers, **13 new `RestoreHarness` assertions** (relative-time buckets incl. singular/plural and the absolute fallback; cloud / same-drive / inside-save / clean cases). Harness **183 -> 196**, Release green, app smoke-launched OK.

## Remaining QoL
Name/note backups and the autobackup-active indicator are left for the UI rebuild (they want proper UI surfaces); accessibility is best done during that rebuild too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)