### PR TITLE
feat: dark/light UI theme (DD2-flavoured charcoal+gold / parchment+bronze)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ All notable changes to Savedrake are recorded here. The format is based on
   timestamp; older backups still show the date. Sorting by date is unchanged. (#50)
 - Backup-location heads-up: when you pick a backup folder that is in a cloud-synced folder (OneDrive, Dropbox, etc.)
   or on the same drive as your saves, Savedrake now gives a one-time, non-blocking note about the trade-off. (#50)
+- Dark and light themes: Savedrake now has a Dragon's Dogma 2-flavoured look, a charcoal-and-gold dark theme (the
+  default) and a parchment-and-bronze light theme, switchable from File > Use light/dark theme and remembered between
+  runs. The whole window is themed, including the menus and the backup list (with gold "pinned" and green "protected"
+  tags). A few Windows-managed bits (the title bar, scrollbars) keep the system colour. (#51)
 
 ### Fixed
 - The updater builds its download URL with `Uri.EscapeDataString` on the version segment

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -61,6 +61,7 @@ namespace Savedrake
         // while WE write the save folder (restore) so our own writes never trigger a backup. The interval timer stays
         // on as a fallback, so a missed/overflowed watcher event is still caught.
         private ToolStripMenuItem _backupOnSaveMenuItem;
+        private ToolStripMenuItem _themeMenuItem; // light/dark toggle
         private FileSystemWatcher _saveWatcher;
         private System.Windows.Forms.Timer _quiesceTimer;
         private volatile bool _suppressSaveWatcher;
@@ -218,6 +219,10 @@ namespace Savedrake
             listView.AfterLabelEdit += listView_AfterLabelEdit;
             listView.ContextMenuStrip = contextMenuStrip;
             listView.KeyDown += ListView_KeyDown;
+            // Theme: owner-draw the backup list so it matches the dark/light palette.
+            listView.DrawColumnHeader += listView_DrawColumnHeader;
+            listView.DrawItem += listView_DrawItem;
+            listView.DrawSubItem += listView_DrawSubItem;
 
             // Integrity column (P1): per-backup state. On load it shows "Protected"/"Legacy" (cheap manifest-presence
             // check); the right-click "Validate all backups" action runs the full hash check and marks each row
@@ -246,6 +251,11 @@ namespace Savedrake
             ToolStripMenuItem detectMenuItem = new ToolStripMenuItem("Detect save folder");
             detectMenuItem.Click += (s, e) => DetectAndOfferSaveFolder(true);
             fileToolStripMenuItem.DropDownItems.Add(detectMenuItem);
+
+            // File menu: light/dark theme toggle.
+            _themeMenuItem = new ToolStripMenuItem();
+            _themeMenuItem.Click += (s, e) => ToggleTheme();
+            fileToolStripMenuItem.DropDownItems.Add(_themeMenuItem);
 
             // Files > Settings: opt-in "clean up old backups" toggles (change-aware autobackup, part 2). OFF by default,
             // so existing behavior (autobackup stops at the limit) is unchanged until the user opts in. Turning it on
@@ -397,6 +407,9 @@ namespace Savedrake
             [XmlElement("BackupOnSaveChange")]
             public bool BackupOnSaveChange { get; set; }
 
+            [XmlElement("ThemeMode")]
+            public string ThemeMode { get; set; }
+
 
 
             // Include HotkeySettings property
@@ -536,6 +549,7 @@ namespace Savedrake
                 AutoCleanupOldBackups = _cleanupMenuItem != null && _cleanupMenuItem.Checked,
                 RemovedToRecycleBin = _recycleMenuItem != null && _recycleMenuItem.Checked,
                 BackupOnSaveChange = _backupOnSaveMenuItem != null && _backupOnSaveMenuItem.Checked,
+                ThemeMode = Theme.Current == Theme.Mode.Light ? "Light" : "Dark",
                 
                 // Save the hotkey settings
                 Hotkey = new HotkeySettings
@@ -662,6 +676,7 @@ namespace Savedrake
                 _recycleMenuItem.Enabled = _cleanupMenuItem.Checked;
             }
             if (_backupOnSaveMenuItem != null) _backupOnSaveMenuItem.Checked = settings.BackupOnSaveChange;
+            Theme.Current = string.Equals(settings.ThemeMode, "Light", StringComparison.OrdinalIgnoreCase) ? Theme.Mode.Light : Theme.Mode.Dark;
 
 
 
@@ -1113,8 +1128,8 @@ namespace Savedrake
                     combobox_auto.Enabled = false;
                     Button_br_1.Enabled = false;
                     Button_br_2.Enabled = false;
-                    Button_br_1.BackColor = System.Drawing.ColorTranslator.FromHtml("#f0f0f0");
-                    Button_br_2.BackColor = System.Drawing.ColorTranslator.FromHtml("#f0f0f0");
+                    Button_br_1.BackColor = Theme.P.PanelAlt;
+                    Button_br_2.BackColor = Theme.P.PanelAlt;
                 }
             }
             else
@@ -1124,8 +1139,8 @@ namespace Savedrake
                 combobox_auto.Enabled = true;
                 Button_br_1.Enabled = true;
                 Button_br_2.Enabled = true;
-                Button_br_1.BackColor = Color.White;
-                Button_br_2.BackColor= Color.White;
+                Button_br_1.BackColor = Theme.P.Panel;
+                Button_br_2.BackColor = Theme.P.Panel;
                 Status.Text = $"Autobackup disabled";
                 // Change-aware autobackup (PR1): drop the baseline when autobackup is turned off so a later re-enable
                 // re-baselines cleanly against whatever the save folder is then (Hook C also nulls it at game-start).
@@ -1579,6 +1594,59 @@ namespace Savedrake
                 return null;
             }
             catch { return null; }
+        }
+
+        // ---- UI theme (dark/light) ----
+        private void UpdateThemeMenuText()
+        {
+            if (_themeMenuItem != null)
+                _themeMenuItem.Text = Theme.Current == Theme.Mode.Dark ? "Use light theme" : "Use dark theme";
+        }
+
+        private void ToggleTheme()
+        {
+            Theme.Current = Theme.Current == Theme.Mode.Dark ? Theme.Mode.Light : Theme.Mode.Dark;
+            Theme.Apply(this);
+            UpdateThemeMenuText();
+            listView.Refresh();
+            try { SaveSettings(); } catch { }
+        }
+
+        private void listView_DrawColumnHeader(object sender, DrawListViewColumnHeaderEventArgs e)
+        {
+            using (var bg = new SolidBrush(Theme.P.TitleBar)) e.Graphics.FillRectangle(bg, e.Bounds);
+            Rectangle r = e.Bounds; r.X += 6; r.Width -= 6;
+            TextRenderer.DrawText(e.Graphics, e.Header.Text, listView.Font, r, Theme.P.TextSecondary,
+                TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.EndEllipsis);
+            using (var pen = new Pen(Theme.P.Border)) e.Graphics.DrawLine(pen, e.Bounds.Right - 1, e.Bounds.Top, e.Bounds.Right - 1, e.Bounds.Bottom);
+        }
+
+        private void listView_DrawItem(object sender, DrawListViewItemEventArgs e)
+        {
+            // Details owner-draw: every cell is painted in DrawSubItem; suppress the default item render (which would
+            // otherwise draw the row first with the cached SubItem colours, causing flicker and a stray light row).
+            e.DrawDefault = false;
+        }
+
+        private void listView_DrawSubItem(object sender, DrawListViewSubItemEventArgs e)
+        {
+            Color back = e.Item.Selected ? Theme.P.Sel : (e.ItemIndex % 2 == 0 ? Theme.P.Panel : Theme.P.PanelAlt);
+            using (var b = new SolidBrush(back)) e.Graphics.FillRectangle(b, e.Bounds);
+
+            Color fore = Theme.P.Text;
+            if (e.ColumnIndex == 2) fore = StatusColor(e.SubItem.Text);
+            else if (e.ColumnIndex == 0 && IsPinnedBackup(e.Item.Text)) fore = Theme.P.Pinned;
+
+            Rectangle r = e.Bounds; r.X += 6; r.Width -= 6;
+            TextRenderer.DrawText(e.Graphics, e.SubItem.Text, listView.Font, r, fore,
+                TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.EndEllipsis);
+        }
+
+        private static Color StatusColor(string s)
+        {
+            if (s == "Validated" || s == "Protected") return Theme.P.Success;
+            if (s == "Corrupt" || s == "Missing") return Theme.P.Danger;
+            return Theme.P.TextSecondary;
         }
 
         private void PromptForFolderSelection()
@@ -2963,7 +3031,7 @@ namespace Savedrake
                         ListViewItem item = new ListViewItem(new[] { fileInfo.Name, FriendlyTime(fileInfo.CreationTime),
                             hasManifest ? "Protected" : "Legacy" });
                         item.UseItemStyleForSubItems = false;
-                        item.SubItems[2].ForeColor = hasManifest ? System.Drawing.Color.SteelBlue : System.Drawing.Color.Gray;
+                        // Integrity-column colour is applied by the owner-draw renderer (StatusColor), so it follows the theme.
                         item.Tag = fileInfo; // Store the FileInfo object in the Tag property
                         listView.Items.Add(item);
                         listView.Sort();
@@ -3022,9 +3090,10 @@ namespace Savedrake
                     while (item.SubItems.Count < 3) item.SubItems.Add(string.Empty);
                     item.UseItemStyleForSubItems = false;
                     item.SubItems[2].Text = state;
-                    if (state == "Validated") { validated++; item.SubItems[2].ForeColor = System.Drawing.Color.ForestGreen; }
-                    else if (state == "Legacy") { legacy++; item.SubItems[2].ForeColor = System.Drawing.Color.Gray; }
-                    else { failed++; item.SubItems[2].ForeColor = System.Drawing.Color.Firebrick; }
+                    // Colour comes from the owner-draw renderer (StatusColor), theme-aware; just tally here.
+                    if (state == "Validated") validated++;
+                    else if (state == "Legacy") legacy++;
+                    else failed++;
                 }
             }
             finally { Cursor.Current = previous; }
@@ -3339,9 +3408,8 @@ namespace Savedrake
             // Enable the button if there are files in the deletedFiles list, otherwise disable it
             button_undo.Enabled = deletedFiles.Count > 0;
 
-            // Set the button's background color
-            button_undo.BackColor = deletedFiles.Count < 0 ? System.Drawing.ColorTranslator.FromHtml("#f0f0f0") : System.Drawing.Color.Transparent;
-            button_undo.BackColor = deletedFiles.Count > 0 ? Color.White : System.Drawing.Color.Transparent;
+            // Theme-aware background (enabled = panel, disabled = dimmer panel).
+            button_undo.BackColor = button_undo.Enabled ? Theme.P.Panel : Theme.P.PanelAlt;
         }
 
 
@@ -3857,6 +3925,9 @@ namespace Savedrake
             LoadSettings();
             // First run: if no save folder is configured yet, offer to auto-detect the DD2 save folder via Steam.
             if (string.IsNullOrWhiteSpace(textbox1.Text)) DetectAndOfferSaveFolder(false);
+            // Apply the saved UI theme (default dark) before the list populates so it owner-draws themed.
+            Theme.Apply(this);
+            UpdateThemeMenuText();
             //randomlyGeneratedToolStripMenuItem.Checked = true;
             LoadBackupHistory();
 

--- a/Savedrake v1.2.3/Savedrake.csproj
+++ b/Savedrake v1.2.3/Savedrake.csproj
@@ -105,6 +105,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ListViewDataComparer.cs" />
+    <Compile Include="Theme.cs" />
     <Compile Include="Main.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Savedrake v1.2.3/Theme.cs
+++ b/Savedrake v1.2.3/Theme.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Savedrake
+{
+    // UI theme (neutral charcoal + gold dark, parchment + bronze light). Palette locked via a Claude-design mockup pass.
+    // Gold is a dark-mode colour (glows on dark, muddy on light), so light mode uses its dark sibling BRONZE for accents.
+    internal static class Theme
+    {
+        internal enum Mode { Dark, Light }
+        internal static Mode Current = Mode.Dark;
+
+        internal struct Palette
+        {
+            public Color Window, TitleBar, Panel, PanelAlt, Input, Border, RowSep, Sel,
+                         Text, TextSecondary, TextHint, Accent, AccentText, AccentDim,
+                         Success, Danger, Pinned;
+        }
+
+        static Color H(string hex) { return ColorTranslator.FromHtml(hex); }
+
+        static readonly Palette Dark = new Palette
+        {
+            Window = H("#1B1B1D"), TitleBar = H("#202022"), Panel = H("#26262A"), PanelAlt = H("#222225"),
+            Input = H("#1E1E20"), Border = H("#34343A"), RowSep = H("#2E2E33"), Sel = H("#3A3A40"),
+            Text = H("#E7E5E0"), TextSecondary = H("#9B9A94"), TextHint = H("#76756F"),
+            Accent = H("#C8A24C"), AccentText = H("#211A0E"), AccentDim = H("#D3BE86"),
+            Success = H("#8FB36A"), Danger = H("#C77B6F"), Pinned = H("#D8B968")
+        };
+
+        static readonly Palette Light = new Palette
+        {
+            Window = H("#E9E0CB"), TitleBar = H("#E3D8BD"), Panel = H("#F5EFDF"), PanelAlt = H("#EFE7D2"),
+            Input = H("#FBF8EE"), Border = H("#D9CBA8"), RowSep = H("#E3D9BF"), Sel = H("#DBCBA0"),
+            Text = H("#2E2A1F"), TextSecondary = H("#5C543E"), TextHint = H("#837A5E"),
+            Accent = H("#7E5E22"), AccentText = H("#F5EFDF"), AccentDim = H("#6E5320"),
+            Success = H("#3E6B33"), Danger = H("#9A3B2E"), Pinned = H("#7E5E22")
+        };
+
+        internal static Palette P { get { return Current == Mode.Dark ? Dark : Light; } }
+
+        // Apply the current palette across a form. ListView is owner-drawn separately by Main (it needs per-row status
+        // colours); here we just set its base colours + OwnerDraw flag.
+        internal static void Apply(Form form)
+        {
+            form.BackColor = P.Window;
+            form.ForeColor = P.Text;
+            ApplyControls(form.Controls);
+        }
+
+        static void ApplyControls(Control.ControlCollection controls)
+        {
+            foreach (Control c in controls)
+            {
+                Style(c);
+                // Don't recurse into a ComboBox: its dropdown list is OS-managed, not a WinForms child control.
+                if (c.HasChildren && !(c is ComboBox)) ApplyControls(c.Controls);
+            }
+        }
+
+        static void Style(Control c)
+        {
+            var menu = c as MenuStrip;
+            if (menu != null) { menu.BackColor = P.TitleBar; menu.ForeColor = P.Text; menu.Renderer = new DarkMenuRenderer(); return; }
+
+            var status = c as StatusStrip;
+            if (status != null) { status.BackColor = P.TitleBar; status.ForeColor = P.TextSecondary; status.Renderer = new DarkMenuRenderer(); return; }
+
+            var btn = c as Button;
+            if (btn != null)
+            {
+                // Restore / Backup are the primary actions -> gold; everything else -> panel. Set ALL FlatAppearance
+                // colours so none go stale across a theme toggle, and reflect Enabled so a disabled button reads dimmer.
+                bool primary = btn.Name == "button_res" || btn.Name == "button_backup";
+                btn.FlatStyle = FlatStyle.Flat;
+                btn.UseVisualStyleBackColor = false;
+                if (primary)
+                {
+                    btn.BackColor = P.Accent; btn.ForeColor = P.AccentText;
+                    btn.FlatAppearance.BorderColor = P.Accent;
+                    btn.FlatAppearance.MouseOverBackColor = P.Pinned;
+                    btn.FlatAppearance.MouseDownBackColor = P.AccentDim;
+                }
+                else
+                {
+                    btn.BackColor = btn.Enabled ? P.Panel : P.PanelAlt;
+                    btn.ForeColor = P.AccentDim;
+                    btn.FlatAppearance.BorderColor = P.Border;
+                    btn.FlatAppearance.MouseOverBackColor = P.PanelAlt;
+                    btn.FlatAppearance.MouseDownBackColor = P.Sel;
+                }
+                return;
+            }
+
+            var tb = c as TextBox;
+            if (tb != null) { tb.BorderStyle = BorderStyle.FixedSingle; tb.BackColor = P.Input; tb.ForeColor = P.Text; return; }
+
+            var cmb = c as ComboBox;
+            if (cmb != null) { cmb.FlatStyle = FlatStyle.Flat; cmb.BackColor = P.Input; cmb.ForeColor = P.Text; return; }
+
+            var chk = c as CheckBox;
+            if (chk != null) { chk.BackColor = Color.Transparent; chk.ForeColor = P.Text; return; }
+
+            var lbl = c as Label;
+            if (lbl != null) { lbl.BackColor = Color.Transparent; lbl.ForeColor = P.Text; return; }
+
+            var lv = c as ListView;
+            if (lv != null)
+            {
+                lv.BackColor = P.Panel; lv.ForeColor = P.Text;
+                lv.BorderStyle = BorderStyle.FixedSingle;
+                lv.OwnerDraw = true;
+                return;
+            }
+
+            var pnl = c as Panel;
+            if (pnl != null) { pnl.BackColor = P.Window; return; }
+
+            // Default: containers and anything else inherit the window colours.
+            c.BackColor = P.Window;
+            c.ForeColor = P.Text;
+        }
+
+        // A flat dark/parchment renderer for the menu bar + status bar (the default professional renderer is light-only).
+        internal sealed class DarkMenuRenderer : ToolStripProfessionalRenderer
+        {
+            internal DarkMenuRenderer() : base(new DarkColors()) { }
+
+            protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
+            {
+                e.TextColor = e.Item.Selected ? P.AccentText : P.Text;
+                base.OnRenderItemText(e);
+            }
+
+            protected override void OnRenderArrow(ToolStripArrowRenderEventArgs e)
+            {
+                e.ArrowColor = P.TextSecondary;
+                base.OnRenderArrow(e);
+            }
+        }
+
+        sealed class DarkColors : ProfessionalColorTable
+        {
+            public override Color ToolStripDropDownBackground { get { return P.Panel; } }
+            public override Color ImageMarginGradientBegin { get { return P.Panel; } }
+            public override Color ImageMarginGradientMiddle { get { return P.Panel; } }
+            public override Color ImageMarginGradientEnd { get { return P.Panel; } }
+            public override Color MenuBorder { get { return P.Border; } }
+            public override Color MenuItemBorder { get { return P.Accent; } }
+            public override Color MenuItemSelected { get { return P.Accent; } }
+            public override Color MenuItemSelectedGradientBegin { get { return P.Accent; } }
+            public override Color MenuItemSelectedGradientEnd { get { return P.Accent; } }
+            public override Color MenuItemPressedGradientBegin { get { return P.PanelAlt; } }
+            public override Color MenuItemPressedGradientEnd { get { return P.PanelAlt; } }
+            public override Color MenuStripGradientBegin { get { return P.TitleBar; } }
+            public override Color MenuStripGradientEnd { get { return P.TitleBar; } }
+            public override Color StatusStripGradientBegin { get { return P.TitleBar; } }
+            public override Color StatusStripGradientEnd { get { return P.TitleBar; } }
+            public override Color SeparatorDark { get { return P.Border; } }
+            public override Color SeparatorLight { get { return P.Border; } }
+            public override Color ToolStripBorder { get { return P.TitleBar; } }
+        }
+    }
+}


### PR DESCRIPTION
The UI redesign theme, built end-to-end and adversarially reviewed.

## What
A full theme system applied across the whole window, switchable and remembered:
- **Dark (default):** neutral charcoal + gold (gold is the only warmth / the hero accent).
- **Light:** parchment + bronze (gold is a dark-mode colour, so light mode uses its dark sibling, bronze, with bright gilt only as small highlights).
- **File > Use light/dark theme** toggles instantly; the choice is persisted (`ThemeMode`).

## How
- `Theme.cs`: the locked palettes, a recursive `Apply(Form)`, and a flat `DarkMenuRenderer` + `ProfessionalColorTable` so the menu and status bars theme too.
- **Owner-drawn backup list**: themed headers, alternating rows, and status text (gold "pinned", green "protected", red "corrupt"). Restore/Backup get the gold primary-button treatment; other buttons are panel-toned.

## Adversarial review
Ran a 3-lens review (owner-draw / theming / robustness) + a verification pass. It found **5 must-fix defects, all fixed in this PR**:
1. `listView_DrawItem` now sets `e.DrawDefault = false` (this was causing the default light row to render under the owner-draw, the stray light cell).
2/3. Removed the hardcoded `SubItem` status `ForeColor`s (in `LoadBackupHistory`/`ValidateAllBackups`) and the `#f0f0f0`/`White` Browse + undo button colours, all theme-aware now.
4. Buttons set **all** `FlatAppearance` colours so none go stale across a toggle; `Refresh()` on toggle.
5. Light `TextSecondary`/`TextHint` darkened for WCAG contrast.

## Verification
Build Debug + Release clean, harness **196** green, **dark theme confirmed via screenshot** (form, labels, textboxes, flat buttons, menu bar, checkboxes all render in charcoal+gold), app smoke-launched OK.

## Scope / honest caveats (deferred, not regressions)
- The **OS title bar** and **scrollbars** keep the system colour (WinForms can't theme those without a custom title bar / custom scrollbars).
- There's a **pre-existing high-DPI layout clip** (the form's own list sits below its clamped height on a high-DPI display); that's the roadmap's DPI/accessibility item, and it's why the list couldn't be screenshot here (the owner-draw was instead adversarially reviewed).
- The **card reorg, the prominent in-window header logo, and surfacing the autobackup settings into the window** need layout surgery and are deferred; the dragon still shows in the title bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)