### PR TITLE
WPF migration phase 3: WPF shell (borderless WindowChrome + warm-dark theme + cards)

### DIFF
--- a/Savedrake.App/App.xaml
+++ b/Savedrake.App/App.xaml
@@ -1,0 +1,12 @@
+<Application x:Class="Savedrake.App.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Themes/Dark.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/Savedrake.App/App.xaml.cs
+++ b/Savedrake.App/App.xaml.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Threading;
+using System.Windows;
+using System.Windows.Threading;
+
+namespace Savedrake.App
+{
+    // WPF application entry point. Enforces a single running instance via a named mutex, initializes the
+    // Savedrake.Core rolling logger, and routes any unhandled exception (UI thread or background) into the log
+    // so a crash is recorded rather than lost. `Log` here is Savedrake.Log from Savedrake.Core.
+    public partial class App : Application
+    {
+        // Unique per-user name so a second launch detects the first and exits. The leading "Local\" keeps it
+        // per-session, which is what we want for a desktop app.
+        private const string MutexName = "Local\\Savedrake.App.SingleInstance";
+
+        private Mutex _instanceMutex;
+        private bool _ownsMutex;
+
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            // Single-instance guard. If we cannot create-and-own the mutex, another copy is already running.
+            bool createdNew;
+            _instanceMutex = new Mutex(true, MutexName, out createdNew);
+            _ownsMutex = createdNew;
+            if (!createdNew)
+            {
+                // Already running; bail out quietly before any window appears.
+                Shutdown();
+                return;
+            }
+
+            // Start logging and capture crashes from both the dispatcher (UI) and any other thread.
+            Savedrake.Log.Init();
+            Savedrake.Log.Info("Savedrake.App starting.");
+
+            DispatcherUnhandledException += OnDispatcherUnhandledException;
+            AppDomain.CurrentDomain.UnhandledException += OnDomainUnhandledException;
+
+            base.OnStartup(e);
+        }
+
+        private void OnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
+        {
+            try { Savedrake.Log.Error("Unhandled UI exception.", e.Exception); }
+            catch { /* logging must never throw into the handler */ }
+        }
+
+        private void OnDomainUnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            try { Savedrake.Log.Error("Unhandled non-UI exception.", e.ExceptionObject as Exception); }
+            catch { /* logging must never throw into the handler */ }
+        }
+
+        protected override void OnExit(ExitEventArgs e)
+        {
+            try
+            {
+                if (_instanceMutex != null)
+                {
+                    if (_ownsMutex)
+                    {
+                        try { _instanceMutex.ReleaseMutex(); } catch { }
+                    }
+                    _instanceMutex.Dispose();
+                    _instanceMutex = null;
+                }
+            }
+            catch { }
+            base.OnExit(e);
+        }
+    }
+}

--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -1,0 +1,118 @@
+<Window x:Class="Savedrake.App.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:shell="clr-namespace:System.Windows.Shell;assembly=PresentationFramework"
+        Title="Savedrake"
+        Width="850" Height="760"
+        MinWidth="700" MinHeight="560"
+        WindowStyle="None"
+        AllowsTransparency="False"
+        ResizeMode="CanResize"
+        WindowStartupLocation="CenterScreen"
+        Background="{StaticResource ShellBrush}"
+        TextOptions.TextFormattingMode="Display"
+        UseLayoutRounding="True"
+        SnapsToDevicePixels="True">
+
+    <!-- Borderless window via WindowChrome so native drag / resize / Aero-Snap / shadow are preserved. -->
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="48" ResizeBorderThickness="6" GlassFrameThickness="0,0,0,1" CornerRadius="0" />
+    </WindowChrome.WindowChrome>
+
+    <!-- Outer margin so the espresso shell shows around the content. -->
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />   <!-- header -->
+            <RowDefinition Height="Auto" />   <!-- gold rule -->
+            <RowDefinition Height="*" />      <!-- content -->
+            <RowDefinition Height="Auto" />   <!-- status bar -->
+        </Grid.RowDefinitions>
+
+        <!-- ============================ HEADER (draggable caption) ============================ -->
+        <Border Grid.Row="0" Background="{StaticResource BarBrush}" CornerRadius="10,10,0,0" Padding="14,8">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />   <!-- brand token -->
+                    <ColumnDefinition Width="Auto" />   <!-- wordmark + version -->
+                    <ColumnDefinition Width="*" />      <!-- drag spacer -->
+                    <ColumnDefinition Width="Auto" />   <!-- right controls -->
+                </Grid.ColumnDefinitions>
+
+                <!-- 40px circular brand token: card-filled ellipse, thin gold-alpha stroke, gold serif 'S'. -->
+                <Grid Grid.Column="0" Width="40" Height="40" VerticalAlignment="Center">
+                    <Ellipse Fill="{StaticResource CardBrush}" Stroke="{StaticResource GoldRuleBrush}" StrokeThickness="1" />
+                    <TextBlock Text="S" FontFamily="Georgia, Times New Roman" FontSize="22" FontWeight="SemiBold"
+                               Foreground="{StaticResource WordmarkBrush}"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" />
+                </Grid>
+
+                <!-- Wordmark in serif gold + small version. -->
+                <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" Margin="12,0,0,0">
+                    <TextBlock Text="Savedrake" FontFamily="Georgia, Times New Roman" FontSize="26"
+                               Foreground="{StaticResource WordmarkBrush}" VerticalAlignment="Center">
+                        <TextBlock.Resources>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="TextOptions.TextFormattingMode" Value="Ideal" />
+                            </Style>
+                        </TextBlock.Resources>
+                    </TextBlock>
+                    <TextBlock Text="1.4.0" FontSize="12" Foreground="{StaticResource TextSecondaryBrush}"
+                               VerticalAlignment="Bottom" Margin="8,0,0,5" />
+                </StackPanel>
+
+                <!-- Right-side controls: clickable (opt out of caption drag). -->
+                <StackPanel Grid.Column="3" Orientation="Horizontal" VerticalAlignment="Center"
+                            shell:WindowChrome.IsHitTestVisibleInChrome="True">
+                    <Button Content="File" Style="{StaticResource HeaderMenuButton}" />
+                    <Button Content="Help" Style="{StaticResource HeaderMenuButton}" Margin="2,0,8,0" />
+                    <Button x:Name="MinimizeButton" Content="&#x2014;" Style="{StaticResource CaptionButton}"
+                            ToolTip="Minimize" Click="MinimizeButton_Click" />
+                    <Button x:Name="CloseButton" Content="&#x2715;" Style="{StaticResource CaptionCloseButton}"
+                            ToolTip="Close" Click="CloseButton_Click" />
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- 1px gold hairline under the header. -->
+        <Border Grid.Row="1" Height="1" Background="{StaticResource GoldRuleBrush}" />
+
+        <!-- ============================ CONTENT: three cards ============================ -->
+        <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" Padding="0,12,0,0">
+            <StackPanel>
+
+                <!-- Folders -->
+                <Border Style="{StaticResource CardBorder}">
+                    <StackPanel>
+                        <TextBlock Text="Folders" Style="{StaticResource SectionTitle}" />
+                        <TextBlock Text="Save folder and backup folder settings appear here."
+                                   Style="{StaticResource CardPlaceholder}" />
+                    </StackPanel>
+                </Border>
+
+                <!-- Autobackup -->
+                <Border Style="{StaticResource CardBorder}">
+                    <StackPanel>
+                        <TextBlock Text="Autobackup" Style="{StaticResource SectionTitle}" />
+                        <TextBlock Text="Automatic backup schedule and on/off control appear here."
+                                   Style="{StaticResource CardPlaceholder}" />
+                    </StackPanel>
+                </Border>
+
+                <!-- Backups -->
+                <Border Style="{StaticResource CardBorder}">
+                    <StackPanel>
+                        <TextBlock Text="Backups" Style="{StaticResource SectionTitle}" />
+                        <TextBlock Text="The list of saved backups appears here."
+                                   Style="{StaticResource CardPlaceholder}" />
+                    </StackPanel>
+                </Border>
+
+            </StackPanel>
+        </ScrollViewer>
+
+        <!-- ============================ STATUS BAR ============================ -->
+        <Border Grid.Row="3" Background="{StaticResource BarBrush}" CornerRadius="0,0,10,10" Padding="14,7">
+            <TextBlock x:Name="StatusText" Text="Ready." FontSize="12" Foreground="{StaticResource TextSecondaryBrush}" />
+        </Border>
+    </Grid>
+</Window>

--- a/Savedrake.App/MainWindow.xaml.cs
+++ b/Savedrake.App/MainWindow.xaml.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+
+namespace Savedrake.App
+{
+    // The borderless themed shell window. WindowChrome (see XAML) keeps native drag / resize / Aero-Snap.
+    // On Win11 we additionally ask DWM for rounded corners, immersive dark mode, and a caption color that
+    // matches the espresso header bar, so the system-drawn parts blend with our theme. All best-effort.
+    public partial class MainWindow : Window
+    {
+        // DWM window attributes (dwmapi.h).
+        private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20; // BOOL: title bar / system UI dark
+        private const int DWMWA_WINDOW_CORNER_PREFERENCE = 33; // int: 2 == DWMWCP_ROUND
+        private const int DWMWA_CAPTION_COLOR = 35;            // COLORREF: 0x00BBGGRR
+
+        private const int DWMWCP_ROUND = 2;
+
+        // The header/caption bar color (#241C14) as a Win32 COLORREF (0x00BBGGRR).
+        // R=0x24, G=0x1C, B=0x14  ->  0x00141C24
+        private const int CaptionColorRef = 0x00141C24;
+
+        [DllImport("dwmapi.dll", PreserveSig = true)]
+        private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int attrValue, int attrSize);
+
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+
+        protected override void OnSourceInitialized(EventArgs e)
+        {
+            base.OnSourceInitialized(e);
+            ApplyDwmTheming();
+        }
+
+        // Ask DWM to round corners, go dark, and tint the caption to our bar color. Each call is guarded:
+        // older Windows builds simply return a non-zero HRESULT, which we ignore.
+        private void ApplyDwmTheming()
+        {
+            try
+            {
+                IntPtr hwnd = new WindowInteropHelper(this).Handle;
+                if (hwnd == IntPtr.Zero) return;
+
+                int darkMode = 1;
+                DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, ref darkMode, sizeof(int));
+
+                int corner = DWMWCP_ROUND;
+                DwmSetWindowAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, ref corner, sizeof(int));
+
+                int caption = CaptionColorRef;
+                DwmSetWindowAttribute(hwnd, DWMWA_CAPTION_COLOR, ref caption, sizeof(int));
+            }
+            catch (Exception ex)
+            {
+                try { Savedrake.Log.Error("DWM theming failed (non-fatal).", ex); }
+                catch { }
+            }
+        }
+
+        private void MinimizeButton_Click(object sender, RoutedEventArgs e)
+        {
+            WindowState = WindowState.Minimized;
+        }
+
+        private void CloseButton_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+    }
+}

--- a/Savedrake.App/Savedrake.App.csproj
+++ b/Savedrake.App/Savedrake.App.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Savedrake.App: the WPF desktop shell (Phase 3 of the WinForms -> WPF migration).
+    Borderless, themed "warm-dark espresso + gold" window. References Savedrake.Core for the
+    portable logic (logging, scan, restore, etc.). UseWindowsForms is on for the tray icon that
+    comes in a later phase. Targets net48 + C# 7.3 to match the rest of the solution.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <OutputType>WinExe</OutputType>
+    <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
+    <LangVersion>7.3</LangVersion>
+    <AssemblyName>Savedrake.App</AssemblyName>
+    <RootNamespace>Savedrake.App</RootNamespace>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Savedrake.Core\Savedrake.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Savedrake.App/Themes/Dark.xaml
+++ b/Savedrake.App/Themes/Dark.xaml
@@ -1,0 +1,253 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+        Locked "warm-dark espresso + gold" palette for the Savedrake WPF shell.
+        Colors are exact per the design mockup. Keep these in sync with the light parchment theme
+        (added later). Brushes only here; controls live in MainWindow.xaml.
+    -->
+
+    <!-- Surfaces -->
+    <Color x:Key="ShellColor">#1F1811</Color>
+    <Color x:Key="BarColor">#241C14</Color>
+    <Color x:Key="CardColor">#2A2118</Color>
+    <Color x:Key="CardAltColor">#251D15</Color>
+    <Color x:Key="InputColor">#1A140C</Color>
+    <Color x:Key="BorderColor">#3A3025</Color>
+    <Color x:Key="GoldDimOutlineColor">#6B5A33</Color>
+    <Color x:Key="RowSepColor">#2F261A</Color>
+    <Color x:Key="SelectionColor">#3E3223</Color>
+
+    <!-- Text -->
+    <Color x:Key="TextColor">#E9E4D8</Color>
+    <Color x:Key="TextSecondaryColor">#A39B88</Color>
+    <Color x:Key="TextHintColor">#837B69</Color>
+
+    <!-- Accents -->
+    <Color x:Key="AccentGoldColor">#C8A24C</Color>
+    <Color x:Key="AccentTextColor">#211A0E</Color>
+    <Color x:Key="AccentDimColor">#D3BE86</Color>
+    <Color x:Key="WordmarkColor">#D8B968</Color>
+    <Color x:Key="SuccessColor">#8FB36A</Color>
+    <Color x:Key="DangerColor">#C77B6F</Color>
+
+    <!-- Brushes -->
+    <SolidColorBrush x:Key="ShellBrush" Color="{StaticResource ShellColor}" />
+    <SolidColorBrush x:Key="BarBrush" Color="{StaticResource BarColor}" />
+    <SolidColorBrush x:Key="CardBrush" Color="{StaticResource CardColor}" />
+    <SolidColorBrush x:Key="CardAltBrush" Color="{StaticResource CardAltColor}" />
+    <SolidColorBrush x:Key="InputBrush" Color="{StaticResource InputColor}" />
+    <SolidColorBrush x:Key="BorderBrush" Color="{StaticResource BorderColor}" />
+    <SolidColorBrush x:Key="GoldDimOutlineBrush" Color="{StaticResource GoldDimOutlineColor}" />
+    <SolidColorBrush x:Key="RowSepBrush" Color="{StaticResource RowSepColor}" />
+    <SolidColorBrush x:Key="SelectionBrush" Color="{StaticResource SelectionColor}" />
+
+    <SolidColorBrush x:Key="TextBrush" Color="{StaticResource TextColor}" />
+    <SolidColorBrush x:Key="TextSecondaryBrush" Color="{StaticResource TextSecondaryColor}" />
+    <SolidColorBrush x:Key="TextHintBrush" Color="{StaticResource TextHintColor}" />
+
+    <SolidColorBrush x:Key="AccentGoldBrush" Color="{StaticResource AccentGoldColor}" />
+    <SolidColorBrush x:Key="AccentTextBrush" Color="{StaticResource AccentTextColor}" />
+    <SolidColorBrush x:Key="AccentDimBrush" Color="{StaticResource AccentDimColor}" />
+    <SolidColorBrush x:Key="WordmarkBrush" Color="{StaticResource WordmarkColor}" />
+    <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
+    <SolidColorBrush x:Key="DangerBrush" Color="{StaticResource DangerColor}" />
+
+    <!-- A 60%-alpha gold for the hairline rule under the header. -->
+    <SolidColorBrush x:Key="GoldRuleBrush" Color="{StaticResource AccentGoldColor}" Opacity="0.6" />
+
+    <!-- ===================== Reusable styles ===================== -->
+
+    <!-- Card container: rounded espresso panel with a thin border. -->
+    <Style x:Key="CardBorder" TargetType="Border">
+        <Setter Property="Background" Value="{StaticResource CardBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="12" />
+        <Setter Property="Padding" Value="18" />
+        <Setter Property="Margin" Value="0,0,0,12" />
+    </Style>
+
+    <!-- Gold section heading at the top of each card. -->
+    <Style x:Key="SectionTitle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Foreground" Value="{StaticResource AccentGoldBrush}" />
+        <Setter Property="Margin" Value="0,0,0,8" />
+    </Style>
+
+    <!-- Faint placeholder line for the empty card bodies in this shell. -->
+    <Style x:Key="CardPlaceholder" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="Foreground" Value="{StaticResource TextHintBrush}" />
+    </Style>
+
+    <!-- Primary gold button: filled gold, dark text. -->
+    <Style x:Key="PrimaryButton" TargetType="Button">
+        <Setter Property="Foreground" Value="{StaticResource AccentTextBrush}" />
+        <Setter Property="Background" Value="{StaticResource AccentGoldBrush}" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Padding" Value="16,8" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="bd" Background="{TemplateBinding Background}"
+                            CornerRadius="8" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{StaticResource AccentDimBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="bd" Property="Opacity" Value="0.45" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Gold-outline button: transparent fill, gold border + gold text. -->
+    <Style x:Key="OutlineButton" TargetType="Button">
+        <Setter Property="Foreground" Value="{StaticResource AccentGoldBrush}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="{StaticResource GoldDimOutlineBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Padding" Value="16,8" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="bd" Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="8" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{StaticResource SelectionBrush}" />
+                            <Setter TargetName="bd" Property="BorderBrush" Value="{StaticResource AccentGoldBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="bd" Property="Opacity" Value="0.45" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Danger button: red-tinted outline, red text. -->
+    <Style x:Key="DangerButton" TargetType="Button">
+        <Setter Property="Foreground" Value="{StaticResource DangerBrush}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="{StaticResource DangerBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Padding" Value="16,8" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="bd" Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="8" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{StaticResource DangerBrush}" />
+                            <Setter TargetName="bd" Property="TextElement.Foreground" Value="{StaticResource AccentTextBrush}" />
+                            <Setter Property="Foreground" Value="{StaticResource AccentTextBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="bd" Property="Opacity" Value="0.45" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Header text-menu button ("File", "Help"): flat, no chrome, light text. -->
+    <Style x:Key="HeaderMenuButton" TargetType="Button">
+        <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="Padding" Value="10,6" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="bd" Background="{TemplateBinding Background}"
+                            CornerRadius="6" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{StaticResource SelectionBrush}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Caption window buttons (minimize / close): ~46x32, flat, glyph in light text. -->
+    <Style x:Key="CaptionButton" TargetType="Button">
+        <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Width" Value="46" />
+        <Setter Property="Height" Value="32" />
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="bd" Background="{TemplateBinding Background}" CornerRadius="6">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{StaticResource SelectionBrush}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Caption close button: red hover. -->
+    <Style x:Key="CaptionCloseButton" TargetType="Button" BasedOn="{StaticResource CaptionButton}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="bd" Background="{TemplateBinding Background}" CornerRadius="6">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{StaticResource DangerBrush}" />
+                            <Setter Property="Foreground" Value="{StaticResource AccentTextBrush}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/Savedrake.sln
+++ b/Savedrake.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RestoreHarness", "RestoreHa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Savedrake.Core", "Savedrake.Core\Savedrake.Core.csproj", "{B2E4B7A1-3C5D-4E6F-A1B2-C3D4E5F60718}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Savedrake.App", "Savedrake.App\Savedrake.App.csproj", "{C7A11E55-1234-4ABC-9DEF-0123456789AB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{B2E4B7A1-3C5D-4E6F-A1B2-C3D4E5F60718}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B2E4B7A1-3C5D-4E6F-A1B2-C3D4E5F60718}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B2E4B7A1-3C5D-4E6F-A1B2-C3D4E5F60718}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7A11E55-1234-4ABC-9DEF-0123456789AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7A11E55-1234-4ABC-9DEF-0123456789AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7A11E55-1234-4ABC-9DEF-0123456789AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7A11E55-1234-4ABC-9DEF-0123456789AB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The first **visible** WPF milestone: a new `Savedrake.App` (net48 WPF) rendering the locked warm-dark espresso+gold mockup as a real WPF window. Card bodies are empty placeholders for now — features wire up in later phases. The WinForms app is untouched and still ships.

## What's here
- **Borderless window via WPF `WindowChrome`** — native drag, resize, Aero Snap, and drop shadow, *none* of the WinForms `WM_NCHITTEST` gymnastics. Verified with **real synthesized mouse input**: header drag moved the window exactly 200,140; right-edge resize delta 150.
- **`Themes/Dark.xaml`** — the locked palette as brushes + reusable styles (`CardBorder`, `SectionTitle`, gold-primary / gold-outline / danger buttons, caption buttons).
- **Branded header** (gold brand token + serif "Savedrake" wordmark + version + File/Help + minimize/close + gold rule), **three rounded gold-titled cards** (Folders / Autobackup / Backups), and a status bar.
- **`App.xaml.cs`** — single-instance `Mutex`, `Log.Init()` + crash handlers routed to the Core `Log`.
- **`MainWindow`** — DWM rounded corners + immersive dark + caption color on init.

## Verification
- Full solution builds via the **exact CI path** (`nuget restore` + plain `msbuild`) — the SDK-style WPF project restores and builds.
- The WPF app launches and renders the mockup (screenshot reviewed).
- Regression harness still **196 passed, 0 failed** (no impact from adding the project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)