### PR TITLE
Fix borderless window drag + resize (keep native frame, strip only the caption)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ All notable changes to Savedrake are recorded here. The format is based on
 - The window now always opens fully on screen: it is sized to fit the monitor's work area and nudged away from the
   edges, so on a shorter screen the bottom (status bar and resize edge) is no longer hidden behind the taskbar. The
   backup list shrinks to fit. (#55)
+- Fixed window dragging and resizing on the borderless window. The window can now be moved by dragging the header and
+  resized from every edge and corner, and it keeps the native Windows behaviours (Aero Snap, the drop shadow, the
+  minimize animation, and the Alt+Space system menu). Previously the custom header swallowed the clicks, so the window
+  could not be moved at all. (#56)
 - The window title bar now follows the theme too (charcoal in dark, parchment in light) on Windows 11, so the whole
   window is cohesive. On Windows 10 the title bar matches dark/light mode; only a few Windows-managed bits (e.g.
   scrollbars) keep the system colour. (#52)

--- a/Savedrake v1.2.3/Main.Layout.cs
+++ b/Savedrake v1.2.3/Main.Layout.cs
@@ -28,53 +28,103 @@ namespace Savedrake
         private bool _frameless = true; // borderless custom chrome (the header is the top of the window)
         private float _scale = 1f;
 
-        // ---- Frameless custom chrome ----
+        // ---- Frameless custom chrome (Approach B) ----
+        // Instead of FormBorderStyle.None losing every window behavior, we keep a REAL sizable window (WS_THICKFRAME) so
+        // the OS still gives resize, Aero Snap, the drop shadow and minimize animations, and only strip the title-bar
+        // caption by returning 0 from WM_NCCALCSIZE (client fills the whole window -> looks borderless). The form's
+        // WM_NCHITTEST returns the resize/caption codes; the header + status child panels return HTTRANSPARENT (see
+        // HeaderPanel.WndProc / the status MouseDown forwarder) so the hit reaches the form over them.
+        private const int WS_MINIMIZEBOX = 0x00020000, WS_SYSMENU = 0x00080000, WS_THICKFRAME = 0x00040000;
+        private const int WM_NCCALCSIZE = 0x0083, WM_NCHITTEST = 0x0084, WM_NCLBUTTONDOWN = 0x00A1;
+        private const int HTCLIENT = 1, HTCAPTION = 2, HTLEFT = 10, HTRIGHT = 11, HTTOP = 12, HTTOPLEFT = 13,
+                          HTTOPRIGHT = 14, HTBOTTOM = 15, HTBOTTOMLEFT = 16, HTBOTTOMRIGHT = 17;
+
         [System.Runtime.InteropServices.DllImport("dwmapi.dll")]
         private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int value, int size);
+        [System.Runtime.InteropServices.DllImport("dwmapi.dll")]
+        private static extern int DwmExtendFrameIntoClientArea(IntPtr hwnd, ref MARGINS m);
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        private static extern bool ReleaseCapture();
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
 
-        // Re-add the drop shadow the OS frame normally provides (CS_DROPSHADOW). Applied at handle creation because
-        // FormBorderStyle is None from the Designer, so _frameless is already true here.
+        [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        private struct MARGINS { public int Left, Right, Top, Bottom; }
+
         protected override CreateParams CreateParams
         {
             get
             {
                 CreateParams cp = base.CreateParams;
-                if (_frameless) cp.ClassStyle |= 0x00020000; // CS_DROPSHADOW
+                // Keep it a resizable window with a system menu + minimize box (snap, shadow, min-animation, Alt+Space).
+                if (_frameless) cp.Style |= WS_THICKFRAME | WS_MINIMIZEBOX | WS_SYSMENU;
                 return cp;
             }
         }
 
-        // Hit-test the borderless window: a resize grip near every edge/corner, and a drag band over the header's
-        // background (but not over the menu or caption buttons, which return HTCLIENT so they still get clicks). Returning
-        // HTCAPTION lets Windows handle move + Aero Snap natively.
         protected override void WndProc(ref Message m)
         {
-            const int WM_NCHITTEST = 0x0084;
-            if (_frameless && _header != null && m.Msg == WM_NCHITTEST && this.WindowState == FormWindowState.Normal)
+            if (_frameless && _header != null)
             {
-                long lp = m.LParam.ToInt64();
-                int sx = (short)(lp & 0xFFFF), sy = (short)((lp >> 16) & 0xFFFF);
-                Point pt = PointToClient(new Point(sx, sy));
-                int grip = Sx(7);
-                bool l = pt.X <= grip, r = pt.X >= ClientSize.Width - grip;
-                bool t = pt.Y <= grip, b = pt.Y >= ClientSize.Height - grip;
-                int code = 0;
-                if (t && l) code = 13; else if (t && r) code = 14; else if (b && l) code = 16; else if (b && r) code = 17;
-                else if (l) code = 10; else if (r) code = 11; else if (t) code = 12; else if (b) code = 15;
-                if (code != 0) { m.Result = (IntPtr)code; return; }
-                if (pt.Y < _header.Height)
+                if (m.Msg == WM_NCCALCSIZE && m.WParam != IntPtr.Zero)
                 {
-                    Point hp = _header.PointToClient(new Point(sx, sy));
-                    if (_header.GetChildAtPoint(hp) == null) { m.Result = (IntPtr)2; return; } // HTCAPTION
+                    // Remove the non-client frame so the client area fills the whole window (borderless look). The
+                    // WS_THICKFRAME style is still set, so the OS keeps resize/snap/shadow/animations.
+                    m.Result = IntPtr.Zero;
+                    return;
+                }
+                if (m.Msg == WM_NCHITTEST)
+                {
+                    m.Result = (IntPtr)NcHitTest(m.LParam);
+                    return;
                 }
             }
             base.WndProc(ref m);
         }
 
+        // Resize grip near each edge/corner; a caption (drag) band over the header background; client otherwise.
+        private int NcHitTest(IntPtr lParam)
+        {
+            long lp = lParam.ToInt64();
+            int sx = (short)(lp & 0xFFFF), sy = (short)((lp >> 16) & 0xFFFF);
+            Point pt = PointToClient(new Point(sx, sy));
+            int g = Sx(8);
+            bool left = pt.X <= g, right = pt.X >= ClientSize.Width - g;
+            bool top = pt.Y <= g, bottom = pt.Y >= ClientSize.Height - g;
+            if (top && left) return HTTOPLEFT;
+            if (top && right) return HTTOPRIGHT;
+            if (bottom && left) return HTBOTTOMLEFT;
+            if (bottom && right) return HTBOTTOMRIGHT;
+            if (left) return HTLEFT;
+            if (right) return HTRIGHT;
+            if (top) return HTTOP;
+            if (bottom) return HTBOTTOM;
+            if (pt.Y < _header.Height)
+            {
+                Point hp = _header.PointToClient(new Point(sx, sy));
+                if (_header.GetChildAtPoint(hp) == null) return HTCAPTION; // drag (not over menu / caption buttons)
+            }
+            return HTCLIENT;
+        }
+
+        // The header and status strip are child HWNDs that cover the top/bottom resize edges. The header (a custom
+        // control) returns HTTRANSPARENT in its own WndProc; the stock StatusStrip is made transparent the same way via a
+        // NativeWindow hook on its handle, so the bottom edge + corners fall through to the form's WM_NCHITTEST.
+        private sealed class HitTransparentWindow : NativeWindow
+        {
+            protected override void WndProc(ref Message m)
+            {
+                if (m.Msg == 0x0084) { m.Result = (IntPtr)(-1); return; } // WM_NCHITTEST -> HTTRANSPARENT
+                base.WndProc(ref m);
+            }
+        }
+        private HitTransparentWindow _statusHook;
+
         private void ApplyFramelessCorners()
         {
-            // Win11 rounded corners for the borderless window (DWMWA_WINDOW_CORNER_PREFERENCE = 33, DWMWCP_ROUND = 2).
+            // Win11 rounded corners (DWMWA_WINDOW_CORNER_PREFERENCE = 33, DWMWCP_ROUND = 2) + restore the DWM drop shadow.
             try { int round = 2; DwmSetWindowAttribute(this.Handle, 33, ref round, 4); } catch { }
+            try { MARGINS mg = new MARGINS { Left = 1, Right = 1, Top = 1, Bottom = 1 }; DwmExtendFrameIntoClientArea(this.Handle, ref mg); } catch { }
         }
 
         // Darkens OS-drawn bits a WinForms theme can't reach (the ListView's scrollbar). "DarkMode_Explorer" gives a
@@ -219,6 +269,13 @@ namespace Savedrake
 
             ApplyListScrollTheme();
             ApplyFramelessCorners();
+            // Make the bottom status strip transparent to hit-testing so the bottom window edge/corners can resize.
+            // Done last so it binds the FINAL handle (Theme/ResumeLayout can recreate the strip's handle earlier).
+            if (_statusHook == null && statusStrip1.IsHandleCreated)
+            {
+                _statusHook = new HitTransparentWindow();
+                _statusHook.AssignHandle(statusStrip1.Handle);
+            }
             FitToWorkArea();
             listViewColumnResize();
         }

--- a/Savedrake v1.2.3/Ui.cs
+++ b/Savedrake v1.2.3/Ui.cs
@@ -133,6 +133,18 @@ namespace Savedrake
             BackColor = Color.Transparent;
         }
 
+        // Make the header's own surface transparent to hit-testing so clicks on its empty areas fall through to the
+        // parent Form (whose WM_NCHITTEST returns HTCAPTION/resize codes) — that's what makes the borderless window
+        // draggable and top-resizable by the header. The header's child controls (menu, caption buttons) are separate
+        // window handles that are hit first, so they still receive their own clicks.
+        protected override void WndProc(ref Message m)
+        {
+            const int WM_NCHITTEST = 0x0084;
+            const int HTTRANSPARENT = -1;
+            if (m.Msg == WM_NCHITTEST) { m.Result = (IntPtr)HTTRANSPARENT; return; }
+            base.WndProc(ref m);
+        }
+
         protected override void OnPaint(PaintEventArgs e)
         {
             float s = DeviceDpi / 96f;


### PR DESCRIPTION
## The bug you hit
The borderless window **could not be dragged**. Root cause: the custom header is a child `Panel` with its own window handle, so real mouse input hit-tests the *header* (returns `HTCLIENT`) and the form's `WM_NCHITTEST`/`HTCAPTION` drag logic never runs. Resize was broken on the header- and status-covered edges for the same reason. My earlier `SendMessage(WM_NCHITTEST)` "probe" was a false positive — it calls the form's handler directly and bypasses the child-window hit-testing that real input goes through.

This is the classic, well-documented `FormBorderStyle.None` trap (a deep-research pass confirmed it and the fix).

## The fix — keep a real sizable window, strip only the caption
- `CreateParams` adds `WS_THICKFRAME | WS_MINIMIZEBOX | WS_SYSMENU`, so the OS still provides **resize, Aero Snap, the drop shadow, the minimize animation, and the Alt+Space system menu**.
- `WM_NCCALCSIZE` returns 0 to remove the non-client frame → the window still *looks* borderless.
- The form's `WM_NCHITTEST` returns resize codes near the edges and `HTCAPTION` over the header.
- `HeaderPanel.WndProc` and a `NativeWindow` hook on the `StatusStrip` return `HTTRANSPARENT`, so clicks over those docked child panels fall through to the form (that's what makes the header draggable and the top/bottom edges resizable).
- `DwmExtendFrameIntoClientArea` restores the drop shadow; corners stay rounded on Win11.

## Verified with REAL input (not a SendMessage probe this time)
Using `SetCursorPos` + `mouse_event` (which go through the OS's real hit-testing):
- **Drag:** clicking the header and moving moved the window exactly **220,160**. ✅
- **Resize:** left / right / top / bottom edges each resized **150px** (top/bottom confirmed in the shrink direction, since the window opens against the screen edges). ✅
- Visual: still a clean borderless window with shadow + rounded corners.
- Builds clean (Debug + Release), regression harness **196/196**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)