### PR TITLE
feat: theme the native title bar via DWM (charcoal dark / parchment light)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,10 @@ All notable changes to Savedrake are recorded here. The format is based on
 - Dark and light themes: Savedrake now has a Dragon's Dogma 2-flavoured look, a charcoal-and-gold dark theme (the
   default) and a parchment-and-bronze light theme, switchable from File > Use light/dark theme and remembered between
   runs. The whole window is themed, including the menus and the backup list (with gold "pinned" and green "protected"
-  tags). A few Windows-managed bits (the title bar, scrollbars) keep the system colour. (#51)
+  tags). (#51)
+- The window title bar now follows the theme too (charcoal in dark, parchment in light) on Windows 11, so the whole
+  window is cohesive. On Windows 10 the title bar matches dark/light mode; only a few Windows-managed bits (e.g.
+  scrollbars) keep the system colour. (#52)
 
 ### Fixed
 - The updater builds its download URL with `Uri.EscapeDataString` on the version segment

--- a/Savedrake v1.2.3/Theme.cs
+++ b/Savedrake v1.2.3/Theme.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 namespace Savedrake
@@ -47,6 +48,60 @@ namespace Savedrake
             form.BackColor = P.Window;
             form.ForeColor = P.Text;
             ApplyControls(form.Controls);
+            ApplyTitleBar(form);
+        }
+
+        // ---- Native title-bar theming via DWM (Win11 = caption+text+border colour; Win10 1809+ = dark mode only) ----
+        [DllImport("dwmapi.dll")] static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int value, int size);
+        [DllImport("ntdll.dll")] static extern void RtlGetNtVersionNumbers(out uint major, out uint minor, out uint build);
+
+        const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;     // Win10 2004+/Win11
+        const int DWMWA_USE_IMMERSIVE_DARK_MODE_OLD = 19; // Win10 1809-1909
+        const int DWMWA_BORDER_COLOR = 34;                // Win11 22000+
+        const int DWMWA_CAPTION_COLOR = 35;               // Win11 22000+
+        const int DWMWA_TEXT_COLOR = 36;                  // Win11 22000+
+
+        // COLORREF is 0x00BBGGRR — NOT Color.ToArgb() (which is 0x00RRGGBB and would swap red/blue).
+        static int ColorRef(Color c) { return c.R | (c.G << 8) | (c.B << 16); }
+
+        static uint OsBuild()
+        {
+            try { uint mj, mn, b; RtlGetNtVersionNumbers(out mj, out mn, out b); return b & 0xFFFF; }
+            catch { return 0; }
+        }
+
+        // Make the OS title bar follow the theme. Best-effort: on a build/OS without DWM support it just no-ops to the
+        // native bar (never throws). The caption glyphs (min/max/close) follow immersive dark mode: white on the dark
+        // bar, black on the parchment bar — both readable.
+        internal static void ApplyTitleBar(Form form)
+        {
+            if (form == null || !form.IsHandleCreated) return;
+            IntPtr h = form.Handle;
+            uint build = OsBuild();
+            try
+            {
+                int dark = Current == Mode.Dark ? 1 : 0;
+                if (build >= 19041)
+                {
+                    if (DwmSetWindowAttribute(h, DWMWA_USE_IMMERSIVE_DARK_MODE, ref dark, 4) != 0)
+                        DwmSetWindowAttribute(h, DWMWA_USE_IMMERSIVE_DARK_MODE_OLD, ref dark, 4);
+                }
+                else if (build >= 17763)
+                {
+                    DwmSetWindowAttribute(h, DWMWA_USE_IMMERSIVE_DARK_MODE_OLD, ref dark, 4);
+                }
+
+                if (build >= 22000) // caption/text/border colours: Windows 11 only
+                {
+                    int caption = ColorRef(P.TitleBar);
+                    int text = ColorRef(P.Text);
+                    int border = ColorRef(P.Border);
+                    DwmSetWindowAttribute(h, DWMWA_CAPTION_COLOR, ref caption, 4);
+                    DwmSetWindowAttribute(h, DWMWA_TEXT_COLOR, ref text, 4);
+                    DwmSetWindowAttribute(h, DWMWA_BORDER_COLOR, ref border, 4);
+                }
+            }
+            catch { /* DWM unavailable -> keep the native title bar, never crash */ }
         }
 
         static void ApplyControls(Control.ControlCollection controls)


### PR DESCRIPTION
Themes the one element that was left light: the OS title bar. No framework move, native DWM.

## What
On **Windows 11**, the native title bar now matches the theme, charcoal caption + light text in dark, parchment caption + bronze text in light, via `DwmSetWindowAttribute` (`DWMWA_CAPTION_COLOR` 35 / `DWMWA_TEXT_COLOR` 36 / `DWMWA_BORDER_COLOR` 34). On **Windows 10 1809+** it sets `DWMWA_USE_IMMERSIVE_DARK_MODE` so the bar at least follows dark/light. The min/max/close glyphs follow immersive mode (white on the charcoal bar, black on parchment), so they stay readable.

## Details
- COLORREF uses the correct `0x00BBGGRR` byte order (not `Color.ToArgb()`, which is RGB and would swap red/blue, a gotcha in one of the research snippets).
- OS build detected via `RtlGetNtVersionNumbers`; the colour attributes are guarded to build 22000+.
- Called from `Theme.Apply`, so it themes on load **and** on the light/dark toggle.
- Best-effort: no-ops to the native bar on an unsupported OS, never throws.

## Why not a rewrite / custom frame
Researched (web + a deep-research pass): WinForms + DWM is the right call. A custom-drawn frame (FormBorderStyle.None) would only be needed for a gradient caption or a logo *inside* the title bar, and it's a big, error-prone undertaking (manual drag/resize/snap/maximize/system-menu/accessibility). Moving to WPF/WinUI just for chrome isn't justified.

## Verification
**Screenshot-confirmed**: the title bar now renders dark charcoal with light text and the dragon, cohesive with the rest of the dark UI. Build (Debug+Release) + harness **196** green; app launches clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)