### PR TITLE
WPF migration phase 4a: Core RestoreService/BackupService + real-flow harness test

### DIFF
--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -813,6 +813,9 @@ namespace RestoreHarness
             Check("RestoreService: staging/rollback temp dirs cleaned up", noTempDirs,
                 "leftover=" + string.Join(",", Directory.GetDirectories(remote).Select(Path.GetFileName)));
             Check("RestoreService: final status is 'Restore successful.'", status.Last == "Restore successful.", "last=" + status.Last);
+            Check("RestoreService: the Steam-Cloud confirm was prompted", dialog.Confirms.Count >= 1, "confirms=" + dialog.Confirms.Count);
+            Check("RestoreService: a success Info dialog was shown", dialog.Infos.Count >= 1, "infos=" + string.Join(" ;; ", dialog.Infos));
+            Check("RestoreService: no Warning dialog on the happy path", dialog.Warns.Count == 0, "warns=" + string.Join(" ;; ", dialog.Warns));
             Console.WriteLine();
         }
 

--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -1,12 +1,37 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
+using Savedrake; // compile-time reference to Savedrake.Core for the end-to-end RestoreService flow test
 
 namespace RestoreHarness
 {
+    // Recording stubs for the Core service seams, used by Test_RestoreServiceFlow to drive the REAL
+    // RestoreService.Restore orchestration headlessly. Confirm returns a configurable bool (default true);
+    // Info/Warn/Error and Set record their text so the test can assert no error dialog fired.
+    internal sealed class StubDialog : IDialogService
+    {
+        public bool ConfirmResult = true;
+        public readonly List<string> Confirms = new List<string>();
+        public readonly List<string> Infos = new List<string>();
+        public readonly List<string> Warns = new List<string>();
+        public readonly List<string> Errors = new List<string>();
+        public bool Confirm(string title, string message) { Confirms.Add(title + " | " + message); return ConfirmResult; }
+        public void Info(string title, string message) { Infos.Add(title + " | " + message); }
+        public void Warn(string title, string message) { Warns.Add(title + " | " + message); }
+        public void Error(string title, string message) { Errors.Add(title + " | " + message); }
+    }
+
+    internal sealed class StubStatus : IStatusSink
+    {
+        public readonly List<string> Lines = new List<string>();
+        public string Last { get { return Lines.Count > 0 ? Lines[Lines.Count - 1] : null; } }
+        public void Set(string text) { Lines.Add(text); }
+    }
+
     // Headless reflection harness for Savedrake's transactional-restore helpers.
     // Loads the REAL compiled Savedrake.exe and invokes the actual private methods
     // (static + UI-free instance methods via an uninitialized Main instance) against
@@ -110,6 +135,7 @@ namespace RestoreHarness
                 Test_ClassifyBackup();   // P1 UI: full Validated/Legacy/Corrupt classification for "Validate all"
                 Test_LogRedaction();   // P2: the rolling logger redacts the Steam account id and user profile path
                 Test_DiskPreflight();   // disk-space preflight helpers (size math + free-space check, fail-open)
+                Test_RestoreServiceFlow();   // Phase 4a: the REAL Core RestoreService.Restore orchestration end-to-end
             }
             catch (Exception ex)
             {
@@ -726,6 +752,67 @@ namespace RestoreHarness
             object[] a3 = { @"\\nonexistent-share-xyz\nope", 1000L, null };
             bool r3 = (bool)hasSpace.Invoke(null, a3);
             Check("undeterminable volume -> fails open (true)", r3);
+            Console.WriteLine();
+        }
+
+        // Phase 4a: exercise the REAL Savedrake.Core orchestration (RestoreService.Restore) end-to-end through its
+        // service seams, with stub IDialogService/IStatusSink. Stronger than the file-level happy-path mirror: it runs
+        // the actual prompt/guard sequence + the transactional swap as the future WPF app will call them. Compile-time
+        // referenced (not reflected), so the call site is the genuine public API.
+        static void Test_RestoreServiceFlow()
+        {
+            Console.WriteLine("== RestoreService.Restore end-to-end (real Core orchestration) ==");
+
+            // A real DD2-style live folder (...\remote\win64_save) holding OLD save data.
+            string remote = NewDir("rsf_remote");
+            string live = Path.Combine(remote, "win64_save");
+            Directory.CreateDirectory(live);
+            File.WriteAllText(Path.Combine(live, "data000.bin"), "OLD-DATA");
+            File.WriteAllText(Path.Combine(live, "system.bin"), "OLD-SYS");
+
+            // A separate backup folder, and a valid backup zip carrying NEW content + an integrity manifest (so the
+            // P1 read-side gate sees a matching manifest and does NOT block).
+            string backupDir = NewDir("rsf_backup");
+            string srcForManifest = NewDir("rsf_src");
+            File.WriteAllText(Path.Combine(srcForManifest, "data000.bin"), "NEW-DATA");
+            File.WriteAllText(Path.Combine(srcForManifest, "system.bin"), "NEW-SYS");
+            string manifest = (string)CM("Manifest", "BuildBackupManifest").Invoke(null, new object[] { srcForManifest });
+            string backupZip = Path.Combine(backupDir, "newsave.zip");
+            MakeZip(backupZip, z =>
+            {
+                z.AddEntry("data000.bin", B("NEW-DATA"));
+                z.AddEntry("system.bin", B("NEW-SYS"));
+                z.AddEntry("_savedrake/manifest.json", B(manifest));
+            });
+
+            var dialog = new StubDialog { ConfirmResult = true }; // auto-Yes to the Steam Cloud + any checkpoint prompt
+            var status = new StubStatus();
+
+            RestoreResult res = RestoreService.Restore(
+                new RestoreRequest
+                {
+                    BackupZipPath = backupZip,
+                    LiveSaveDir = live,
+                    BackupDir = backupDir,
+                    GameRunning = false
+                },
+                dialog, status);
+
+            Check("RestoreService: result.Ok is true", res.Ok, "msg=" + res.Message + " errors=" + string.Join(" ;; ", dialog.Errors));
+            Check("RestoreService: result not Cancelled", !res.Cancelled);
+            Check("RestoreService: no Error dialog fired", dialog.Errors.Count == 0, "errors=" + string.Join(" ;; ", dialog.Errors));
+            Check("RestoreService: data000.bin now holds NEW content",
+                File.Exists(Path.Combine(live, "data000.bin")) && File.ReadAllText(Path.Combine(live, "data000.bin")) == "NEW-DATA");
+            Check("RestoreService: system.bin now holds NEW content",
+                File.Exists(Path.Combine(live, "system.bin")) && File.ReadAllText(Path.Combine(live, "system.bin")) == "NEW-SYS");
+
+            string[] checkpoints = Directory.GetFiles(backupDir, "(Pre-Restore)*.zip");
+            Check("RestoreService: a (Pre-Restore) checkpoint zip was created", checkpoints.Length == 1, "found " + checkpoints.Length);
+
+            bool noTempDirs = Directory.GetDirectories(remote).All(d => !Path.GetFileName(d).StartsWith("._savedrake"));
+            Check("RestoreService: staging/rollback temp dirs cleaned up", noTempDirs,
+                "leftover=" + string.Join(",", Directory.GetDirectories(remote).Select(Path.GetFileName)));
+            Check("RestoreService: final status is 'Restore successful.'", status.Last == "Restore successful.", "last=" + status.Last);
             Console.WriteLine();
         }
 

--- a/RestoreHarness/RestoreHarness.csproj
+++ b/RestoreHarness/RestoreHarness.csproj
@@ -24,6 +24,16 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+  <!-- Compile-time reference to Savedrake.Core so Test_RestoreServiceFlow can implement the Core service interfaces
+       (IDialogService / IStatusSink) and call RestoreService.Restore directly, exercising the REAL Core orchestration
+       end-to-end. The rest of the harness still loads Core by reflection from the app's bin (AssemblyResolve);
+       MSBuild also copies Core's dll next to this exe, which is byte-identical code built from the same source. -->
+  <ItemGroup>
+    <ProjectReference Include="..\Savedrake.Core\Savedrake.Core.csproj">
+      <Project>{B2E4B7A1-3C5D-4E6F-A1B2-C3D4E5F60718}</Project>
+      <Name>Savedrake.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />
   </ItemGroup>

--- a/Savedrake.Core/BackupService.cs
+++ b/Savedrake.Core/BackupService.cs
@@ -1,0 +1,188 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Savedrake
+{
+    // UI-agnostic backup orchestration for the WPF migration (Phase 4a). Transcribes the WinForms BackupOperation
+    // flow VERBATIM: the input guards, the no-save-data guard (R6), the same==same guard, the disk-space preflight,
+    // the atomic temp-zip build (AddDirectory + in-zip integrity manifest + hidden comment), the two-layer
+    // verify-on-create, and the atomic File.Move publish. Every MessageBox.Show is routed through IDialogService and
+    // every Status.Text write through IStatusSink, with the SAME title/message/status text. All non-UI work uses the
+    // already-extracted Core helpers (DiskPreflight.*, Manifest.*, BackupNaming.*) — the same ones Main forwards to.
+    //
+    // Deliberately NOT modelled (these were UI-only / autobackup-cleanup concerns in BackupOperation, and are CALLER
+    // responsibilities in the WPF app — see the report):
+    //   * checkbox_auto.Checked = false on a guard failure (turning the auto-backup toggle off in the UI),
+    //   * the "non-default save folder" warning (directorywarningShown + PromptForFolderSelection),
+    //   * the "backup location does not exist -> create it?" prompt (the WPF app validates BackupDir up front;
+    //     this service requires it to exist, mirroring the post-prompt state),
+    //   * the operation lock (_operationInProgress) — a caller concern, as in RestoreService,
+    //   * success/failure SOUND playback (PlaySoundFromResource / PlaySoundFromResource2),
+    //   * LoadBackupHistory() list refresh, the _lastAutoBackupFingerprint baseline advance, and the
+    //     post-autobackup CleanUpOldAutobackups() retention pass (_cleanupMenuItem-gated).
+    public static class BackupService
+    {
+        public static BackupResult Backup(BackupRequest req, IDialogService dialog, IStatusSink status)
+        {
+            // Check if the source directory is not empty and the directory exists.
+            if (string.IsNullOrWhiteSpace(req.LiveSaveDir) || !Directory.Exists(req.LiveSaveDir))
+            {
+                dialog.Error("Error", "Please select a valid Savegame location first.");
+                return new BackupResult { Ok = false, Message = "Please select a valid Savegame location first." };
+            }
+
+            // Check if the backup directory is not empty.
+            if (string.IsNullOrWhiteSpace(req.BackupDir))
+            {
+                dialog.Error("Error", "Please select a Backup location.");
+                return new BackupResult { Ok = false, Message = "Please select a Backup location." };
+            }
+
+            // Check if the directory is empty.
+            DirectoryInfo directoryInfo = new DirectoryInfo(req.LiveSaveDir);
+            if (directoryInfo.GetFileSystemInfos().Length == 0)
+            {
+                dialog.Error("Error", "The selected Savegame location is empty.");
+                return new BackupResult { Ok = false, Message = "The selected Savegame location is empty." };
+            }
+
+            // R6: a folder can be non-empty yet hold no DD2 save data (wrong folder, or leftover files). Refuse to
+            // create a useless/empty-looking backup — require at least one data*.bin / system.bin (searched
+            // recursively; .Any() short-circuits on the first match, so the common case is fast). If the recursive
+            // scan can't complete (e.g. a permission-denied/locked subfolder on a non-default path), fail OPEN:
+            // proceed rather than block a legitimate backup — and never let it throw out of here.
+            bool hasSaveData = true;
+            try
+            {
+                hasSaveData = Directory
+                    .EnumerateFiles(req.LiveSaveDir, "*", SearchOption.AllDirectories)
+                    .Any(p => SaveScan.IsRealSaveEntry(Path.GetFileName(p)));
+            }
+            catch (UnauthorizedAccessException) { }
+            catch (System.IO.IOException) { }
+            if (!hasSaveData)
+            {
+                dialog.Error("Error",
+                    "The selected Savegame location has no Dragon's Dogma 2 save data " +
+                    "(no data*.bin / system.bin), so there is nothing to back up.");
+                return new BackupResult { Ok = false, Message = "The selected Savegame location has no Dragon's Dogma 2 save data." };
+            }
+
+            // Check if the source and destination directories are not the same.
+            if (req.LiveSaveDir.Equals(req.BackupDir, StringComparison.OrdinalIgnoreCase))
+            {
+                dialog.Error("Error", "The Savegame and Backup locations cannot be the same.");
+                return new BackupResult { Ok = false, Message = "The Savegame and Backup locations cannot be the same." };
+            }
+
+            // The "backup location does not exist -> create it?" prompt is a CALLER concern (see header). Require the
+            // backup folder to exist here, mirroring the post-prompt state of the original flow.
+            if (!Directory.Exists(req.BackupDir))
+            {
+                dialog.Error("Error", "Please select a Backup location.");
+                return new BackupResult { Ok = false, Message = "Please select a Backup location." };
+            }
+
+            string backupFileName;
+            if (req.RandomName)
+            {
+                backupFileName = Path.Combine(req.BackupDir, GenerateBackupFileName(req.BackupDir, req.IsAutoBackup));
+            }
+            else
+            {
+                string autoPrefix = req.IsAutoBackup ? "auto" : "";
+                // Timestamp names are only second-resolution, so two backups in the same second would collide.
+                // The random-name branch already dedups (GenerateBackupFileName); make this branch unique too so a
+                // second same-second backup can't silently overwrite the first.
+                backupFileName = BackupNaming.MakeUniquePath(Path.Combine(req.BackupDir, $"{autoPrefix}backup_{DateTime.Now:yyMMddHHmmss}.zip"));
+            }
+
+            // Disk-space preflight: refuse before writing if the backup volume can't hold the data (+ headroom). A
+            // disk-full mid-write only leaves a temp file (cleaned up below), but checking first avoids the wasted
+            // work and a confusing partial failure.
+            long sourceSize = DiskPreflight.GetDirectorySize(req.LiveSaveDir);
+            if (!DiskPreflight.HasFreeSpaceFor(req.BackupDir, sourceSize, out string backupSpaceReason))
+            {
+                status.Set("Backup skipped: low disk space.");
+                dialog.Warn("Low Disk Space", "Cannot create the backup: " + backupSpaceReason + ".");
+                return new BackupResult { Ok = false, Message = "Cannot create the backup: " + backupSpaceReason + "." };
+            }
+
+            // Build the zip into a temp file in the SAME directory, then publish it with an atomic rename. A
+            // failure mid-Save (disk full, a source save file locked/removed) then leaves only the temp file
+            // (cleaned up below) — never a partial/corrupt .zip at the real backup path, and never an existing
+            // good backup overwritten by a truncated stub.
+            string tempZip = backupFileName + ".savedrake.tmp";
+            try
+            {
+                // Sweep any orphaned temp files left by a previous backup that was hard-killed mid-write (a graceful
+                // failure cleans up via the catch below; a power-loss/kill can't). They're invisible to the *.zip
+                // listing/counter but still consume disk, so reclaim them here. Subsumes deleting our own tempZip.
+                try { foreach (string stale in Directory.GetFiles(req.BackupDir, "*.savedrake.tmp")) File.Delete(stale); } catch { }
+                using (Ionic.Zip.ZipFile zip = new Ionic.Zip.ZipFile())
+                {
+                    status.Set("Backup started... Please wait.");
+                    zip.AddDirectory(req.LiveSaveDir); // Add the directory to the zip
+                    // Integrity manifest (P1 layer 2): record every source file's path/length/SHA-256 inside the zip
+                    // so we can prove on create (and re-check later) that the backup is complete and uncorrupted.
+                    zip.AddEntry(Manifest.ManifestEntryName, System.Text.Encoding.UTF8.GetBytes(Manifest.BuildBackupManifest(req.LiveSaveDir)));
+                    zip.Comment = "SamMorrison9800"; // This is the hidden comment
+                    zip.Save(tempZip); // Save to the temp file first
+                }
+                // Verify-on-create: a backup that fails verification must never be published as if it were good. Reject
+                // it here (delete the temp, throw into the catch below) so the user is told now, while their live saves
+                // are untouched, instead of discovering it only at restore time. Layer 1 = CRC test-extract of every
+                // entry; layer 2 = every file present with the manifest's recorded length + SHA-256.
+                if (!Manifest.VerifyZipRestorable(tempZip, out string verifyReason) || !Manifest.VerifyZipAgainstManifest(tempZip, out verifyReason))
+                {
+                    try { File.Delete(tempZip); } catch { }
+                    throw new System.IO.IOException("the backup failed verification after writing (" + verifyReason + ")");
+                }
+                File.Move(tempZip, backupFileName); // atomically publish the completed backup
+
+                string okMsg = req.IsAutoBackup ? $"Autobackup created at {DateTime.Now.ToString("hh:mm:ss tt")}." : "Backup created successfully.";
+                status.Set(okMsg);
+                Log.Info("Backup created: " + Path.GetFileName(backupFileName) + (req.IsAutoBackup ? " (auto)" : ""));
+                return new BackupResult { Ok = true, CreatedPath = backupFileName, Message = okMsg };
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Backup failed", ex);
+                // Clean up the partial temp file so a failed backup leaves nothing behind.
+                try { if (File.Exists(tempZip)) File.Delete(tempZip); } catch { }
+                status.Set("Backup failed.");
+                dialog.Error("Error", $"An error occurred while creating the backup: {ex.Message}");
+                return new BackupResult { Ok = false, Message = $"An error occurred while creating the backup: {ex.Message}" };
+            }
+        }
+
+        // Transcribed from Main.GenerateBackupFileName (the "randomly generated" name format). Lives in Core now so a
+        // backup with the random-name format selected does not depend on the WinForms textbox2 instance state; the
+        // backup directory is passed in. Same word list, same (Auto) prefix, same File.Exists dedup counter.
+        private static string GenerateBackupFileName(string backupDir, bool isAutoBackup)
+        {
+            // Use a random combination of words for the file name
+            string[] words = { "Bitterblack", "Everfall", "Cassardis", "Cyclops", "Dragonforged", "Chimera", "Gransys", "Sorcerer", "Strider", "Mage", "Warrior", "Mystic", "Knight", "Ranger", "Assassin", "Archer", "Magic", "Bluemoon", "Soren", "Dragonsbane", "Salomet", "Quina", "Mercedes", "Julien", "Selene", "Feste", "Daimon", "Ur-Dragon", "Golem", "Harpy", "Saurian", "Ogre", "Lich", "Wight", "Cockatrice", "Manticore", "Goblin", "Hobgoblin", "Bandit", "Phantom", "Specter", "Wraith", "Skeleton", "Zombie", "Hellhound", "Chimera", "Griffin", "Naga", "Lamia", "Medusa", "Basilisk", "Wyrm", "Wyvern", "Drake", "Dark Bishop", "Eliminator", "Gazer", "Death", "Maneater", "Giant", "Undead", "Cursed", "Abyssal", "Lure", "Brine", "Riftstone", "Portcrystal", "Wakestone", "Godsbane", "Airtight", "Flask", "Liquid", "Vim", "Ferrystone", "Conqueror", "Periapts" };
+            Random rnd = new Random();
+
+            // Apply the (Auto) prefix if isAutoBackup is true
+            string autoPrefix = isAutoBackup ? "(Auto) " : "";
+
+            // Generate the random file name
+            string fileName = $"{autoPrefix}{words[rnd.Next(words.Length)]} {words[rnd.Next(words.Length)]}.zip";
+
+            // Check if the file already exists and append a number if necessary
+            int counter = 1;
+            string fullPath = Path.Combine(backupDir, fileName);
+            while (File.Exists(fullPath))
+            {
+                // Ensure the counter is added after the (Auto) prefix
+                fileName = $"{autoPrefix}{Path.GetFileNameWithoutExtension(fileName).Replace($" {counter - 1}", "")} {counter++}.zip";
+                fullPath = Path.Combine(backupDir, fileName);
+            }
+
+            return fileName;
+        }
+    }
+}

--- a/Savedrake.Core/RestoreService.cs
+++ b/Savedrake.Core/RestoreService.cs
@@ -1,0 +1,188 @@
+using System;
+using System.IO;
+
+namespace Savedrake
+{
+    // UI-agnostic restore orchestration for the WPF migration (Phase 4a). Transcribes the WinForms restore flow
+    // VERBATIM: the prompt/guard sequence from Main.button_res_Click, then the destructive swap from
+    // Main.RestoreTransactional + Main.HandleRestoreFailure. Every MessageBox.Show is routed through IDialogService
+    // and every Status.Text write through IStatusSink, with the SAME title/message/status text. All file work uses
+    // the already-extracted RestoreEngine.* primitives — the same ones Main forwards to.
+    //
+    // SAFETY-CRITICAL: a bug here can delete a user's only save. The stagingStarted / rollbackOk bookkeeping and the
+    // ORDERED catch blocks are the data-loss safety and are preserved exactly. CALLER concerns deliberately NOT
+    // included (they were UI-only in button_res_Click): the operation lock (_operationInProgress), the save-watcher
+    // suppression (_suppressSaveWatcher), and the post-success list refresh / undo-button / fingerprint-baseline.
+    public static class RestoreService
+    {
+        public static RestoreResult Restore(RestoreRequest req, IDialogService dialog, IStatusSink status)
+        {
+            // ----- prompt/guard sequence (transcribed from button_res_Click) -----
+
+            // Validate the live + backup folders exist (textbox1 / textbox2 validity checks).
+            if (string.IsNullOrWhiteSpace(req.LiveSaveDir) || !Directory.Exists(req.LiveSaveDir))
+            {
+                dialog.Error("Invalid Directory", "Please provide a valid Savegame location.");
+                return new RestoreResult { Cancelled = true, Message = "Please provide a valid Savegame location." };
+            }
+
+            if (string.IsNullOrWhiteSpace(req.BackupDir) || !Directory.Exists(req.BackupDir))
+            {
+                dialog.Error("Invalid Directory", "Please provide a valid Backup file location.");
+                return new RestoreResult { Cancelled = true, Message = "Please provide a valid Backup file location." };
+            }
+
+            // Validate the backup is readable BEFORE touching the live saves, so a
+            // corrupt or missing zip can't strand the user with no save game.
+            if (string.IsNullOrWhiteSpace(req.BackupZipPath) || !File.Exists(req.BackupZipPath))
+            {
+                dialog.Error("Restore Failed", "The selected Backup file no longer exists on disk.");
+                return new RestoreResult { Cancelled = true, Message = "The selected Backup file no longer exists on disk." };
+            }
+
+            string filePath = req.BackupZipPath;
+            string liveDir = req.LiveSaveDir;
+
+            // STEP 1 — game-running guard (R2). The caller takes the FRESH synchronous read (CheckGameRunningStatus)
+            // and passes it as req.GameRunning; do NOT use a cached value.
+            if (req.GameRunning)
+            {
+                dialog.Warn("Game Running", "Please quit Dragon's Dogma 2 before restoring.");
+                return new RestoreResult { Cancelled = true, Message = "Please quit Dragon's Dogma 2 before restoring." };
+            }
+
+            // STEP 2 — Steam Cloud warning (run4 C). Declining costs nothing; no live file touched yet.
+            if (!dialog.Confirm(
+                    "Exit Steam Before Restoring",
+                    "Before restoring, fully EXIT Steam (or disable Dragon's Dogma 2 Cloud Saves in " +
+                    "Steam > Properties). Otherwise Steam may re-upload your OLD save and overwrite this restore." +
+                    "\n\nSavedrake snapshots your current save first, so you can undo this from File > Undo last restore." +
+                    "\n\nContinue with the restore?"))
+            {
+                status.Set("Restore cancelled.");
+                return new RestoreResult { Cancelled = true, Message = "Restore cancelled." };
+            }
+
+            // STEP 3 — validate the backup BEFORE touching live saves (R1).
+            if (!RestoreEngine.ValidateBackup(filePath, out string reason))
+            {
+                dialog.Error("Restore Failed", reason + "\n\nYour current save files have not been touched.");
+                return new RestoreResult { Cancelled = true, Message = reason };
+            }
+
+            // STEP 3a — re-verify a manifest-bearing backup against its recorded hashes before touching live saves
+            // (P1). Catches a backup that has bit-rotted on disk since it was created. Legacy backups without a
+            // manifest are unaffected and restore as before.
+            if (Manifest.RestoreBlockedByManifest(filePath, out string integrityReason))
+            {
+                dialog.Error("Restore Failed",
+                    "This backup failed its integrity check (" + integrityReason + ").\n\n" +
+                    "Your current save files have not been touched.");
+                return new RestoreResult { Cancelled = true, Message = "This backup failed its integrity check (" + integrityReason + ")." };
+            }
+
+            // STEP 3c — disk-space preflight: the restore extracts the backup into a staging folder on the save
+            // volume before swapping it in. Refuse up front if that volume can't hold it (+ headroom), with the
+            // live saves untouched, instead of failing partway through the extraction.
+            long restoreNeeded = DiskPreflight.GetZipUncompressedSize(filePath);
+            if (!DiskPreflight.HasFreeSpaceFor(liveDir, restoreNeeded, out string restoreSpaceReason))
+            {
+                dialog.Warn("Low Disk Space",
+                    "Cannot restore: " + restoreSpaceReason + ".\n\nYour current save files have not been touched.");
+                return new RestoreResult { Cancelled = true, Message = "Cannot restore: " + restoreSpaceReason + "." };
+            }
+
+            // STEP 3b — pre-restore safety checkpoint (P4). RestoreTransactional deletes the current live save
+            // on success, so snapshot it first into a "(Pre-Restore)" backup the user can roll back to. If the
+            // snapshot can't be made, let the user decide rather than silently proceeding without a safety net.
+            status.Set("Creating pre-restore checkpoint...");
+            if (!RestoreEngine.CreatePreRestoreCheckpoint(liveDir, req.BackupDir))
+            {
+                if (!dialog.Confirm(
+                        "Pre-Restore Checkpoint Failed",
+                        "Savedrake could not create a safety snapshot of your current save before restoring.\n\n" +
+                        "If you continue, your current save will be replaced and its current state will be lost.\n\n" +
+                        "Restore anyway?"))
+                {
+                    status.Set("Restore cancelled.");
+                    return new RestoreResult { Cancelled = true, Message = "Restore cancelled." };
+                }
+            }
+
+            // STEP 4 — delegate ALL destructive work (staging, swap, rollback, cleanup) to the transaction.
+            bool ok = RestoreTransactional(filePath, liveDir, dialog, status);
+            return new RestoreResult
+            {
+                Ok = ok,
+                Cancelled = false,
+                Message = ok ? "Restore successful." : "Restore failed."
+            };
+        }
+
+        // ===== Transactional restore (Bucket 2 — kills R1 / R2 / R3) =====
+        // Invariant: at every instant the user's saves exist intact in exactly one place — liveDir or rollbackDir.
+        // Transcribed verbatim from Main.RestoreTransactional; Status.Text -> status.Set, MessageBox -> dialog.
+        private static bool RestoreTransactional(string filePath, string liveDir, IDialogService dialog, IStatusSink status)
+        {
+            status.Set("Restore started... Please wait.");
+            Log.Info("Restore started from: " + Path.GetFileName(filePath));
+            string stagingDir  = RestoreEngine.CreateSiblingTempDir(liveDir, "savedrake_stage");
+            string rollbackDir = RestoreEngine.CreateSiblingTempDir(liveDir, "savedrake_rollback");
+            bool stagingStarted = false; // true once T4 begins: live then holds disposable STAGED content, not originals
+            bool rollbackOk = true;      // success leaves true (old saves now stale); a failed recovery sets it false
+            try
+            {
+                RestoreEngine.ExtractZipToStaging(filePath, stagingDir);   // T1 stage + zip-slip guard
+                RestoreEngine.FlattenNestedLayout(stagingDir);            // T1b flatten nested win64_save wrapper(s) (R3)
+                if (!RestoreEngine.VerifyStagedDir(stagingDir))           // T2 verify on disk
+                    throw new System.IO.IOException(
+                        "The backup extracted but does not contain Dragon's Dogma 2 save data. Restore aborted.");
+
+                RestoreEngine.MoveDirContents(liveDir, rollbackDir);      // T3 move live aside (same-volume rename)
+                stagingStarted = true;                                    // originals are all in rollbackDir now
+                RestoreEngine.MoveDirContents(stagingDir, liveDir);       // T4 move staged into live
+                // T5 strip ReadOnly (R2). The restore is ALREADY committed here (staged saves are live), so this
+                // cosmetic post-step must never throw into the catch below and trigger a rollback of a good
+                // restore. Best-effort guard (ClearReadOnlyRecursive is itself non-throwing now too).
+                try { RestoreEngine.ClearReadOnlyRecursive(liveDir); } catch { } // T5 strip ReadOnly (R2)
+
+                status.Set("Restore successful.");                        // T6 commit
+                Log.Info("Restore successful from: " + Path.GetFileName(filePath));
+                dialog.Info("Information", "Restore successful.");
+                return true;
+            }
+            // CS0160: order is load-bearing. ZipException : Exception, UnauthorizedAccessException : SystemException,
+            // IOException : SystemException — none derives from another, so the first three are order-free; Exception MUST be last.
+            catch (Ionic.Zip.ZipException ze)       { rollbackOk = HandleRestoreFailure(ze,  rollbackDir, liveDir, stagingStarted, dialog, status); return false; }
+            catch (UnauthorizedAccessException uae) { rollbackOk = HandleRestoreFailure(uae, rollbackDir, liveDir, stagingStarted, dialog, status); return false; }
+            catch (System.IO.IOException ioEx)      { rollbackOk = HandleRestoreFailure(ioEx, rollbackDir, liveDir, stagingStarted, dialog, status); return false; }
+            catch (Exception ex)                    { rollbackOk = HandleRestoreFailure(ex,  rollbackDir, liveDir, stagingStarted, dialog, status); return false; }
+            finally
+            {
+                RestoreEngine.TryDeleteDir(stagingDir);
+                // Delete the set-aside originals ONLY when provably safe. Success leaves rollbackOk==true (live now
+                // holds the committed restore, so the old copy is stale); a FULLY recovered failure also leaves it
+                // true with rollbackDir already emptied. When recovery did NOT fully succeed (rollbackOk==false),
+                // rollbackDir may hold the user's ONLY intact copy — preserve it (the dialog named it for recovery).
+                if (rollbackOk) RestoreEngine.TryDeleteDir(rollbackDir);
+            }
+        }
+
+        private static bool HandleRestoreFailure(Exception ex, string rollbackDir, string liveDir, bool stagingStarted, IDialogService dialog, IStatusSink status)
+        {
+            bool recovered = RestoreEngine.Rollback(liveDir, rollbackDir, stagingStarted);
+            Log.Error("Restore failed (recovered=" + recovered + ")", ex);
+            status.Set(recovered
+                ? "Restore failed. Your previous save files were restored."
+                : "Restore failed. See the dialog to recover your saves.");
+            string tail = recovered
+                ? "\n\nYour previous save files have been restored."
+                : "\n\nWARNING: automatic recovery did not fully complete, but your ORIGINAL save files were NOT deleted." +
+                  " Some may already be back in your save folder:\n" + liveDir +
+                  "\nand the rest are preserved here:\n" + rollbackDir +
+                  "\nMove any files from the second folder into the first to finish recovering.";
+            dialog.Error("Restore Failed", ex.Message + tail);
+            return recovered; // tells RestoreTransactional whether rollbackDir is empty (safe to delete) or holds the only copy
+        }
+    }
+}

--- a/Savedrake.Core/Services.cs
+++ b/Savedrake.Core/Services.cs
@@ -1,0 +1,72 @@
+namespace Savedrake
+{
+    // UI-agnostic service seams for the WinForms -> WPF migration (Phase 4a). The orchestration services
+    // (RestoreService / BackupService) transcribe the WinForms restore + backup flows VERBATIM (same logic,
+    // sequence, and dialog/status text), with every direct MessageBox.Show / Status.Text call replaced by a
+    // call through one of these interfaces. The WPF app supplies real implementations (a dialog host + a status
+    // bar binding); the headless harness supplies stubs. SAFETY-CRITICAL: the services drive a destructive
+    // restore — do not reorder the guards or change the text.
+
+    // Modal user interaction the flows need. Confirm returns true for the "Yes"/affirmative choice (the WinForms
+    // originals used MessageBox YesNo and tested == DialogResult.Yes). Info/Warn/Error are one-way notifications
+    // mapping to the Information/Warning/Error MessageBox icons the originals used.
+    public interface IDialogService
+    {
+        bool Confirm(string title, string message);
+        void Info(string title, string message);
+        void Warn(string title, string message);
+        void Error(string title, string message);
+    }
+
+    // The status-line sink. Each Set(...) replaces a `Status.Text = ...` write in the original flow, verbatim.
+    public interface IStatusSink
+    {
+        void Set(string text);
+    }
+
+    // Inputs for a restore. The caller resolves these from its UI/state before calling RestoreService.Restore:
+    //   BackupZipPath = the selected backup file (textbox2 + selected list item in the WinForms app),
+    //   LiveSaveDir   = the live save folder (textbox1), BackupDir = the backup folder (textbox2),
+    //   GameRunning   = a FRESH game-running read taken by the caller (the WinForms guard called
+    //                   CheckGameRunningStatus() synchronously, NOT the cached isGameRunning field).
+    public sealed class RestoreRequest
+    {
+        public string BackupZipPath;
+        public string LiveSaveDir;
+        public string BackupDir;
+        public bool GameRunning;
+    }
+
+    // Outcome of a restore. Ok = the swap committed. Cancelled = a guard stopped before any destructive work
+    // (inputs invalid, game running, user declined, validation/integrity/space/checkpoint gate). Message mirrors
+    // the status text. When Ok==false && Cancelled==false the swap was attempted and failed (recovery ran).
+    public sealed class RestoreResult
+    {
+        public bool Ok;
+        public bool Cancelled;
+        public string Message;
+    }
+
+    // Inputs for a backup. LiveSaveDir = the save folder to back up (textbox1), BackupDir = where the zip is
+    // written (textbox2), IsAutoBackup = whether this is a timer-driven autobackup (controls the file-name prefix
+    // and the autobackup status text), RandomName = whether the "randomly generated" name format menu item is
+    // checked (chooses GenerateBackupFileName vs the timestamped name). Pieces of BackupOperation that are purely
+    // autobackup-cleanup / retention-limit concerns are CALLER responsibilities and are intentionally not modelled
+    // here (see BackupService for the list).
+    public sealed class BackupRequest
+    {
+        public string LiveSaveDir;
+        public string BackupDir;
+        public bool IsAutoBackup;
+        public bool RandomName;
+    }
+
+    // Outcome of a backup. Ok = a verified backup zip was published. CreatedPath = its full path on success.
+    // Message mirrors the status text.
+    public sealed class BackupResult
+    {
+        public bool Ok;
+        public string CreatedPath;
+        public string Message;
+    }
+}


### PR DESCRIPTION
The orchestration the WPF app will call, created **additively** — the shipped WinForms `Main.cs` is **byte-for-byte unchanged** (so the verified restore path stays frozen). The restore/backup flows are transcribed **verbatim** into Core with the UI behind small interfaces.

## New in `Savedrake.Core`
- **`Services.cs`** — `IDialogService`, `IStatusSink`, and the request/result DTOs.
- **`RestoreService.Restore(...)`** — the full restore flow, verbatim: input guards → game-running → Steam-cloud confirm → `ValidateBackup` → manifest re-verify → disk preflight → pre-restore checkpoint → the **T1–T6 transactional swap** with the exact `stagingStarted`/`rollbackOk` bookkeeping, the four ordered catch blocks, and the `rollbackOk`-gated finally (the data-loss safety — confirmed verbatim). Caller concerns (op lock, watcher suppression, list refresh, fingerprint baseline) are intentionally excluded.
- **`BackupService.Backup(...)`** — `BackupOperation`'s manual happy path (verified zip + in-zip manifest + atomic publish). Autobackup cleanup/limit/sounds noted as caller concerns.

## Harness
- New **`Test_RestoreServiceFlow`** drives the **real `RestoreService.Restore` end-to-end** (stub dialog/status, crafted manifest-bearing zip, temp live dir) and asserts the swap, the `(Pre-Restore)` checkpoint, and temp cleanup — stronger coverage than the old mirror. `RestoreHarness` now references Core at compile time.

## Verification
- Debug + Release build clean.
- Harness: **204 passed, 0 failed** (was 196; +8 RestoreService checks), all data-loss / partial-T4 / zip-slip / checkpoint groups still green.
- `git diff` confirms `Main.cs` (and every WinForms file) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)