### PR TITLE
WPF migration phase 4b: Folders + backup list + Backup/Restore/Delete

### DIFF
--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:shell="clr-namespace:System.Windows.Shell;assembly=PresentationFramework"
+        xmlns:vm="clr-namespace:Savedrake.App.ViewModels"
         Title="Savedrake"
         Width="850" Height="760"
         MinWidth="700" MinHeight="560"
@@ -18,6 +19,14 @@
     <WindowChrome.WindowChrome>
         <WindowChrome CaptionHeight="48" ResizeBorderThickness="6" GlassFrameThickness="0,0,0,1" CornerRadius="0" />
     </WindowChrome.WindowChrome>
+
+    <Window.Resources>
+        <!-- Display-only converters for the Backups list rows. -->
+        <vm:PinnedToBrushConverter x:Key="PinDotBrush" OnKey="AccentGoldBrush" OffKey="TextSecondaryBrush" />
+        <vm:PinnedToBrushConverter x:Key="PinNameBrush" OnKey="AccentGoldBrush" OffKey="TextBrush" />
+        <vm:RowToPillTextConverter x:Key="PillText" />
+        <vm:RowToPillBrushConverter x:Key="PillBrush" />
+    </Window.Resources>
 
     <!-- Outer margin so the espresso shell shows around the content. -->
     <Grid Margin="12">
@@ -84,8 +93,43 @@
                 <Border Style="{StaticResource CardBorder}">
                     <StackPanel>
                         <TextBlock Text="Folders" Style="{StaticResource SectionTitle}" />
-                        <TextBlock Text="Save folder and backup folder settings appear here."
-                                   Style="{StaticResource CardPlaceholder}" />
+
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="90" />    <!-- label -->
+                                <ColumnDefinition Width="*" />     <!-- path box -->
+                                <ColumnDefinition Width="Auto" />  <!-- count -->
+                                <ColumnDefinition Width="Auto" />  <!-- browse -->
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="8" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+
+                            <!-- Save game row -->
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Save game" VerticalAlignment="Center"
+                                       FontSize="13" Foreground="{StaticResource TextSecondaryBrush}" />
+                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding SaveDir}" IsReadOnly="True"
+                                     VerticalContentAlignment="Center" Padding="8,6" FontSize="12"
+                                     Background="{StaticResource InputBrush}" Foreground="{StaticResource TextBrush}"
+                                     BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" />
+                            <Button Grid.Row="0" Grid.Column="3" Content="Browse" Style="{StaticResource OutlineButton}"
+                                    Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseSaveCommand}" />
+
+                            <!-- Backups row -->
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Backups" VerticalAlignment="Center"
+                                       FontSize="13" Foreground="{StaticResource TextSecondaryBrush}" />
+                            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding BackupDir}" IsReadOnly="True"
+                                     VerticalContentAlignment="Center" Padding="8,6" FontSize="12"
+                                     Background="{StaticResource InputBrush}" Foreground="{StaticResource TextBrush}"
+                                     BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" />
+                            <TextBlock Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" Margin="10,0,0,0"
+                                       FontSize="12" Foreground="{StaticResource TextHintBrush}"
+                                       Text="{Binding BackupCount, StringFormat={}{0} backups}" />
+                            <Button Grid.Row="2" Grid.Column="3" Content="Browse" Style="{StaticResource OutlineButton}"
+                                    Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseBackupCommand}" />
+                        </Grid>
                     </StackPanel>
                 </Border>
 
@@ -93,7 +137,7 @@
                 <Border Style="{StaticResource CardBorder}">
                     <StackPanel>
                         <TextBlock Text="Autobackup" Style="{StaticResource SectionTitle}" />
-                        <TextBlock Text="Automatic backup schedule and on/off control appear here."
+                        <TextBlock Text="Autobackup settings — coming in the next update."
                                    Style="{StaticResource CardPlaceholder}" />
                     </StackPanel>
                 </Border>
@@ -101,9 +145,119 @@
                 <!-- Backups -->
                 <Border Style="{StaticResource CardBorder}">
                     <StackPanel>
-                        <TextBlock Text="Backups" Style="{StaticResource SectionTitle}" />
-                        <TextBlock Text="The list of saved backups appears here."
-                                   Style="{StaticResource CardPlaceholder}" />
+                        <!-- Header row: title on the left, actions on the right. -->
+                        <Grid Margin="0,0,0,10">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="Backups" Style="{StaticResource SectionTitle}"
+                                       Margin="0" VerticalAlignment="Center" />
+                            <StackPanel Grid.Column="1" Orientation="Horizontal">
+                                <Button Content="Back up now" Style="{StaticResource PrimaryButton}"
+                                        Padding="14,7" Command="{Binding BackupCommand}" />
+                                <Button Content="Restore" Style="{StaticResource OutlineButton}"
+                                        Padding="14,7" Margin="8,0,0,0" Command="{Binding RestoreCommand}" />
+                                <Button Content="Delete" Style="{StaticResource DangerButton}"
+                                        Padding="14,7" Margin="8,0,0,0" Command="{Binding DeleteCommand}" />
+                            </StackPanel>
+                        </Grid>
+
+                        <!-- Backup list: dark, header-less, custom row template. -->
+                        <ListView ItemsSource="{Binding Backups}"
+                                  SelectedItem="{Binding SelectedBackup, Mode=TwoWay}"
+                                  Background="{StaticResource CardBrush}"
+                                  BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                                  Foreground="{StaticResource TextBrush}"
+                                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                  MinHeight="180" MaxHeight="320">
+                            <ListView.Resources>
+                                <!-- No column headers: this is a single-template list, not a grid. -->
+                                <Style TargetType="GridViewColumnHeader">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </Style>
+                            </ListView.Resources>
+
+                            <!-- Dark, full-width, theme-coloured rows with a custom selection highlight. -->
+                            <ListView.ItemContainerStyle>
+                                <Style TargetType="ListViewItem">
+                                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                    <Setter Property="Padding" Value="0" />
+                                    <Setter Property="BorderThickness" Value="0,0,0,1" />
+                                    <Setter Property="BorderBrush" Value="{StaticResource RowSepBrush}" />
+                                    <Setter Property="Background" Value="Transparent" />
+                                    <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+                                    <Setter Property="Template">
+                                        <Setter.Value>
+                                            <ControlTemplate TargetType="ListViewItem">
+                                                <Border x:Name="bd" Background="{TemplateBinding Background}"
+                                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                                        BorderThickness="{TemplateBinding BorderThickness}">
+                                                    <ContentPresenter VerticalAlignment="Center" />
+                                                </Border>
+                                                <ControlTemplate.Triggers>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter TargetName="bd" Property="Background" Value="{StaticResource CardAltBrush}" />
+                                                    </Trigger>
+                                                    <Trigger Property="IsSelected" Value="True">
+                                                        <Setter TargetName="bd" Property="Background" Value="{StaticResource SelectionBrush}" />
+                                                    </Trigger>
+                                                </ControlTemplate.Triggers>
+                                            </ControlTemplate>
+                                        </Setter.Value>
+                                    </Setter>
+                                </Style>
+                            </ListView.ItemContainerStyle>
+
+                            <!-- Right-click actions. Delete is wired; the rest are stubs for a later phase. -->
+                            <ListView.ContextMenu>
+                                <ContextMenu>
+                                    <MenuItem Header="Rename" IsEnabled="False" />
+                                    <MenuItem Header="Delete"
+                                              Command="{Binding PlacementTarget.DataContext.DeleteCommand,
+                                                        RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                    <MenuItem Header="Pin" IsEnabled="False" />
+                                    <Separator />
+                                    <MenuItem Header="Validate all" IsEnabled="False" />
+                                </ContextMenu>
+                            </ListView.ContextMenu>
+
+                            <ListView.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid Margin="10,9">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />  <!-- dot -->
+                                            <ColumnDefinition Width="*" />     <!-- file name -->
+                                            <ColumnDefinition Width="Auto" />  <!-- pill -->
+                                            <ColumnDefinition Width="Auto" />  <!-- friendly time -->
+                                        </Grid.ColumnDefinitions>
+
+                                        <!-- Leading dot: gold if pinned, muted otherwise. -->
+                                        <Ellipse Grid.Column="0" Width="8" Height="8" VerticalAlignment="Center"
+                                                 Margin="0,0,10,0"
+                                                 Fill="{Binding IsPinned, Converter={StaticResource PinDotBrush}}" />
+
+                                        <!-- File name: gold if pinned, normal text otherwise. -->
+                                        <TextBlock Grid.Column="1" Text="{Binding FileName}" VerticalAlignment="Center"
+                                                   FontSize="13" TextTrimming="CharacterEllipsis"
+                                                   Foreground="{Binding IsPinned, Converter={StaticResource PinNameBrush}}" />
+
+                                        <!-- Status / pin pill. -->
+                                        <Border Grid.Column="2" Margin="10,0" Padding="8,2" CornerRadius="9"
+                                                Background="{StaticResource InputBrush}" VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding Converter={StaticResource PillText}}"
+                                                       FontSize="11"
+                                                       Foreground="{Binding Converter={StaticResource PillBrush}}" />
+                                        </Border>
+
+                                        <!-- Friendly creation time, right-aligned and muted. -->
+                                        <TextBlock Grid.Column="3" Text="{Binding FriendlyTime}" VerticalAlignment="Center"
+                                                   FontSize="12" Foreground="{StaticResource TextSecondaryBrush}"
+                                                   TextAlignment="Right" MinWidth="80" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ListView.ItemTemplate>
+                        </ListView>
                     </StackPanel>
                 </Border>
 
@@ -112,7 +266,7 @@
 
         <!-- ============================ STATUS BAR ============================ -->
         <Border Grid.Row="3" Background="{StaticResource BarBrush}" CornerRadius="0,0,10,10" Padding="14,7">
-            <TextBlock x:Name="StatusText" Text="Ready." FontSize="12" Foreground="{StaticResource TextSecondaryBrush}" />
+            <TextBlock Text="{Binding StatusText}" FontSize="12" Foreground="{StaticResource TextSecondaryBrush}" />
         </Border>
     </Grid>
 </Window>

--- a/Savedrake.App/MainWindow.xaml.cs
+++ b/Savedrake.App/MainWindow.xaml.cs
@@ -27,6 +27,7 @@ namespace Savedrake.App
         public MainWindow()
         {
             InitializeComponent();
+            DataContext = new Savedrake.App.ViewModels.MainViewModel();
         }
 
         protected override void OnSourceInitialized(EventArgs e)

--- a/Savedrake.App/Savedrake.App.csproj
+++ b/Savedrake.App/Savedrake.App.csproj
@@ -4,18 +4,25 @@
     Savedrake.App: the WPF desktop shell (Phase 3 of the WinForms -> WPF migration).
     Borderless, themed "warm-dark espresso + gold" window. References Savedrake.Core for the
     portable logic (logging, scan, restore, etc.). UseWindowsForms is on for the tray icon that
-    comes in a later phase. Targets net48 + C# 7.3 to match the rest of the solution.
+    comes in a later phase. Targets net48; LangVersion 8.0 (the rest of the solution is 7.3) so the
+    CommunityToolkit.Mvvm [ObservableProperty]/[RelayCommand] source generators can run — they
+    require C# 8.0+. net48 supports every C# 8.0 feature we use (the generated property/command
+    code); the two runtime-bound 8.0 features (default interface members, async streams) are unused.
   -->
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <AssemblyName>Savedrake.App</AssemblyName>
     <RootNamespace>Savedrake.App</RootNamespace>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Savedrake.Core\Savedrake.Core.csproj" />

--- a/Savedrake.App/ViewModels/BackupRowConverters.cs
+++ b/Savedrake.App/ViewModels/BackupRowConverters.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Savedrake.App.ViewModels
+{
+    // Small display-only converters for the Backups list row template. They turn a BackupRow's pin/status state into
+    // the brush key, glyph, and pill text the dark theme uses, so the DataTemplate stays declarative. Brushes are
+    // resolved by key against the merged theme dictionary at use time.
+
+    // IsPinned -> a theme brush KEY (string). The row binds this through StaticResource indirection in XAML, so we
+    // return the key and let a second converter resolve it. Simpler: resolve the brush here directly.
+    public sealed class PinnedToBrushConverter : IValueConverter
+    {
+        // Brush keys for the "on" (pinned / true) and "off" states. Set in XAML.
+        public string OnKey { get; set; }
+        public string OffKey { get; set; }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            bool on = value is bool b && b;
+            string key = on ? OnKey : OffKey;
+            object res = System.Windows.Application.Current?.TryFindResource(key);
+            return res ?? Binding.DoNothing;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => Binding.DoNothing;
+    }
+
+    // A BackupRow -> the pill TEXT: "pinned" when pinned, otherwise the lower-cased status ("protected" / "legacy").
+    public sealed class RowToPillTextConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var row = value as BackupRow;
+            if (row == null) return "";
+            if (row.IsPinned) return "pinned";
+            return (row.Status ?? "").ToLowerInvariant();
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => Binding.DoNothing;
+    }
+
+    // A BackupRow -> the pill FOREGROUND brush: gold when pinned, green ("Success") when Protected, muted
+    // (TextSecondary) for Legacy / anything else.
+    public sealed class RowToPillBrushConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var row = value as BackupRow;
+            string key = "TextSecondaryBrush";
+            if (row != null)
+            {
+                if (row.IsPinned) key = "AccentGoldBrush";
+                else if (string.Equals(row.Status, "Protected", StringComparison.OrdinalIgnoreCase)) key = "SuccessBrush";
+                else key = "TextSecondaryBrush";
+            }
+            object res = System.Windows.Application.Current?.TryFindResource(key);
+            return res ?? Binding.DoNothing;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => Binding.DoNothing;
+    }
+}

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Savedrake.App.ViewModels
+{
+    // One row in the Backups list. Mirrors the WinForms LoadBackupHistory columns (file name, friendly time,
+    // integrity status) plus the pin state, with the full path kept for Restore/Delete. Plain DTO — the list is
+    // rebuilt wholesale by RefreshBackups, so no per-row change notification is needed.
+    public sealed class BackupRow
+    {
+        public string FileName { get; set; }
+        public string FriendlyTime { get; set; }
+        public string Status { get; set; }   // "Protected" (has manifest) or "Legacy"
+        public bool IsPinned { get; set; }
+        public string FullPath { get; set; }
+    }
+
+    // The main workflow view model (Phase 4b). Drives the Folders + Backups cards and routes the Backup / Restore /
+    // Delete actions through the UI-agnostic Core services (BackupService / RestoreService) using the WPF dialog +
+    // status implementations below. MVVM via CommunityToolkit.Mvvm source generators.
+    public partial class MainViewModel : ObservableObject
+    {
+        private readonly IDialogService _dialog;
+        private readonly IStatusSink _status;
+
+        // The two folders the workflow operates on.
+        [ObservableProperty]
+        private string saveDir;
+
+        [ObservableProperty]
+        private string backupDir;
+
+        // The backup list shown in the Backups card (newest first), and the current selection.
+        public ObservableCollection<BackupRow> Backups { get; } = new ObservableCollection<BackupRow>();
+
+        [ObservableProperty]
+        private BackupRow selectedBackup;
+
+        // Status-bar text (bound) and the count shown beside the Backups folder path.
+        [ObservableProperty]
+        private string statusText = "Ready.";
+
+        [ObservableProperty]
+        private string backupCount;
+
+        public MainViewModel()
+        {
+            _dialog = new WpfDialogService();
+            _status = new StatusSink(this);
+
+            LoadSettings();
+            RefreshBackups();
+        }
+
+        // ----- settings (read-only reuse of the WinForms savedrake_settings.xml, best-effort) -----
+
+        private static string AppDataDir => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Savedrake");
+
+        private static string SettingsFilePath => Path.Combine(AppDataDir, "savedrake_settings.xml");
+
+        // Read SaveDir / BackupDir from the WinForms settings file's <Textbox1> / <Textbox2> if present. Read-only,
+        // dependency-free (a tiny hand-rolled XML read so we don't pull in the WinForms AppSettings type). Never throws.
+        private void LoadSettings()
+        {
+            try
+            {
+                if (!File.Exists(SettingsFilePath)) return;
+                var doc = System.Xml.Linq.XDocument.Load(SettingsFilePath);
+                string t1 = (string)doc.Root?.Element("Textbox1");
+                string t2 = (string)doc.Root?.Element("Textbox2");
+                if (!string.IsNullOrWhiteSpace(t1)) SaveDir = t1;
+                if (!string.IsNullOrWhiteSpace(t2)) BackupDir = t2;
+            }
+            catch { /* best-effort: missing/garbled settings just leave the fields blank */ }
+        }
+
+        // Persist the two folders into the same <Textbox1>/<Textbox2> shape the WinForms app reads, preserving any
+        // other elements already present. Best-effort: a write failure must never break the workflow.
+        private void SaveSettings()
+        {
+            try
+            {
+                Directory.CreateDirectory(AppDataDir);
+                System.Xml.Linq.XDocument doc;
+                if (File.Exists(SettingsFilePath))
+                {
+                    try { doc = System.Xml.Linq.XDocument.Load(SettingsFilePath); }
+                    catch { doc = new System.Xml.Linq.XDocument(new System.Xml.Linq.XElement("AppSettings")); }
+                }
+                else
+                {
+                    doc = new System.Xml.Linq.XDocument(new System.Xml.Linq.XElement("AppSettings"));
+                }
+
+                var root = doc.Root ?? new System.Xml.Linq.XElement("AppSettings");
+                if (doc.Root == null) doc.Add(root);
+                SetElement(root, "Textbox1", SaveDir ?? "");
+                SetElement(root, "Textbox2", BackupDir ?? "");
+                doc.Save(SettingsFilePath);
+            }
+            catch { /* best-effort persistence */ }
+        }
+
+        private static void SetElement(System.Xml.Linq.XElement root, string name, string value)
+        {
+            var el = root.Element(name);
+            if (el == null) root.Add(new System.Xml.Linq.XElement(name, value));
+            else el.Value = value;
+        }
+
+        // ----- backup list -----
+
+        // Rebuild the Backups list from the *.zip files in BackupDir, newest first, exactly like the WinForms
+        // LoadBackupHistory: open each zip, "Protected" if it carries a manifest else "Legacy", friendly creation
+        // time, pin state from the file name. Unreadable files are skipped silently (no per-file dialogs).
+        public void RefreshBackups()
+        {
+            Backups.Clear();
+
+            string dir = BackupDir;
+            if (string.IsNullOrWhiteSpace(dir) || !Directory.Exists(dir))
+            {
+                BackupCount = "0";
+                SelectedBackup = null;
+                return;
+            }
+
+            string[] zipFiles;
+            try { zipFiles = Directory.GetFiles(dir, "*.zip"); }
+            catch { zipFiles = new string[0]; }
+
+            // Newest first by creation time (same ordering as LoadBackupHistory).
+            Array.Sort(zipFiles, (x, y) => File.GetCreationTime(y).CompareTo(File.GetCreationTime(x)));
+
+            foreach (string path in zipFiles)
+            {
+                try
+                {
+                    bool hasManifest;
+                    using (var zip = Ionic.Zip.ZipFile.Read(path))
+                    {
+                        hasManifest = zip.Entries.Any(e => Manifest.IsManifestEntry(e.FileName));
+                    }
+
+                    string name = Path.GetFileName(path);
+                    Backups.Add(new BackupRow
+                    {
+                        FileName = name,
+                        FriendlyTime = TimeText.Friendly(File.GetCreationTime(path)),
+                        Status = hasManifest ? "Protected" : "Legacy",
+                        IsPinned = Pinning.IsPinnedBackup(name),
+                        FullPath = path
+                    });
+                }
+                catch (Ionic.Zip.ZipException) { /* not a readable zip — skip */ }
+                catch (Exception) { /* locked / in use — skip silently */ }
+            }
+
+            BackupCount = Backups.Count.ToString();
+        }
+
+        // ----- folder pickers -----
+
+        [RelayCommand]
+        private void BrowseSave()
+        {
+            string picked = PickFolder(SaveDir);
+            if (picked == null) return;
+            SaveDir = picked;
+            SaveSettings();
+            RefreshBackups();
+        }
+
+        [RelayCommand]
+        private void BrowseBackup()
+        {
+            string picked = PickFolder(BackupDir);
+            if (picked == null) return;
+            BackupDir = picked;
+            SaveSettings();
+            RefreshBackups();
+        }
+
+        private static string PickFolder(string current)
+        {
+            using (var dlg = new System.Windows.Forms.FolderBrowserDialog())
+            {
+                if (!string.IsNullOrWhiteSpace(current) && Directory.Exists(current))
+                    dlg.SelectedPath = current;
+                return dlg.ShowDialog() == System.Windows.Forms.DialogResult.OK ? dlg.SelectedPath : null;
+            }
+        }
+
+        // ----- workflow actions -----
+
+        [RelayCommand]
+        private void Backup()
+        {
+            BackupService.Backup(
+                new BackupRequest
+                {
+                    LiveSaveDir = SaveDir,
+                    BackupDir = BackupDir,
+                    IsAutoBackup = false,
+                    RandomName = true
+                },
+                _dialog, _status);
+            RefreshBackups();
+        }
+
+        [RelayCommand]
+        private void Restore()
+        {
+            if (SelectedBackup == null)
+            {
+                _dialog.Warn("Restore", "Please select a backup to restore first.");
+                return;
+            }
+
+            RestoreService.Restore(
+                new RestoreRequest
+                {
+                    BackupZipPath = SelectedBackup.FullPath,
+                    LiveSaveDir = SaveDir,
+                    BackupDir = BackupDir,
+                    GameRunning = IsGameRunning()
+                },
+                _dialog, _status);
+            RefreshBackups();
+        }
+
+        // Best-effort game-running check: a plain process-name probe. The WinForms CheckGameRunningStatus is more
+        // thorough (it also inspects window state); a process check is sufficient for the restore guard for now.
+        // TODO (Phase 5): replace with the full CheckGameRunningStatus parity check.
+        private static bool IsGameRunning()
+        {
+            try
+            {
+                return System.Diagnostics.Process.GetProcessesByName("DD2").Length > 0
+                    || System.Diagnostics.Process.GetProcessesByName("DD2-game").Length > 0;
+            }
+            catch { return false; }
+        }
+
+        [RelayCommand]
+        private void Delete()
+        {
+            if (SelectedBackup == null)
+            {
+                _dialog.Warn("Delete", "Please select a backup to delete first.");
+                return;
+            }
+
+            BackupRow row = SelectedBackup;
+            if (!_dialog.Confirm("Delete Backup",
+                    "Delete this backup permanently?\n\n" + row.FileName))
+                return;
+
+            try
+            {
+                File.Delete(row.FullPath);
+                _status.Set("Backup deleted.");
+            }
+            catch (Exception ex)
+            {
+                _dialog.Error("Delete Failed", "Could not delete the backup: " + ex.Message);
+            }
+            RefreshBackups();
+        }
+
+        // ----- WPF service implementations -----
+
+        // Modal dialogs via System.Windows.MessageBox. Confirm uses YesNo (Yes == affirmative, matching the WinForms
+        // DialogResult.Yes convention the Core services were transcribed against); Info/Warn/Error map to the
+        // matching MessageBox icons.
+        private sealed class WpfDialogService : IDialogService
+        {
+            public bool Confirm(string title, string message)
+            {
+                return MessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxImage.Question)
+                       == MessageBoxResult.Yes;
+            }
+
+            public void Info(string title, string message)
+                => MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Information);
+
+            public void Warn(string title, string message)
+                => MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Warning);
+
+            public void Error(string title, string message)
+                => MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+
+        // Routes each Core Status.Text write into the bound StatusText property, marshalled to the UI thread (a
+        // backup/restore may set status from a non-UI context in later phases).
+        private sealed class StatusSink : IStatusSink
+        {
+            private readonly MainViewModel _vm;
+            public StatusSink(MainViewModel vm) { _vm = vm; }
+
+            public void Set(string text)
+            {
+                Dispatcher d = Application.Current?.Dispatcher;
+                if (d != null && !d.CheckAccess())
+                    d.Invoke(() => _vm.StatusText = text);
+                else
+                    _vm.StatusText = text;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The main workflow, wired into the WPF app via MVVM and calling the Core `RestoreService`/`BackupService` from Phase 4a. WinForms app untouched.

## What's here
- **`MainViewModel`** (CommunityToolkit.Mvvm): `SaveDir`/`BackupDir` (persisted to the existing `savedrake_settings.xml`), a `Backups` collection (Protected/Legacy + friendly time + pinned, computed like the WinForms `LoadBackupHistory`), `StatusText`, `BackupCount`; `Browse`/`Backup`/`Restore`/`Delete` commands; WPF `IDialogService` (MessageBox) + `IStatusSink` (Dispatcher-marshalled) impls.
- **`MainWindow`**: Folders card (labels + path boxes + count + gold-outline Browse), Autobackup placeholder (Phase 5), Backups card (gold title + `Back up now` / `Restore` / `Delete` + a dark header-less `ListView` with leading dot, name, status pill, friendly time; right-click Delete wired).
- Bumped **`Savedrake.App` LangVersion 7.3 → 8.0** (the MVVM Toolkit source generators require C# 8; net48 supports it; Core/WinForms/harness stay 7.3).

## TODOs (later phases)
- Restore's game-detection is a simple process probe; Phase 5 restores the fuller `CheckGameRunningStatus` parity.
- Context-menu Rename/Pin/Validate-all are stubbed.

## Verification
- Release builds clean; harness **207 passed, 0 failed** (no regression).
- The app launches and shows the populated backups list matching the mockup (screenshot reviewed).
- **No live backup/restore was executed** — the loaded settings point at the real DD2 saves, and the rule is never to restore against those. The Core services are harness-proven (incl. the end-to-end `RestoreService` test); a sandboxed end-to-end UI run is deferred to a controlled test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)