### PR TITLE
Frameless window (header is the top of the window, no OS title bar)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ All notable changes to Savedrake are recorded here. The format is based on
   row is Back up now / Restore / Delete. Open save folder, Open backup folder, Refresh list, and Undo delete moved into
   the File menu. The whole layout is high-DPI aware. The autobackup interval is now chosen from the preset list (custom
   free-typed intervals are no longer entered inline). (#53)
+- The window is now borderless: the branded header is the top of the window (no separate OS title bar), with themed
+  minimize and close buttons in the top-right corner and rounded corners on Windows 11. The window can still be moved by
+  dragging the header and resized from any edge or corner. (#54)
 - The window title bar now follows the theme too (charcoal in dark, parchment in light) on Windows 11, so the whole
   window is cohesive. On Windows 10 the title bar matches dark/light mode; only a few Windows-managed bits (e.g.
   scrollbars) keep the system colour. (#52)

--- a/Savedrake v1.2.3/Main.Designer.cs
+++ b/Savedrake v1.2.3/Main.Designer.cs
@@ -564,6 +564,7 @@
             this.Controls.Add(this.menuStrip1);
             this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             this.MainMenuStrip = this.menuStrip1;
             this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.MaximizeBox = false;

--- a/Savedrake v1.2.3/Main.Layout.cs
+++ b/Savedrake v1.2.3/Main.Layout.cs
@@ -22,9 +22,60 @@ namespace Savedrake
         private Button _btnDelete;
         private Panel _autoSep;
         private ToolStripMenuItem _undoDeleteMenuItem;
+        private CaptionButton _btnMin, _btnClose;
         private bool _syncingSettings;
         private bool _variantBBuilt;
+        private bool _frameless = true; // borderless custom chrome (the header is the top of the window)
         private float _scale = 1f;
+
+        // ---- Frameless custom chrome ----
+        [System.Runtime.InteropServices.DllImport("dwmapi.dll")]
+        private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int value, int size);
+
+        // Re-add the drop shadow the OS frame normally provides (CS_DROPSHADOW). Applied at handle creation because
+        // FormBorderStyle is None from the Designer, so _frameless is already true here.
+        protected override CreateParams CreateParams
+        {
+            get
+            {
+                CreateParams cp = base.CreateParams;
+                if (_frameless) cp.ClassStyle |= 0x00020000; // CS_DROPSHADOW
+                return cp;
+            }
+        }
+
+        // Hit-test the borderless window: a resize grip near every edge/corner, and a drag band over the header's
+        // background (but not over the menu or caption buttons, which return HTCLIENT so they still get clicks). Returning
+        // HTCAPTION lets Windows handle move + Aero Snap natively.
+        protected override void WndProc(ref Message m)
+        {
+            const int WM_NCHITTEST = 0x0084;
+            if (_frameless && _header != null && m.Msg == WM_NCHITTEST && this.WindowState == FormWindowState.Normal)
+            {
+                long lp = m.LParam.ToInt64();
+                int sx = (short)(lp & 0xFFFF), sy = (short)((lp >> 16) & 0xFFFF);
+                Point pt = PointToClient(new Point(sx, sy));
+                int grip = Sx(7);
+                bool l = pt.X <= grip, r = pt.X >= ClientSize.Width - grip;
+                bool t = pt.Y <= grip, b = pt.Y >= ClientSize.Height - grip;
+                int code = 0;
+                if (t && l) code = 13; else if (t && r) code = 14; else if (b && l) code = 16; else if (b && r) code = 17;
+                else if (l) code = 10; else if (r) code = 11; else if (t) code = 12; else if (b) code = 15;
+                if (code != 0) { m.Result = (IntPtr)code; return; }
+                if (pt.Y < _header.Height)
+                {
+                    Point hp = _header.PointToClient(new Point(sx, sy));
+                    if (_header.GetChildAtPoint(hp) == null) { m.Result = (IntPtr)2; return; } // HTCAPTION
+                }
+            }
+            base.WndProc(ref m);
+        }
+
+        private void ApplyFramelessCorners()
+        {
+            // Win11 rounded corners for the borderless window (DWMWA_WINDOW_CORNER_PREFERENCE = 33, DWMWCP_ROUND = 2).
+            try { int round = 2; DwmSetWindowAttribute(this.Handle, 33, ref round, 4); } catch { }
+        }
 
         // Darkens OS-drawn bits a WinForms theme can't reach (the ListView's scrollbar). "DarkMode_Explorer" gives a
         // dark scrollbar on Win10 1809+/Win11; "Explorer" restores the normal light one for the parchment theme.
@@ -63,7 +114,16 @@ namespace Savedrake
             menuStrip1.AutoSize = false;
             menuStrip1.Size = SZ(150, 30);
             _header.Controls.Add(menuStrip1);
-            menuStrip1.Location = new Point(_header.Width - menuStrip1.Width - Sx(24), Sx(22));
+
+            // Caption buttons (minimize / close) at the very top-right corner; File/Help sits to their left.
+            int cbw = Sx(46), cbh = Sx(34);
+            _btnClose = new CaptionButton { Type = CaptionButton.Kind.Close, Size = new Size(cbw, cbh), Location = new Point(_header.Width - cbw, 0), Anchor = AnchorStyles.Top | AnchorStyles.Right };
+            _btnMin = new CaptionButton { Type = CaptionButton.Kind.Minimize, Size = new Size(cbw, cbh), Location = new Point(_header.Width - cbw * 2, 0), Anchor = AnchorStyles.Top | AnchorStyles.Right };
+            _btnClose.Click += (s, e) => this.Close();
+            _btnMin.Click += (s, e) => this.WindowState = FormWindowState.Minimized;
+            _header.Controls.Add(_btnClose); _header.Controls.Add(_btnMin);
+
+            menuStrip1.Location = new Point(_header.Width - menuStrip1.Width - cbw * 2 - Sx(8), Sx(22));
             menuStrip1.Anchor = AnchorStyles.Top | AnchorStyles.Right;
 
             // ---- Cards ----
@@ -158,6 +218,7 @@ namespace Savedrake
             foreach (Control inner in _numKeep.Controls) { inner.BackColor = Theme.P.Input; inner.ForeColor = Theme.P.Text; }
 
             ApplyListScrollTheme();
+            ApplyFramelessCorners();
             listViewColumnResize();
         }
 

--- a/Savedrake v1.2.3/Ui.cs
+++ b/Savedrake v1.2.3/Ui.cs
@@ -182,6 +182,43 @@ namespace Savedrake
         }
     }
 
+    // A minimal themed caption button (minimize / close) for the frameless window. Painted on the header's warm bar;
+    // close turns red on hover. The window's WM_NCHITTEST returns HTCLIENT over these so they receive clicks.
+    internal sealed class CaptionButton : Control
+    {
+        internal enum Kind { Minimize, Close }
+        public Kind Type = Kind.Minimize;
+        bool _hover;
+
+        public CaptionButton()
+        {
+            // Fully paints its own background in OnPaint, so it does not need (and a raw Control does not support)
+            // a transparent BackColor.
+            SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint | ControlStyles.OptimizedDoubleBuffer, true);
+            TabStop = false;
+        }
+
+        protected override void OnMouseEnter(EventArgs e) { _hover = true; Invalidate(); base.OnMouseEnter(e); }
+        protected override void OnMouseLeave(EventArgs e) { _hover = false; Invalidate(); base.OnMouseLeave(e); }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            float s = DeviceDpi / 96f;
+            var g = e.Graphics;
+            g.SmoothingMode = SmoothingMode.AntiAlias;
+            Color bg = _hover ? (Type == Kind.Close ? Theme.P.Danger : Theme.P.Sel) : Theme.P.TitleBar;
+            using (var b = new SolidBrush(bg)) g.FillRectangle(b, ClientRectangle);
+
+            Color fg = (_hover && Type == Kind.Close) ? Color.White : Theme.P.Text;
+            int cx = Width / 2, cy = Height / 2, r = (int)(5 * s);
+            using (var pen = new Pen(fg, Math.Max(1f, 1.3f * s)))
+            {
+                if (Type == Kind.Minimize) g.DrawLine(pen, cx - r, cy, cx + r, cy);
+                else { g.DrawLine(pen, cx - r, cy - r, cx + r, cy + r); g.DrawLine(pen, cx + r, cy - r, cx - r, cy + r); }
+            }
+        }
+    }
+
     // Attaches owner-drawn rendering to a stock CheckBox so the check reads as a gold tick in a gold-tinted rounded box
     // on dark (bronze on parchment in light mode). The CheckBox keeps its native click/toggle behaviour (AutoCheck);
     // we only repaint. Re-reads Theme.P each paint, so it follows the theme toggle.


### PR DESCRIPTION
Completes the exact-mockup match by removing the OS title bar so the branded warm-dark header *is* the top of the window — the last deviation flagged in #53.

## What changed
- **`FormBorderStyle = None`** (Designer) — no OS title bar or frame.
- **Custom chrome** (`Main.Layout.cs`):
  - `WndProc` hit-testing: resize from any edge/corner, and a drag band over the header background. The menu and caption buttons return `HTCLIENT` (so they still receive clicks); the header background returns `HTCAPTION` so Windows handles window move + Aero Snap natively.
  - `CreateParams` adds `CS_DROPSHADOW`; DWM rounds the corners on Windows 11 (`DWMWA_WINDOW_CORNER_PREFERENCE`).
- **Caption buttons** (`Ui.cs` `CaptionButton`) — themed minimize + close in the header's top-right corner (close turns red on hover); File/Help sits to their left. (No maximize — the card layout is a fixed design, `MaximizeBox` stays false.)

## Notes
- Minimize → taskbar (and to tray if "Minimize to tray" is on); Close runs the normal `FormClosing` (saves settings + cleanup).
- A first build crashed because `CaptionButton` set `BackColor = Transparent` (a raw `Control` doesn't support it) — fixed by painting its own background.

## Verification
- Builds clean (Debug + Release), regression harness **196/196**.
- Verified frameless live via a DPI-aware screenshot at 2×: window is exactly the client area (1700×1520, no OS frame), header + min/close render correctly, all cards intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)