### PR TITLE
Warm-dark card-layout redesign (match the locked mockup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,10 +66,18 @@ All notable changes to Savedrake are recorded here. The format is based on
   timestamp; older backups still show the date. Sorting by date is unchanged. (#50)
 - Backup-location heads-up: when you pick a backup folder that is in a cloud-synced folder (OneDrive, Dropbox, etc.)
   or on the same drive as your saves, Savedrake now gives a one-time, non-blocking note about the trade-off. (#50)
-- Dark and light themes: Savedrake now has a Dragon's Dogma 2-flavoured look, a charcoal-and-gold dark theme (the
+- Dark and light themes: Savedrake now has a Dragon's Dogma 2-flavoured look, a warm-dark espresso-and-gold theme (the
   default) and a parchment-and-bronze light theme, switchable from File > Use light/dark theme and remembered between
   runs. The whole window is themed, including the menus and the backup list (with gold "pinned" and green "protected"
   tags). (#51)
+- Redesigned main window (warm-dark card layout): the window now has a branded header (the dragon mark, the "Savedrake"
+  wordmark, the version, and a gold rule) and three grouped cards — Folders, Autobackup, and Backups. The autobackup
+  options that used to be tucked away in File > Settings (automatically clean up old backups, send removed to the Recycle
+  Bin, back up the moment the game saves, and the keep-at-most limit) are now shown directly on the window. The backup
+  list is cleaner — backup name, a friendly time, and a status tag (green "protected", gold "pinned") — and the action
+  row is Back up now / Restore / Delete. Open save folder, Open backup folder, Refresh list, and Undo delete moved into
+  the File menu. The whole layout is high-DPI aware. The autobackup interval is now chosen from the preset list (custom
+  free-typed intervals are no longer entered inline). (#53)
 - The window title bar now follows the theme too (charcoal in dark, parchment in light) on Windows 11, so the whole
   window is cohesive. On Windows 10 the title bar matches dark/light mode; only a few Windows-managed bits (e.g.
   scrollbars) keep the system colour. (#52)

--- a/Savedrake v1.2.3/Main.Designer.cs
+++ b/Savedrake v1.2.3/Main.Designer.cs
@@ -541,7 +541,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(334, 661);
+            this.ClientSize = new System.Drawing.Size(850, 760);
             this.Controls.Add(this.listView);
             this.Controls.Add(this.textbox3);
             this.Controls.Add(this.statusStrip1);
@@ -567,7 +567,7 @@
             this.MainMenuStrip = this.menuStrip1;
             this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.MaximizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(320, 660);
+            this.MinimumSize = new System.Drawing.Size(850, 760);
             this.Name = "Main";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;

--- a/Savedrake v1.2.3/Main.Layout.cs
+++ b/Savedrake v1.2.3/Main.Layout.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Savedrake
+{
+    // "Variant B" warm-dark card layout. Built once at the end of Main_Load: it adds a branded header + three rounded
+    // cards + a status bar, REPARENTS the existing Designer controls into those cards (so all the event wiring and
+    // storage keys keep working), surfaces the autobackup settings that used to live only in File > Settings, and
+    // restyles the action buttons + backup list to match the locked mockup.
+    //
+    // All coordinates below are 96-dpi logical units; every Location/Size is scaled to device pixels via Sx/SP/SZ so the
+    // layout is correct on high-DPI displays (the form is AutoScaleMode.Dpi and its design ClientSize is now 850x760).
+    // The canonical state for the surfaced settings stays on the existing menu items, so Save/Load need no new keys.
+    public partial class Main
+    {
+        private HeaderPanel _header;
+        private CardPanel _cardFolders, _cardAuto, _cardBackups;
+        private CheckBox _chkBackupOnSave, _chkCleanup, _chkRecycle;
+        private NumericUpDown _numKeep;
+        private Label _countSave, _countBackup, _hint, _lblKeepPre, _lblKeepPost;
+        private Button _btnDelete;
+        private Panel _autoSep;
+        private ToolStripMenuItem _undoDeleteMenuItem;
+        private bool _syncingSettings;
+        private bool _variantBBuilt;
+        private float _scale = 1f;
+
+        // Darkens OS-drawn bits a WinForms theme can't reach (the ListView's scrollbar). "DarkMode_Explorer" gives a
+        // dark scrollbar on Win10 1809+/Win11; "Explorer" restores the normal light one for the parchment theme.
+        [System.Runtime.InteropServices.DllImport("uxtheme.dll", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
+        private static extern int SetWindowTheme(IntPtr hWnd, string pszSubAppName, string pszSubIdList);
+
+        private void ApplyListScrollTheme()
+        {
+            try
+            {
+                if (listView != null && listView.IsHandleCreated)
+                    SetWindowTheme(listView.Handle, Theme.Current == Theme.Mode.Dark ? "DarkMode_Explorer" : "Explorer", null);
+            }
+            catch { }
+        }
+
+        private int Sx(int v) { return (int)Math.Round(v * _scale); }
+        private Point SP(int x, int y) { return new Point(Sx(x), Sx(y)); }
+        private Size SZ(int w, int h) { return new Size(Sx(w), Sx(h)); }
+
+        internal void BuildVariantBLayout()
+        {
+            if (_variantBBuilt) return;
+            _variantBBuilt = true;
+
+            _scale = this.DeviceDpi / 96f;
+            SuspendLayout();
+            this.Text = "Savedrake";
+            this.ClientSize = SZ(850, 760);
+
+            // ---- Header (branded strip; File/Help menu moves into it) ----
+            _header = new HeaderPanel { Dock = DockStyle.Top, Height = Sx(70), AppIcon = this.Icon, Version = "1.4.0" };
+            this.Controls.Add(_header);
+
+            menuStrip1.Dock = DockStyle.None;
+            menuStrip1.AutoSize = false;
+            menuStrip1.Size = SZ(150, 30);
+            _header.Controls.Add(menuStrip1);
+            menuStrip1.Location = new Point(_header.Width - menuStrip1.Width - Sx(24), Sx(22));
+            menuStrip1.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+
+            // ---- Cards ----
+            _cardFolders = new CardPanel { Title = "Folders", Location = SP(30, 84), Size = SZ(790, 132), Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right };
+            _cardAuto = new CardPanel { Title = "Autobackup", Location = SP(30, 228), Size = SZ(790, 286), Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right };
+            _cardBackups = new CardPanel { Title = "Backups", Location = SP(30, 526), Size = SZ(790, 196), Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right };
+            this.Controls.Add(_cardFolders);
+            this.Controls.Add(_cardAuto);
+            this.Controls.Add(_cardBackups);
+
+            // ---- Card 1: Folders ----
+            Reparent(label1, _cardFolders, SP(22, 56)); label1.Text = "Save game"; label1.AutoSize = true;
+            Reparent(textbox1, _cardFolders, SP(120, 52)); textbox1.Size = SZ(490, 26); textbox1.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            _countSave = MakeCountBox(); Reparent(_countSave, _cardFolders, SP(622, 52)); _countSave.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            Reparent(Button_br_1, _cardFolders, SP(668, 51)); Button_br_1.Size = SZ(100, 28); Button_br_1.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+
+            Reparent(label2, _cardFolders, SP(22, 96)); label2.Text = "Backups"; label2.AutoSize = true;
+            Reparent(textbox2, _cardFolders, SP(120, 92)); textbox2.Size = SZ(490, 26); textbox2.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            _countBackup = MakeCountBox(); Reparent(_countBackup, _cardFolders, SP(622, 92)); _countBackup.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            Reparent(Button_br_2, _cardFolders, SP(668, 91)); Button_br_2.Size = SZ(100, 28); Button_br_2.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+
+            // ---- Card 2: Autobackup ----
+            Reparent(checkbox_auto, _cardAuto, SP(22, 44)); checkbox_auto.Text = "Autobackup while game runs"; checkbox_auto.Size = SZ(320, 24);
+            Reparent(combobox_auto, _cardAuto, SP(628, 42)); combobox_auto.Size = SZ(140, 24); combobox_auto.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            // DropDownList (not editable) so the closed display + list are fully owner-drawn dark; the system EDIT field
+            // of an editable combobox can't be themed. Presets still select normally.
+            combobox_auto.DropDownStyle = ComboBoxStyle.DropDownList;
+            combobox_auto.DrawMode = DrawMode.OwnerDrawFixed; combobox_auto.DrawItem += ComboAuto_DrawItem;
+
+            _chkBackupOnSave = MakeCheck("Back up the moment the game saves", SP(58, 78), SZ(360, 24)); _cardAuto.Controls.Add(_chkBackupOnSave);
+            _chkCleanup = MakeCheck("Automatically clean up old backups", SP(58, 110), SZ(360, 24)); _cardAuto.Controls.Add(_chkCleanup);
+            _chkRecycle = MakeCheck("Send removed to the Recycle Bin", SP(80, 142), SZ(340, 24)); _cardAuto.Controls.Add(_chkRecycle);
+
+            _lblKeepPre = new Label { Text = "Keep at most", AutoSize = true, Location = SP(58, 178) };
+            _numKeep = new NumericUpDown { Location = SP(162, 174), Size = SZ(72, 24), Minimum = 1, Maximum = 100000, Value = 800 };
+            _lblKeepPost = new Label { Text = "backups", AutoSize = true, Location = SP(244, 178) };
+            _cardAuto.Controls.Add(_lblKeepPre); _cardAuto.Controls.Add(_numKeep); _cardAuto.Controls.Add(_lblKeepPost);
+
+            _autoSep = new Panel { Location = SP(22, 212), Size = SZ(746, 1), Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right };
+            _cardAuto.Controls.Add(_autoSep);
+
+            Reparent(checkbox_hot, _cardAuto, SP(22, 226)); checkbox_hot.Text = "Global hotkey"; checkbox_hot.Size = SZ(150, 24);
+            Reparent(textbox3, _cardAuto, SP(180, 228));
+            Reparent(checkbox_tray, _cardAuto, SP(300, 226)); checkbox_tray.Text = "Minimize to tray"; checkbox_tray.Size = SZ(220, 24);
+
+            _hint = new Label { Text = "Unchanged saves are skipped automatically.", AutoSize = true, Location = SP(22, 256) };
+            _cardAuto.Controls.Add(_hint);
+
+            ThemedCheck.Attach(checkbox_auto); ThemedCheck.Attach(checkbox_hot); ThemedCheck.Attach(checkbox_tray);
+            ThemedCheck.Attach(_chkBackupOnSave); ThemedCheck.Attach(_chkCleanup); ThemedCheck.Attach(_chkRecycle);
+
+            // ---- Card 3: Backups ----
+            Reparent(button_backup, _cardBackups, SP(430, 12)); button_backup.Text = "Back up now"; button_backup.Size = SZ(118, 30); button_backup.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            Reparent(button_res, _cardBackups, SP(556, 12)); button_res.Text = "Restore"; button_res.Size = SZ(104, 30); button_res.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            _btnDelete = new Button { Text = "Delete", Location = SP(668, 12), Size = SZ(100, 30), Anchor = AnchorStyles.Top | AnchorStyles.Right, FlatStyle = FlatStyle.Flat };
+            _btnDelete.Click += (s, e) => DeleteMenuItem_Click(s, e);
+            _cardBackups.Controls.Add(_btnDelete);
+
+            Reparent(listView, _cardBackups, SP(22, 54)); listView.Size = SZ(746, 130); listView.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            listView.HeaderStyle = ColumnHeaderStyle.None;
+            ImageList rowHeight = new ImageList { ImageSize = new Size(1, Sx(34)) }; // forces a taller, mockup-like row
+            listView.SmallImageList = rowHeight;
+
+            // ---- Off-form controls now reachable from the File menu (mockup's action row is Back up now / Restore / Delete) ----
+            Button_op_1.Visible = false; Button_op_2.Visible = false; button_ref.Visible = false; button_undo.Visible = false;
+
+            ToolStripMenuItem openSave = new ToolStripMenuItem("Open save folder"); openSave.Click += Button_op_1_Click;
+            ToolStripMenuItem openBackup = new ToolStripMenuItem("Open backup folder"); openBackup.Click += Button_op_2_Click;
+            ToolStripMenuItem refreshItem = new ToolStripMenuItem("Refresh list"); refreshItem.Click += button_ref_Click;
+            _undoDeleteMenuItem = new ToolStripMenuItem("Undo delete") { Enabled = false }; _undoDeleteMenuItem.Click += button_undo_Click;
+            fileToolStripMenuItem.DropDownItems.Insert(0, openSave);
+            fileToolStripMenuItem.DropDownItems.Insert(1, openBackup);
+            fileToolStripMenuItem.DropDownItems.Insert(2, refreshItem);
+            fileToolStripMenuItem.DropDownItems.Insert(3, _undoDeleteMenuItem);
+
+            statusStrip1.Dock = DockStyle.Bottom;
+
+            ResumeLayout(false);
+            PerformLayout();
+
+            // Theme everything (the recursion now reaches the new cards/checks), then apply the look details Theme.Style
+            // can't infer from a control's name (outlined Restore, red Delete, card-bg labels, separator colour, etc.).
+            Theme.Apply(this);
+            ApplyVariantBOverrides();
+
+            WireSurfacedSettings();
+            SyncSettingControlsFromState();
+
+            // Polish: clear the top-level menu items' stale system-white background, theme the spinner's inner controls,
+            // and drop the combobox's text selection so it doesn't open with a harsh blue highlight.
+            foreach (ToolStripItem it in menuStrip1.Items) it.BackColor = Color.Transparent;
+            foreach (Control inner in _numKeep.Controls) { inner.BackColor = Theme.P.Input; inner.ForeColor = Theme.P.Text; }
+
+            ApplyListScrollTheme();
+            listViewColumnResize();
+        }
+
+        // Re-skin pass for things the generic Theme can't decide from a control name.
+        private void ApplyVariantBOverrides()
+        {
+            Color card = Theme.P.Panel;
+            if (label1 != null) { label1.BackColor = card; label1.ForeColor = Theme.P.TextSecondary; }
+            if (label2 != null) { label2.BackColor = card; label2.ForeColor = Theme.P.TextSecondary; }
+            if (_lblKeepPre != null) { _lblKeepPre.BackColor = card; _lblKeepPre.ForeColor = Theme.P.Text; }
+            if (_lblKeepPost != null) { _lblKeepPost.BackColor = card; _lblKeepPost.ForeColor = Theme.P.Text; }
+            if (textbox3 != null) { textbox3.BackColor = card; textbox3.ForeColor = Theme.P.AccentDim; }
+            if (_hint != null) { _hint.BackColor = card; _hint.ForeColor = Theme.P.TextHint; }
+            if (_countSave != null) { _countSave.BackColor = Theme.P.Input; _countSave.ForeColor = Theme.P.TextSecondary; }
+            if (_countBackup != null) { _countBackup.BackColor = Theme.P.Input; _countBackup.ForeColor = Theme.P.TextSecondary; }
+            if (_autoSep != null) _autoSep.BackColor = Theme.P.RowSep;
+            if (_numKeep != null) { _numKeep.BackColor = Theme.P.Input; _numKeep.ForeColor = Theme.P.Text; _numKeep.BorderStyle = BorderStyle.FixedSingle; }
+            if (combobox_auto != null) { combobox_auto.FlatStyle = FlatStyle.Flat; combobox_auto.BackColor = Theme.P.Input; combobox_auto.ForeColor = Theme.P.Text; }
+
+            // button_backup stays gold (Theme makes it primary by name). Restore = outlined, Delete = red.
+            StyleOutlineButton(button_res);
+            StyleDangerButton(_btnDelete);
+        }
+
+        private void StyleOutlineButton(Button b)
+        {
+            if (b == null) return;
+            b.FlatStyle = FlatStyle.Flat; b.UseVisualStyleBackColor = false;
+            b.BackColor = Theme.P.Panel; b.ForeColor = Theme.P.AccentDim;
+            b.FlatAppearance.BorderColor = Theme.P.Outline;
+            b.FlatAppearance.MouseOverBackColor = Theme.P.PanelAlt;
+            b.FlatAppearance.MouseDownBackColor = Theme.P.Sel;
+        }
+
+        private void StyleDangerButton(Button b)
+        {
+            if (b == null) return;
+            b.FlatStyle = FlatStyle.Flat; b.UseVisualStyleBackColor = false;
+            b.BackColor = Theme.P.Panel; b.ForeColor = Theme.P.Danger;
+            b.FlatAppearance.BorderColor = Theme.P.Danger;
+            b.FlatAppearance.MouseOverBackColor = Theme.P.PanelAlt;
+            b.FlatAppearance.MouseDownBackColor = Theme.P.Sel;
+        }
+
+        // Owner-draw the interval combobox so its closed display + dropdown list follow the dark theme (the stock
+        // combobox renders light). The edit field stays editable so custom intervals can still be typed.
+        private void ComboAuto_DrawItem(object sender, DrawItemEventArgs e)
+        {
+            Color bg = (e.State & DrawItemState.Selected) != 0 ? Theme.P.Sel : Theme.P.Input;
+            using (var b = new SolidBrush(bg)) e.Graphics.FillRectangle(b, e.Bounds);
+            string txt = e.Index >= 0 ? combobox_auto.Items[e.Index].ToString() : combobox_auto.Text;
+            Rectangle r = e.Bounds; r.X += (int)(4 * _scale);
+            TextRenderer.DrawText(e.Graphics, txt, combobox_auto.Font, r, Theme.P.Text,
+                TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.EndEllipsis);
+        }
+
+        private Label MakeCountBox()
+        {
+            return new Label
+            {
+                AutoSize = false,
+                Size = SZ(40, 26),
+                TextAlign = ContentAlignment.MiddleCenter,
+                BorderStyle = BorderStyle.FixedSingle,
+                Font = new Font("Segoe UI", 9f)
+            };
+        }
+
+        private CheckBox MakeCheck(string text, Point loc, Size size)
+        {
+            return new CheckBox { Text = text, Location = loc, Size = size, FlatStyle = FlatStyle.Flat, AutoSize = false };
+        }
+
+        // Add a control to a new parent and reset its layout state (Designer anchors were relative to the form).
+        private void Reparent(Control c, Control parent, Point loc)
+        {
+            if (c == null) return;
+            if (c.Parent != null) c.Parent.Controls.Remove(c);
+            parent.Controls.Add(c);
+            c.Anchor = AnchorStyles.Top | AnchorStyles.Left;
+            c.Location = loc;
+            c.Visible = true;
+        }
+
+        // ---- Surfaced settings: two-way sync between the on-form controls and the canonical menu-item state ----
+        private void WireSurfacedSettings()
+        {
+            _chkBackupOnSave.CheckedChanged += (s, e) =>
+            {
+                if (_syncingSettings) return;
+                _syncingSettings = true;
+                _backupOnSaveMenuItem.Checked = _chkBackupOnSave.Checked; // fires its watcher start/stop lambda
+                _syncingSettings = false;
+                try { SaveSettings(); } catch { }
+            };
+
+            _chkCleanup.CheckedChanged += (s, e) =>
+            {
+                if (_syncingSettings) return;
+                bool want = _chkCleanup.Checked;
+                if (want)
+                {
+                    DialogResult r = MessageBox.Show(
+                        "Savedrake will keep all your recent autobackups and a spread of older ones, then remove the " +
+                        "extra older autobackups so they don't pile up. Your manual backups and pinned backups are never removed.\n\n" +
+                        "Turn this on?",
+                        "Automatically clean up old autobackups", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                    if (r != DialogResult.Yes) { _syncingSettings = true; _chkCleanup.Checked = false; _syncingSettings = false; return; }
+                }
+                _syncingSettings = true;
+                _cleanupMenuItem.Checked = want;
+                _recycleMenuItem.Enabled = want;
+                if (!want) _recycleMenuItem.Checked = false;
+                _syncingSettings = false;
+                SyncSettingControlsFromState();
+                try { SaveSettings(); } catch { }
+            };
+
+            _chkRecycle.CheckedChanged += (s, e) =>
+            {
+                if (_syncingSettings) return;
+                _syncingSettings = true;
+                _recycleMenuItem.Checked = _chkRecycle.Checked;
+                _syncingSettings = false;
+                try { SaveSettings(); } catch { }
+            };
+
+            _numKeep.ValueChanged += (s, e) =>
+            {
+                if (_syncingSettings) return;
+                toolStripTextBox2.Text = ((int)_numKeep.Value).ToString();
+                try { SaveSettings(); } catch { }
+            };
+
+            // Reflect menu-driven changes back onto the form controls.
+            _cleanupMenuItem.CheckedChanged += (s, e) => { if (!_syncingSettings) SyncSettingControlsFromState(); };
+            _recycleMenuItem.CheckedChanged += (s, e) => { if (!_syncingSettings) SyncSettingControlsFromState(); };
+            _backupOnSaveMenuItem.CheckedChanged += (s, e) => { if (!_syncingSettings) SyncSettingControlsFromState(); };
+        }
+
+        private void SyncSettingControlsFromState()
+        {
+            if (_chkCleanup == null) return;
+            _syncingSettings = true;
+            try
+            {
+                _chkBackupOnSave.Checked = _backupOnSaveMenuItem.Checked;
+                _chkCleanup.Checked = _cleanupMenuItem.Checked;
+                _chkRecycle.Checked = _recycleMenuItem.Checked;
+                _chkRecycle.Enabled = _cleanupMenuItem.Checked;
+                int n;
+                if (int.TryParse(toolStripTextBox2.Text, out n) && n >= 1 && n <= 100000) _numKeep.Value = n;
+            }
+            finally { _syncingSettings = false; }
+        }
+    }
+}

--- a/Savedrake v1.2.3/Main.cs
+++ b/Savedrake v1.2.3/Main.cs
@@ -1607,6 +1607,8 @@ namespace Savedrake
         {
             Theme.Current = Theme.Current == Theme.Mode.Dark ? Theme.Mode.Light : Theme.Mode.Dark;
             Theme.Apply(this);
+            // Re-apply the card/button look that Theme.Style can't infer (outlined Restore, red Delete, card-bg labels).
+            if (_variantBBuilt) { ApplyVariantBOverrides(); ApplyListScrollTheme(); Invalidate(true); }
             UpdateThemeMenuText();
             listView.Refresh();
             try { SaveSettings(); } catch { }
@@ -1632,14 +1634,40 @@ namespace Savedrake
         {
             Color back = e.Item.Selected ? Theme.P.Sel : (e.ItemIndex % 2 == 0 ? Theme.P.Panel : Theme.P.PanelAlt);
             using (var b = new SolidBrush(back)) e.Graphics.FillRectangle(b, e.Bounds);
+            // Subtle row separator along the bottom (matches the mockup's clean list).
+            using (var sep = new Pen(Theme.P.RowSep))
+                e.Graphics.DrawLine(sep, e.Bounds.Left, e.Bounds.Bottom - 1, e.Bounds.Right, e.Bounds.Bottom - 1);
 
-            Color fore = Theme.P.Text;
-            if (e.ColumnIndex == 2) fore = StatusColor(e.SubItem.Text);
-            else if (e.ColumnIndex == 0 && IsPinnedBackup(e.Item.Text)) fore = Theme.P.Pinned;
+            float s = listView.DeviceDpi / 96f;
+            int pad = (int)(12 * s);
+            bool pinned = IsPinnedBackup(e.Item.Text);
+            Rectangle r = e.Bounds; r.X += pad; r.Width -= pad * 2;
 
-            Rectangle r = e.Bounds; r.X += 6; r.Width -= 6;
-            TextRenderer.DrawText(e.Graphics, e.SubItem.Text, listView.Font, r, fore,
-                TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.EndEllipsis);
+            if (e.ColumnIndex == 0)
+            {
+                // Leading dot (gold for pinned) + the backup name (gold if pinned, cream otherwise).
+                int dot = (int)(6 * s), dy = e.Bounds.Top + (e.Bounds.Height - dot) / 2;
+                using (var db = new SolidBrush(pinned ? Theme.P.Pinned : Theme.P.TextSecondary))
+                    e.Graphics.FillEllipse(db, e.Bounds.X + pad, dy, dot, dot);
+                Rectangle nr = r; nr.X += (int)(16 * s); nr.Width -= (int)(16 * s);
+                TextRenderer.DrawText(e.Graphics, e.SubItem.Text, listView.Font, nr, pinned ? Theme.P.Pinned : Theme.P.Text,
+                    TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.EndEllipsis);
+            }
+            else if (e.ColumnIndex == 1)
+            {
+                // Friendly time, right-aligned and muted.
+                TextRenderer.DrawText(e.Graphics, e.SubItem.Text, listView.Font, r, Theme.P.TextSecondary,
+                    TextFormatFlags.Right | TextFormatFlags.VerticalCenter | TextFormatFlags.EndEllipsis);
+            }
+            else
+            {
+                // Status tag, right-aligned. Pinned backups read "pinned" (gold); otherwise the integrity status in its
+                // theme colour (green "protected"/"validated", red "corrupt"/"missing").
+                string tag = pinned ? "pinned" : (e.SubItem.Text ?? string.Empty).ToLowerInvariant();
+                Color c = pinned ? Theme.P.Pinned : StatusColor(e.SubItem.Text);
+                TextRenderer.DrawText(e.Graphics, tag, listView.Font, r, c,
+                    TextFormatFlags.Right | TextFormatFlags.VerticalCenter | TextFormatFlags.EndEllipsis);
+            }
         }
 
         private static Color StatusColor(string s)
@@ -1830,12 +1858,16 @@ namespace Savedrake
         {
             if (listView.Columns.Count >= 3)
             {
-                // File Name | Date & Time | Integrity. Give Integrity a fixed slice and split the rest ~55/45.
-                int integrity = 72;
-                int rest = Math.Max(0, listView.Width - integrity);
-                listView.Columns[0].Width = (int)(rest * 0.55);
-                listView.Columns[1].Width = rest - listView.Columns[0].Width;
-                listView.Columns[2].Width = integrity;
+                // Name (flex) | friendly time (right) | status tag (right). The mockup gives the name the room and keeps
+                // the time + tag as narrow right-aligned columns. Size against ClientSize (excludes any vertical
+                // scrollbar) so the columns never overflow into a horizontal scrollbar.
+                float s = listView.DeviceDpi / 96f;
+                int tag = (int)(110 * s), time = (int)(150 * s);
+                int avail = listView.ClientSize.Width;
+                int name = Math.Max((int)(80 * s), avail - tag - time);
+                listView.Columns[0].Width = name;
+                listView.Columns[1].Width = time;
+                listView.Columns[2].Width = tag;
                 return;
             }
             listView.Columns[0].Width = listView.Width / 2;
@@ -3063,6 +3095,9 @@ namespace Savedrake
 
             // Write the new count back to the file
             File.WriteAllText(countFilePath, backupCount.ToString());
+
+            // Reflect the on-disk backup count in the Folders card's count box (mockup shows it beside the backup path).
+            if (_countBackup != null) _countBackup.Text = listView.Items.Count.ToString();
         }
 
         // Right-click "Validate all backups" action (P1): run the FULL integrity check on every listed backup and mark
@@ -3410,6 +3445,9 @@ namespace Savedrake
 
             // Theme-aware background (enabled = panel, disabled = dimmer panel).
             button_undo.BackColor = button_undo.Enabled ? Theme.P.Panel : Theme.P.PanelAlt;
+
+            // The on-form Undo button is hidden in the variant-B layout; keep its File-menu twin in sync.
+            if (_undoDeleteMenuItem != null) _undoDeleteMenuItem.Enabled = deletedFiles.Count > 0;
         }
 
 
@@ -3928,6 +3966,10 @@ namespace Savedrake
             // Apply the saved UI theme (default dark) before the list populates so it owner-draws themed.
             Theme.Apply(this);
             UpdateThemeMenuText();
+            // Build the warm-dark "variant B" card layout: reparents the controls above into cards, adds the branded
+            // header + surfaced autobackup settings, and restyles the list/buttons. Runs after the theme + settings load
+            // so it moves live, populated controls; it re-applies the theme to the new cards itself.
+            BuildVariantBLayout();
             //randomlyGeneratedToolStripMenuItem.Checked = true;
             LoadBackupHistory();
 

--- a/Savedrake v1.2.3/Savedrake.csproj
+++ b/Savedrake v1.2.3/Savedrake.csproj
@@ -106,8 +106,12 @@
   <ItemGroup>
     <Compile Include="ListViewDataComparer.cs" />
     <Compile Include="Theme.cs" />
+    <Compile Include="Ui.cs" />
     <Compile Include="Main.cs">
       <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Main.Layout.cs">
+      <DependentUpon>Main.cs</DependentUpon>
     </Compile>
     <Compile Include="Main.Designer.cs">
       <DependentUpon>Main.cs</DependentUpon>

--- a/Savedrake v1.2.3/Theme.cs
+++ b/Savedrake v1.2.3/Theme.cs
@@ -5,8 +5,11 @@ using System.Windows.Forms;
 
 namespace Savedrake
 {
-    // UI theme (neutral charcoal + gold dark, parchment + bronze light). Palette locked via a Claude-design mockup pass.
-    // Gold is a dark-mode colour (glows on dark, muddy on light), so light mode uses its dark sibling BRONZE for accents.
+    // UI theme (warm dark + gold dark, parchment + bronze light). Palette locked via a Claude-design mockup pass
+    // ("B - my refinement: warm dark, readable gold, restrained colour"). The dark shell is a warm espresso brown,
+    // NOT a neutral/cool charcoal -- the structural greys carry a brown undertone (red >= green > blue) so the gold
+    // reads as part of the same family. Gold is a dark-mode colour (glows on dark, muddy on light), so light mode
+    // uses its dark sibling BRONZE for accents.
     internal static class Theme
     {
         internal enum Mode { Dark, Light }
@@ -14,7 +17,7 @@ namespace Savedrake
 
         internal struct Palette
         {
-            public Color Window, TitleBar, Panel, PanelAlt, Input, Border, RowSep, Sel,
+            public Color Window, TitleBar, Panel, PanelAlt, Input, Border, Outline, RowSep, Sel,
                          Text, TextSecondary, TextHint, Accent, AccentText, AccentDim,
                          Success, Danger, Pinned;
         }
@@ -23,9 +26,10 @@ namespace Savedrake
 
         static readonly Palette Dark = new Palette
         {
-            Window = H("#1B1B1D"), TitleBar = H("#202022"), Panel = H("#26262A"), PanelAlt = H("#222225"),
-            Input = H("#1E1E20"), Border = H("#34343A"), RowSep = H("#2E2E33"), Sel = H("#3A3A40"),
-            Text = H("#E7E5E0"), TextSecondary = H("#9B9A94"), TextHint = H("#76756F"),
+            // Warm espresso shell (brown undertone, R >= G > B) so the bar/panels/inputs sit in the same family as gold.
+            Window = H("#1F1811"), TitleBar = H("#241C14"), Panel = H("#2A2118"), PanelAlt = H("#251D15"),
+            Input = H("#1A140C"), Border = H("#3A3025"), Outline = H("#6B5A33"), RowSep = H("#2F261A"), Sel = H("#3E3223"),
+            Text = H("#E9E4D8"), TextSecondary = H("#A39B88"), TextHint = H("#837B69"),
             Accent = H("#C8A24C"), AccentText = H("#211A0E"), AccentDim = H("#D3BE86"),
             Success = H("#8FB36A"), Danger = H("#C77B6F"), Pinned = H("#D8B968")
         };
@@ -33,7 +37,7 @@ namespace Savedrake
         static readonly Palette Light = new Palette
         {
             Window = H("#E9E0CB"), TitleBar = H("#E3D8BD"), Panel = H("#F5EFDF"), PanelAlt = H("#EFE7D2"),
-            Input = H("#FBF8EE"), Border = H("#D9CBA8"), RowSep = H("#E3D9BF"), Sel = H("#DBCBA0"),
+            Input = H("#FBF8EE"), Border = H("#D9CBA8"), Outline = H("#B89B5B"), RowSep = H("#E3D9BF"), Sel = H("#DBCBA0"),
             Text = H("#2E2A1F"), TextSecondary = H("#5C543E"), TextHint = H("#837A5E"),
             Accent = H("#7E5E22"), AccentText = H("#F5EFDF"), AccentDim = H("#6E5320"),
             Success = H("#3E6B33"), Danger = H("#9A3B2E"), Pinned = H("#7E5E22")
@@ -141,7 +145,7 @@ namespace Savedrake
                 {
                     btn.BackColor = btn.Enabled ? P.Panel : P.PanelAlt;
                     btn.ForeColor = P.AccentDim;
-                    btn.FlatAppearance.BorderColor = P.Border;
+                    btn.FlatAppearance.BorderColor = P.Outline; // gold-dim outline = the mockup's secondary buttons
                     btn.FlatAppearance.MouseOverBackColor = P.PanelAlt;
                     btn.FlatAppearance.MouseDownBackColor = P.Sel;
                 }
@@ -158,7 +162,14 @@ namespace Savedrake
             if (chk != null) { chk.BackColor = Color.Transparent; chk.ForeColor = P.Text; return; }
 
             var lbl = c as Label;
-            if (lbl != null) { lbl.BackColor = Color.Transparent; lbl.ForeColor = P.Text; return; }
+            // Header-style labels (those ending in ":", e.g. "Savegame Location:") get the gold/bronze accent so the
+            // theme's personality shows even without the card layout; other labels stay in the normal text colour.
+            if (lbl != null)
+            {
+                lbl.BackColor = Color.Transparent;
+                lbl.ForeColor = (!string.IsNullOrEmpty(lbl.Text) && lbl.Text.TrimEnd().EndsWith(":")) ? P.Accent : P.Text;
+                return;
+            }
 
             var lv = c as ListView;
             if (lv != null)

--- a/Savedrake v1.2.3/Ui.cs
+++ b/Savedrake v1.2.3/Ui.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Text;
+using System.Windows.Forms;
+
+namespace Savedrake
+{
+    // Reusable WinForms building blocks for the warm-dark "variant B" look: rounded cards, a branded header with the
+    // gold serif wordmark, a themed checkbox, and small paint helpers. All colours come from the static Theme palette
+    // (Theme.P), so these controls re-skin automatically when the light/dark theme toggles and Theme.Apply re-runs.
+    internal static class UiPaint
+    {
+        // A rounded-rectangle path (used for cards and the checkbox glyph). Inset by 0.5px-friendly integer bounds.
+        internal static GraphicsPath RoundRect(Rectangle r, int radius)
+        {
+            int d = radius * 2;
+            var p = new GraphicsPath();
+            if (radius <= 0) { p.AddRectangle(r); p.CloseFigure(); return p; }
+            p.AddArc(r.X, r.Y, d, d, 180, 90);
+            p.AddArc(r.Right - d, r.Y, d, d, 270, 90);
+            p.AddArc(r.Right - d, r.Bottom - d, d, d, 0, 90);
+            p.AddArc(r.X, r.Bottom - d, d, d, 90, 90);
+            p.CloseFigure();
+            return p;
+        }
+
+        // Cached serif font resolver for the wordmark. Tries Cinzel (if ever bundled/installed), then common system
+        // serifs, then the generic serif family — never throws. Fonts are cached and never disposed (process-lifetime).
+        static readonly Dictionary<string, Font> _serifCache = new Dictionary<string, Font>();
+        static FontFamily _serifFamily;
+
+        static FontFamily SerifFamily()
+        {
+            if (_serifFamily != null) return _serifFamily;
+            foreach (var name in new[] { "Cinzel", "Trajan Pro", "Georgia", "Times New Roman" })
+            {
+                try { var f = new FontFamily(name); _serifFamily = f; return f; } catch { }
+            }
+            _serifFamily = FontFamily.GenericSerif;
+            return _serifFamily;
+        }
+
+        internal static Font Serif(float size, FontStyle style)
+        {
+            string key = size.ToString("0.0") + "/" + (int)style;
+            Font f;
+            if (_serifCache.TryGetValue(key, out f)) return f;
+            try { f = new Font(SerifFamily(), size, style, GraphicsUnit.Pixel); }
+            catch { f = new Font(FontFamily.GenericSerif, size, style, GraphicsUnit.Pixel); }
+            _serifCache[key] = f;
+            return f;
+        }
+
+        // Draw a string with manual per-glyph letter-spacing (GDI+ has no tracking API).
+        internal static void DrawTracked(Graphics g, string text, Font font, Color color, float x, float y, float spacing)
+        {
+            g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
+            using (var b = new SolidBrush(color))
+            {
+                var fmt = StringFormat.GenericTypographic;
+                foreach (char c in text)
+                {
+                    string s = c.ToString();
+                    g.DrawString(s, font, b, x, y, fmt);
+                    x += g.MeasureString(s, font, PointF.Empty, fmt).Width + spacing;
+                }
+            }
+        }
+    }
+
+    // A rounded card: warm card fill, a 1px border, and an optional gold serif section title at the top-left. Children
+    // are positioned by the layout code in the card's client area (below the title band).
+    internal sealed class CardPanel : Panel
+    {
+        public Color FillColor = Color.Empty;     // Empty => Theme.P.Panel at paint time
+        public Color BorderColor = Color.Empty;   // Empty => Theme.P.Border
+        public Color ShellColor = Color.Empty;    // corner colour behind the rounded edge; Empty => Theme.P.Window
+        public string Title = null;
+        public int CornerRadius = 12;
+        public int TitleInset = 18;
+
+        public CardPanel()
+        {
+            SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint
+                     | ControlStyles.OptimizedDoubleBuffer | ControlStyles.ResizeRedraw, true);
+            BackColor = Color.Transparent;
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            float s = DeviceDpi / 96f;
+            Color fill = FillColor.IsEmpty ? Theme.P.Panel : FillColor;
+            Color border = BorderColor.IsEmpty ? Theme.P.Border : BorderColor;
+            Color shell = ShellColor.IsEmpty ? Theme.P.Window : ShellColor;
+
+            var g = e.Graphics;
+            g.SmoothingMode = SmoothingMode.AntiAlias;
+            using (var sb = new SolidBrush(shell)) g.FillRectangle(sb, ClientRectangle);
+
+            Rectangle r = ClientRectangle; r.Width -= 1; r.Height -= 1;
+            using (var path = UiPaint.RoundRect(r, (int)(CornerRadius * s)))
+            using (var fb = new SolidBrush(fill))
+            using (var bp = new Pen(border))
+            {
+                g.FillPath(fb, path);
+                g.DrawPath(bp, path);
+            }
+
+            if (!string.IsNullOrEmpty(Title))
+            {
+                using (var tf = new Font("Segoe UI Semibold", 11f, FontStyle.Bold))
+                {
+                    TextRenderer.DrawText(g, Title, tf, new Point((int)(TitleInset * s), (int)(12 * s)), Theme.P.Accent,
+                        TextFormatFlags.NoPadding);
+                }
+            }
+        }
+    }
+
+    // The branded header strip: shell bg, a circular logo token, the gold serif "Savedrake" wordmark, the version, and
+    // a 1px gold rule along the bottom. The File/Help MenuStrip is parented here by the layout code (right side).
+    internal sealed class HeaderPanel : Panel
+    {
+        public Icon AppIcon;
+        public string Version = "";
+
+        public HeaderPanel()
+        {
+            SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint
+                     | ControlStyles.OptimizedDoubleBuffer | ControlStyles.ResizeRedraw, true);
+            BackColor = Color.Transparent;
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            float s = DeviceDpi / 96f;
+            var g = e.Graphics;
+            g.SmoothingMode = SmoothingMode.AntiAlias;
+            // Slightly distinct warm bar so the reparented File/Help menu (rendered in TitleBar) blends seamlessly.
+            using (var bg = new SolidBrush(Theme.P.TitleBar)) g.FillRectangle(bg, ClientRectangle);
+
+            // Logo token: a warm disc + faint gold ring + the app icon glyph.
+            int d = (int)(44 * s), lx = (int)(30 * s), ly = (Height - d) / 2;
+            var disc = new Rectangle(lx, ly, d, d);
+            using (var db = new SolidBrush(Theme.P.Panel)) g.FillEllipse(db, disc);
+            using (var rp = new Pen(Color.FromArgb(120, Theme.P.Accent), s)) g.DrawEllipse(rp, disc);
+            if (AppIcon != null)
+            {
+                try
+                {
+                    using (var bmp = AppIcon.ToBitmap())
+                    {
+                        int gs = (int)(28 * s), gp = lx + (d - gs) / 2, gq = ly + (d - gs) / 2;
+                        g.InterpolationMode = InterpolationMode.HighQualityBicubic;
+                        g.DrawImage(bmp, new Rectangle(gp, gq, gs, gs));
+                    }
+                }
+                catch { }
+            }
+
+            // Wordmark + version, vertically centred against the token.
+            Font wf = UiPaint.Serif(26f * s, FontStyle.Regular);
+            float track = 1.5f * s;
+            float wx = lx + d + 16 * s;
+            float wy = (Height - wf.Height) / 2f - 1;
+            UiPaint.DrawTracked(g, "Savedrake", wf, Theme.P.Pinned, wx, wy, track);
+
+            if (!string.IsNullOrEmpty(Version))
+            {
+                float ww = 0; var fmt = StringFormat.GenericTypographic;
+                foreach (char c in "Savedrake") ww += g.MeasureString(c.ToString(), wf, PointF.Empty, fmt).Width + track;
+                using (var vf = new Font("Segoe UI", 10.5f))
+                    TextRenderer.DrawText(g, Version, vf, new Point((int)(wx + ww + 10 * s), (int)(wy + wf.Height - 22 * s)),
+                        Theme.P.TextSecondary, TextFormatFlags.NoPadding);
+            }
+
+            // Bottom gold rule.
+            using (var rule = new Pen(Color.FromArgb(150, Theme.P.Accent), s))
+                g.DrawLine(rule, lx, Height - 1, Width - lx, Height - 1);
+        }
+    }
+
+    // Attaches owner-drawn rendering to a stock CheckBox so the check reads as a gold tick in a gold-tinted rounded box
+    // on dark (bronze on parchment in light mode). The CheckBox keeps its native click/toggle behaviour (AutoCheck);
+    // we only repaint. Re-reads Theme.P each paint, so it follows the theme toggle.
+    internal static class ThemedCheck
+    {
+        internal static void Attach(CheckBox cb)
+        {
+            cb.FlatStyle = FlatStyle.Flat;
+            cb.FlatAppearance.BorderSize = 0;
+            cb.AutoSize = false;
+            cb.BackColor = Color.Transparent;
+            cb.Paint += Paint;
+            cb.CheckedChanged += (s, e) => cb.Invalidate();
+            cb.EnabledChanged += (s, e) => cb.Invalidate();
+            cb.MouseEnter += (s, e) => cb.Invalidate();
+            cb.MouseLeave += (s, e) => cb.Invalidate();
+        }
+
+        static void Paint(object sender, PaintEventArgs e)
+        {
+            var cb = (CheckBox)sender;
+            float s = cb.DeviceDpi / 96f;
+            var g = e.Graphics;
+            g.SmoothingMode = SmoothingMode.AntiAlias;
+
+            // Erase the native glyph + text by repainting the card background underneath.
+            using (var bg = new SolidBrush(Theme.P.Panel)) g.FillRectangle(bg, cb.ClientRectangle);
+
+            int box = (int)(18 * s);
+            int by = (cb.Height - box) / 2;
+            var rect = new Rectangle(0, by, box, box);
+            bool on = cb.Checked;
+            bool dim = !cb.Enabled;
+
+            using (var path = UiPaint.RoundRect(rect, (int)(4 * s)))
+            {
+                if (on)
+                {
+                    Color fill = dim ? Theme.P.AccentDim : Theme.P.Accent;
+                    using (var fb = new SolidBrush(fill)) g.FillPath(fb, path);
+                    // tick
+                    using (var pen = new Pen(Theme.P.AccentText, 2f * s) { StartCap = LineCap.Round, EndCap = LineCap.Round })
+                    {
+                        g.DrawLines(pen, new[]
+                        {
+                            new PointF(rect.X + 4 * s, rect.Y + 9 * s),
+                            new PointF(rect.X + 8 * s, rect.Y + 13 * s),
+                            new PointF(rect.X + 14 * s, rect.Y + 5 * s)
+                        });
+                    }
+                }
+                else
+                {
+                    using (var fb = new SolidBrush(Theme.P.Input)) g.FillPath(fb, path);
+                    using (var bp = new Pen(dim ? Theme.P.RowSep : Theme.P.Border, s)) g.DrawPath(bp, path);
+                }
+            }
+
+            Color textColor = dim ? Theme.P.TextHint : Theme.P.Text;
+            var textRect = new Rectangle(box + (int)(8 * s), 0, cb.Width - box - (int)(8 * s), cb.Height);
+            TextRenderer.DrawText(g, cb.Text, cb.Font, textRect, textColor,
+                TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.NoPadding | TextFormatFlags.EndEllipsis);
+        }
+    }
+}


### PR DESCRIPTION
Reworks the main window into the locked **"variant B" warm-dark** design, end to end, on top of the existing `Theme` system. This is a layout/skin change only — no backup/restore logic was touched, and the 196-assertion regression harness stays green.

## What changed
- **Warm-dark palette correction** (`Theme.cs`): the dark shell was shipped as cool/neutral charcoal (`#1B1B1D`, blue > red); the locked mockup is "warm dark, readable gold." Corrected to a warm espresso brown (red ≥ green > blue) across window/bars/panels/inputs/borders. Gold, text, green, and red accents unchanged.
- **`Ui.cs` (new)** — reusable building blocks, all palette-driven and DPI-scaled:
  - `CardPanel`: rounded card with a 1px border and a gold serif section title.
  - `HeaderPanel`: circular logo token + "Savedrake" gold serif wordmark + version + bottom gold rule.
  - `ThemedCheck`: owner-drawn gold-tick checkbox.
- **`Main.Layout.cs` (new)** — `BuildVariantBLayout()` runs at the end of `Main_Load`: it adds the header + three cards (Folders / Autobackup / Backups), **reparents** the existing Designer controls into them (so all event wiring + settings keys keep working), and **surfaces** the autobackup settings that used to live in File > Settings (clean up old backups, send removed to Recycle Bin, back up the moment the game saves, keep-at-most) onto the window with two-way sync to the existing menu-item state. Action row is now `Back up now / Restore / Delete`; Open save/backup folder, Refresh list, and Undo delete moved into the File menu. Every coordinate is scaled by device DPI.
- **`Main.cs`** — the backup list is owner-drawn to match the mockup (leading dot, gold pinned name, right-aligned muted friendly-time, right-aligned status tag), the list scrollbar is darkened via `SetWindowTheme("DarkMode_Explorer")`, and the card/button overrides re-apply on theme toggle. Form design `ClientSize` is now 850×760.
- **`Main.Designer.cs`** — only the form's base `ClientSize`/`MinimumSize` updated (the auto-scale base); the control declarations and wiring are untouched.

## Notes / tradeoffs
- The OS title bar is kept (already DWM-themed warm) with the branded wordmark header below it. The mockup is a frameless concept; going fully frameless (custom drag/resize/snap) is a larger, riskier change and was deliberately deferred — the header is built to host caption buttons if we ever do it.
- The autobackup interval combobox is now a preset `DropDownList` (so it themes fully dark); inline free-typing of a custom interval is no longer offered.

## Verification
- Builds clean in Debug + Release.
- Regression harness: **196 passed, 0 failed**.
- Both themes (warm-dark default + parchment-bronze light) verified live via screenshots; high-DPI (2×) layout verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)