### PR TITLE
Fit the frameless window to the monitor work area (bottom no longer cut off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,9 @@ All notable changes to Savedrake are recorded here. The format is based on
 - The window is now borderless: the branded header is the top of the window (no separate OS title bar), with themed
   minimize and close buttons in the top-right corner and rounded corners on Windows 11. The window can still be moved by
   dragging the header and resized from any edge or corner. (#54)
+- The window now always opens fully on screen: it is sized to fit the monitor's work area and nudged away from the
+  edges, so on a shorter screen the bottom (status bar and resize edge) is no longer hidden behind the taskbar. The
+  backup list shrinks to fit. (#55)
 - The window title bar now follows the theme too (charcoal in dark, parchment in light) on Windows 11, so the whole
   window is cohesive. On Windows 10 the title bar matches dark/light mode; only a few Windows-managed bits (e.g.
   scrollbars) keep the system colour. (#52)

--- a/Savedrake v1.2.3/Main.Designer.cs
+++ b/Savedrake v1.2.3/Main.Designer.cs
@@ -568,7 +568,7 @@
             this.MainMenuStrip = this.menuStrip1;
             this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.MaximizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(850, 760);
+            this.MinimumSize = new System.Drawing.Size(850, 600);
             this.Name = "Main";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;

--- a/Savedrake v1.2.3/Main.Layout.cs
+++ b/Savedrake v1.2.3/Main.Layout.cs
@@ -219,7 +219,24 @@ namespace Savedrake
 
             ApplyListScrollTheme();
             ApplyFramelessCorners();
+            FitToWorkArea();
             listViewColumnResize();
+        }
+
+        // Keep the borderless window inside the monitor work area: shrink it if it is taller/wider than the usable area
+        // (the list, anchored top+bottom, absorbs the difference) and nudge it fully on-screen. Without this, a window
+        // taller than the screen would sit pinned at the top with its bottom edge (status bar + resize grip) hidden
+        // behind the taskbar, and with no title bar it could not be dragged up.
+        private void FitToWorkArea()
+        {
+            Rectangle wa = Screen.FromHandle(this.Handle).WorkingArea;
+            int margin = Sx(8);
+            int w = Math.Min(this.Width, wa.Width - margin * 2);
+            int h = Math.Min(this.Height, wa.Height - margin * 2);
+            if (w != this.Width || h != this.Height) this.Size = new Size(w, h);
+            int x = Math.Min(Math.Max(this.Left, wa.Left + margin), wa.Right - this.Width - margin);
+            int y = Math.Min(Math.Max(this.Top, wa.Top + margin), wa.Bottom - this.Height - margin);
+            this.Location = new Point(x, y);
         }
 
         // Re-skin pass for things the generic Theme can't decide from a control name.


### PR DESCRIPTION
## The bug
After going frameless (#54), the window opened at its full design height (760 logical ≈ 1520px at 2× DPI). On a monitor whose **work area is shorter than the window** (e.g. this 2560×1600 display has a 1504px work area, and most laptops are far shorter), the window was pinned at the top of the screen with its **bottom edge hidden behind the taskbar** — the status bar and the bottom resize grip were off-screen. With no OS title bar, you couldn't drag it up to reach them. It read as broken/cut off.

## The fix
- **`FitToWorkArea()`** (run at the end of `BuildVariantBLayout`): shrink the window to the monitor's work area if it's larger, and nudge it fully on-screen with a small margin. The backup list (anchored top+bottom) absorbs the height reduction.
- **Lowered `MinimumSize` height** (760 → 600) so the window can actually shrink to fit a short screen.

## Verification
- `WM_NCHITTEST` probe on the live window confirms the chrome still works after the resize: header = `HTCAPTION` (drag), all four edges + corners = resize codes, min/close buttons = `HTCLIENT` (clickable).
- DPI-aware screenshot: window now opens at y=16 (was y=0), 1700×1472, **fully inside the work area** (bottom 1488 < 1504). Everything visible: header, all three cards, surfaced settings, action row, list, status bar.
- Builds clean, regression harness **196/196**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)