### PR TITLE
WPF Phase 5a: extract autobackup engine logic into Savedrake.Core

### DIFF
--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -136,6 +136,10 @@ namespace RestoreHarness
                 Test_LogRedaction();   // P2: the rolling logger redacts the Steam account id and user profile path
                 Test_DiskPreflight();   // disk-space preflight helpers (size math + free-space check, fail-open)
                 Test_RestoreServiceFlow();   // Phase 4a: the REAL Core RestoreService.Restore orchestration end-to-end
+                Test_AutobackupPolicy();   // Phase 5: the change-aware autobackup decision (every branch + game-start bypass)
+                Test_AutobackupCountStore();   // Phase 5: forgiving read of the autobackup count file (missing/garbled -> 0)
+                Test_AutobackupCleanup();   // Phase 5: auto-thinning excludes manual/pre-restore/pinned, removes surplus autos
+                Test_GameDetect();   // Phase 5: DD2 running-state registry read returns a bool and never throws
             }
             catch (Exception ex)
             {
@@ -816,6 +820,122 @@ namespace RestoreHarness
             Check("RestoreService: the Steam-Cloud confirm was prompted", dialog.Confirms.Count >= 1, "confirms=" + dialog.Confirms.Count);
             Check("RestoreService: a success Info dialog was shown", dialog.Infos.Count >= 1, "infos=" + string.Join(" ;; ", dialog.Infos));
             Check("RestoreService: no Warning dialog on the happy path", dialog.Warns.Count == 0, "warns=" + string.Join(" ;; ", dialog.Warns));
+            Console.WriteLine();
+        }
+
+        static void Test_AutobackupPolicy()
+        {
+            // Phase 5: AutobackupPolicy.Decide is the whole change-aware autobackup decision as one pure function.
+            // It must reproduce the shipped RunChangeAwareAutobackup / OnGameStatusChanged tree exactly, including the
+            // ordering (game first, then limit, then the change gate) and the game-start bypass that lets the first
+            // backup of a session always fire.
+            Console.WriteLine("== Phase 5: change-aware autobackup decision ==");
+            Func<bool, bool, int, int, bool, string, string, bool, AutobackupAction> D = AutobackupPolicy.Decide;
+
+            // 1. Game not running wins over everything else (even an invalid limit / a hit cap).
+            Check("game not running -> pause", D(false, false, 99, 1, false, null, null, false) == AutobackupAction.PauseGameNotRunning);
+            Check("game not running -> pause even at game-start bypass", D(false, true, 0, 10, true, "fp", null, true) == AutobackupAction.PauseGameNotRunning);
+
+            // 2. Invalid limit field (only checked once the game is running).
+            Check("invalid limit -> InvalidLimit", D(true, false, 0, 0, false, "fp", null, false) == AutobackupAction.InvalidLimit);
+
+            // 3. Limit reached with cleanup off -> stop; with cleanup on -> keep going.
+            Check("count == limit, cleanup off -> LimitReached", D(true, true, 5, 5, false, "fp", null, false) == AutobackupAction.LimitReached);
+            Check("count over limit, cleanup off -> LimitReached", D(true, true, 9, 5, false, "fp", null, false) == AutobackupAction.LimitReached);
+            Check("count == limit, cleanup ON -> proceeds (DoBackup)", D(true, true, 5, 5, true, "fp", null, false) == AutobackupAction.DoBackup);
+            Check("count below limit -> proceeds", D(true, true, 4, 5, false, "new", "old", false) == AutobackupAction.DoBackup);
+
+            // 4. The change gate (only on the timer/watcher path, i.e. bypass = false).
+            Check("null fingerprint -> SkipNotReady (fail closed)", D(true, true, 0, 5, false, null, "old", false) == AutobackupAction.SkipNotReady);
+            Check("fingerprint unchanged -> SkipNoChange", D(true, true, 0, 5, false, "same", "same", false) == AutobackupAction.SkipNoChange);
+            Check("null baseline never skips -> DoBackup", D(true, true, 0, 5, false, "fp", null, false) == AutobackupAction.DoBackup);
+            Check("changed fingerprint -> DoBackup", D(true, true, 0, 5, false, "new", "old", false) == AutobackupAction.DoBackup);
+
+            // 5. Game-start bypass: the change gate is skipped, but the limit still applies.
+            Check("game-start bypass: null fp still DoBackup", D(true, true, 0, 5, false, null, null, true) == AutobackupAction.DoBackup);
+            Check("game-start bypass: unchanged fp still DoBackup", D(true, true, 0, 5, false, "same", "same", true) == AutobackupAction.DoBackup);
+            Check("game-start bypass still respects the limit", D(true, true, 5, 5, false, "same", "same", true) == AutobackupAction.LimitReached);
+            Console.WriteLine();
+        }
+
+        static void Test_AutobackupCountStore()
+        {
+            // Phase 5: the count read is advisory and must be crash-proof — a missing/empty/garbled/locked file reads 0.
+            Console.WriteLine("== Phase 5: autobackup count store ==");
+            string dir = NewDir("count");
+            Check("missing file -> 0", AutobackupCountStore.Read(Path.Combine(dir, "nope.txt")) == 0);
+            Check("null/empty path -> 0", AutobackupCountStore.Read(null) == 0 && AutobackupCountStore.Read("") == 0);
+
+            string f = Path.Combine(dir, "count.txt");
+            File.WriteAllText(f, "7");
+            Check("valid integer is read", AutobackupCountStore.Read(f) == 7);
+            File.WriteAllText(f, "  12 \r\n");
+            Check("whitespace-padded integer is read", AutobackupCountStore.Read(f) == 12);
+            File.WriteAllText(f, "");
+            Check("empty file -> 0", AutobackupCountStore.Read(f) == 0);
+            File.WriteAllText(f, "not-a-number");
+            Check("garbled file -> 0 (no throw)", AutobackupCountStore.Read(f) == 0);
+
+            // A file open with an exclusive write lock must not crash the read.
+            using (var fs = new FileStream(f, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                fs.Write(B("5"), 0, 1);
+                Check("exclusively-locked file -> 0 (no throw)", AutobackupCountStore.Read(f) == 0);
+            }
+            Console.WriteLine();
+        }
+
+        static void Test_AutobackupCleanup()
+        {
+            // Phase 5: auto-thinning must only ever touch autobackups. Manual backups, the (Pre-Restore) checkpoint,
+            // and pinned autobackups are protected by name/token regardless of age; surplus plain autos are removed.
+            Console.WriteLine("== Phase 5: autobackup auto-cleanup ==");
+            string dir = NewDir("cleanup");
+            long now = DateTime.UtcNow.Ticks;
+            DateTime old = DateTime.UtcNow - TimeSpan.FromDays(30);
+
+            Action<string> makeOld = name =>
+            {
+                string p = Path.Combine(dir, name);
+                MakeZip(p, z => z.AddEntry("win64_save\\data.sav", B("payload-" + name)));
+                File.SetLastWriteTimeUtc(p, old);
+            };
+
+            // Five plain autobackups, all old and within minutes of each other (one retention bucket -> keep newest).
+            for (int i = 0; i < 5; i++) { makeOld("(Auto) save " + i + ".zip"); File.SetLastWriteTimeUtc(Path.Combine(dir, "(Auto) save " + i + ".zip"), old.AddMinutes(i)); }
+            // Protected siblings, also old so survival proves the exclusion (not just recency).
+            makeOld("(Auto) keepme [PINNED].zip");   // pinned autobackup
+            makeOld("MyManualBackup.zip");           // manual (no prefix)
+            makeOld("(Pre-Restore) checkpoint.zip");  // restore checkpoint
+
+            int removed = AutobackupCleanup.Run(dir, 10, false, now); // maxKeep high so the count cap is inactive
+
+            Check("cleanup removed at least one surplus autobackup", removed >= 1, "removed=" + removed);
+            Check("the pinned autobackup survived", File.Exists(Path.Combine(dir, "(Auto) keepme [PINNED].zip")));
+            Check("the manual backup survived", File.Exists(Path.Combine(dir, "MyManualBackup.zip")));
+            Check("the (Pre-Restore) checkpoint survived", File.Exists(Path.Combine(dir, "(Pre-Restore) checkpoint.zip")));
+            int plainAutosLeft = Directory.GetFiles(dir, "(Auto)*.zip").Count(p => !Pinning.IsPinnedBackup(Path.GetFileName(p)));
+            Check("at least the newest plain autobackup survived", plainAutosLeft >= 1, "left=" + plainAutosLeft);
+            Check("removed count == plain autos thinned", removed == 5 - plainAutosLeft, "removed=" + removed + " left=" + plainAutosLeft);
+
+            // Recent-only autos must not be thinned, and an empty/absent dir is a no-op.
+            string fresh = NewDir("cleanup_fresh");
+            for (int i = 0; i < 3; i++) MakeZip(Path.Combine(fresh, "(Auto) r" + i + ".zip"), z => z.AddEntry("a", B("x")));
+            Check("recent autobackups are not thinned", AutobackupCleanup.Run(fresh, 10, false, now) == 0);
+            Check("empty dir -> 0 removed", AutobackupCleanup.Run(NewDir("cleanup_empty"), 5, false, now) == 0);
+            Check("missing dir -> 0 removed (no throw)", AutobackupCleanup.Run(Path.Combine(dir, "does-not-exist"), 5, false, now) == 0);
+            Console.WriteLine();
+        }
+
+        static void Test_GameDetect()
+        {
+            // Phase 5: the DD2 running-state read is a plain registry lookup. On the build/CI box DD2 is not installed,
+            // so it must return false without throwing (a missing key is the normal "not installed" case).
+            Console.WriteLine("== Phase 5: game detection ==");
+            bool threw = false, result = false;
+            try { result = GameDetect.IsDd2Running(); } catch { threw = true; }
+            Check("IsDd2Running() does not throw on a box without DD2", !threw);
+            Check("IsDd2Running() reports not-running when the key is absent", result == false);
             Console.WriteLine();
         }
 

--- a/Savedrake.Core/AutobackupCleanup.cs
+++ b/Savedrake.Core/AutobackupCleanup.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Savedrake
+{
+    // Automatic thinning of old autobackups, lifted out of the WinForms CleanUpOldAutobackups minus its UI side
+    // effects (status text + list refresh stay with the caller). Eligible = autobackups only ("(Auto)"/"auto"
+    // prefix); manual backups and the "(Pre-Restore)" checkpoint are never touched, pinned backups are never
+    // touched, and a corrupt archive is never auto-removed. Which ones to drop is decided by the same
+    // RetentionPolicy.SelectAutobackupsToThin the shipped app uses (keep recent + a spread of older ones).
+    public static class AutobackupCleanup
+    {
+        // Removes the surplus old autobackups under backupDir and returns how many were removed. toRecycle sends
+        // them to the Recycle Bin instead of deleting outright. nowTicksUtc is passed in (not read from the clock)
+        // so the thinning decision stays deterministic and testable. Never throws: per-file failures are logged and
+        // skipped, and any unexpected top-level error is swallowed (cleanup is best-effort housekeeping).
+        public static int Run(string backupDir, int maxKeep, bool toRecycle, long nowTicksUtc)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(backupDir) || !Directory.Exists(backupDir)) return 0;
+
+                var files = new List<string>();
+                var ticks = new List<long>();
+                foreach (string file in Directory.GetFiles(backupDir, "*.zip"))
+                {
+                    string name = Path.GetFileName(file);
+                    if (!(name.StartsWith("(Auto)") || name.StartsWith("auto"))) continue;
+                    if (Pinning.IsPinnedBackup(name)) continue; // pinned backups are never removed
+                    files.Add(file);
+                    ticks.Add(File.GetLastWriteTimeUtc(file).Ticks);
+                }
+                if (files.Count == 0) return 0;
+
+                int keep = maxKeep > 0 ? maxKeep : 0;
+                int[] toRemove = RetentionPolicy.SelectAutobackupsToThin(ticks.ToArray(), nowTicksUtc, keep);
+
+                int removed = 0;
+                foreach (int i in toRemove)
+                {
+                    try
+                    {
+                        if (Manifest.ClassifyBackupFully(files[i]) == "Corrupt") continue; // never auto-remove a corrupt backup
+                        if (toRecycle)
+                            Microsoft.VisualBasic.FileIO.FileSystem.DeleteFile(files[i],
+                                Microsoft.VisualBasic.FileIO.UIOption.OnlyErrorDialogs,
+                                Microsoft.VisualBasic.FileIO.RecycleOption.SendToRecycleBin);
+                        else
+                            File.Delete(files[i]);
+                        removed++;
+                    }
+                    catch (Exception ex) { Log.Warn("Could not remove old autobackup " + Path.GetFileName(files[i]) + ": " + ex.Message); }
+                }
+                return removed;
+            }
+            catch (Exception ex)
+            {
+                Log.Warn("Auto-cleanup of old autobackups failed: " + ex.Message);
+                return 0;
+            }
+        }
+    }
+}

--- a/Savedrake.Core/AutobackupCountStore.cs
+++ b/Savedrake.Core/AutobackupCountStore.cs
@@ -1,0 +1,31 @@
+using System.IO;
+
+namespace Savedrake
+{
+    // The persisted "how many autobackups exist" counter. It is a single integer in a text file under the app data
+    // directory; the autobackup limit is enforced against it. Reading is deliberately forgiving: a missing, empty,
+    // garbled, or transiently locked file reads as 0 rather than throwing, because the count is advisory (the real
+    // source of truth is the files on disk, recomputed after every backup) and a read hiccup must never crash or
+    // wedge the autobackup loop. This is the one intentional hardening over the shipped inline read, which had no
+    // guard around File.ReadAllText.
+    public static class AutobackupCountStore
+    {
+        public static int Read(string countFilePath)
+        {
+            int count = 0;
+            try
+            {
+                if (!string.IsNullOrEmpty(countFilePath) && File.Exists(countFilePath))
+                {
+                    int.TryParse(File.ReadAllText(countFilePath), out count);
+                }
+            }
+            catch
+            {
+                // Locked / unreadable count file: treat as 0. Worst case is one extra eligible attempt, which the
+                // change-aware gate and the on-disk recount immediately correct.
+            }
+            return count;
+        }
+    }
+}

--- a/Savedrake.Core/AutobackupPolicy.cs
+++ b/Savedrake.Core/AutobackupPolicy.cs
@@ -1,0 +1,56 @@
+namespace Savedrake
+{
+    // The single decision one autobackup attempt resolves to. The mechanism (timers, the save watcher, WMI game
+    // events, the Dispatcher) lives in the UI layer; this enum is what that machinery asks for and acts on.
+    public enum AutobackupAction
+    {
+        DoBackup,             // take a backup now
+        SkipNoChange,         // save folder is byte-identical to the last backup — nothing to capture
+        SkipNotReady,         // fingerprint unavailable (folder missing/locked/mid-write) — fail closed, retry later
+        PauseGameNotRunning,  // DD2 is no longer running — pause the timer and the save watcher
+        LimitReached,         // the autobackup limit is hit and auto-cleanup is off — stop and tell the user
+        InvalidLimit          // the configured limit is not a valid integer — tell the user
+    }
+
+    // The change-aware autobackup decision, lifted out of the WinForms RunChangeAwareAutobackup / OnGameStatusChanged
+    // so it is one pure, fully testable function with no UI, no I/O, and no timers. The caller gathers the live inputs
+    // (a fresh game-running read, the count on disk, the current vs last fingerprint) and acts on the returned action.
+    //
+    // Order matters and mirrors the shipped app exactly:
+    //   1. game not running         -> PauseGameNotRunning   (checked first; never back up stale saves)
+    //   2. limit field not an int   -> InvalidLimit
+    //   3. limit reached, no cleanup-> LimitReached          (cleanup on => keep going, cleanup enforces the cap)
+    //   4. change gate (unless bypassed at game-start, where the first backup of a session always fires):
+    //        - no fingerprint       -> SkipNotReady          (fail CLOSED: a null fp never counts as "unchanged")
+    //        - fingerprint unchanged-> SkipNoChange          (a null baseline never skips — first eligible attempt)
+    //   5. otherwise                -> DoBackup
+    public static class AutobackupPolicy
+    {
+        public static AutobackupAction Decide(
+            bool gameRunning,
+            bool maxBackupsValid,
+            int backupCount,
+            int maxBackups,
+            bool cleanupEnabled,
+            string currentFingerprint,
+            string lastFingerprint,
+            bool bypassChangeGate)
+        {
+            if (!gameRunning) return AutobackupAction.PauseGameNotRunning;
+            if (!maxBackupsValid) return AutobackupAction.InvalidLimit;
+
+            // Cleanup on -> keep backing up (cleanup enforces the limit); off -> original stop-at-limit behaviour.
+            if (!(cleanupEnabled || backupCount < maxBackups)) return AutobackupAction.LimitReached;
+
+            // The immediate backup at game-start is NOT routed through the change gate (it always fires, then the
+            // next attempt establishes the baseline). The interval timer and the save watcher always gate.
+            if (!bypassChangeGate)
+            {
+                if (currentFingerprint == null) return AutobackupAction.SkipNotReady;
+                if (lastFingerprint != null && currentFingerprint == lastFingerprint) return AutobackupAction.SkipNoChange;
+            }
+
+            return AutobackupAction.DoBackup;
+        }
+    }
+}

--- a/Savedrake.Core/GameDetect.cs
+++ b/Savedrake.Core/GameDetect.cs
@@ -1,0 +1,36 @@
+using System;
+using Microsoft.Win32;
+
+namespace Savedrake
+{
+    // Game-running detection for Dragon's Dogma 2 (Steam app 2054970). Steam writes a "Running" DWORD (0/1) under
+    // HKCU\Software\Valve\Steam\Apps\<appid> while the game is up, so a plain registry read tells us the live state
+    // with no process scanning. Extracted verbatim from the WinForms CheckGameRunningStatus during the WPF migration
+    // (Phase 5) so both the shipped app and the new WPF autobackup engine read the exact same key the same way.
+    public static class GameDetect
+    {
+        // Dragon's Dogma 2's Steam application id.
+        public const string Dd2SteamAppId = "2054970";
+
+        private static string RunningKeyPath => @"Software\Valve\Steam\Apps\" + Dd2SteamAppId;
+
+        // True only when Steam reports DD2 as Running (the "Running" value == 1). Any other state (key absent, value
+        // absent, non-int, or 0) reads as not running. Never throws for a missing key — that is the normal "DD2 not
+        // installed / not launched" case.
+        public static bool IsDd2Running()
+        {
+            using (RegistryKey key = Registry.CurrentUser.OpenSubKey(RunningKeyPath))
+            {
+                if (key != null)
+                {
+                    object runningValue = key.GetValue("Running");
+                    if (runningValue != null && runningValue is int)
+                    {
+                        return Convert.ToInt32(runningValue) == 1;
+                    }
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/Savedrake.Core/Savedrake.Core.csproj
+++ b/Savedrake.Core/Savedrake.Core.csproj
@@ -23,4 +23,11 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
+  <!-- Microsoft.VisualBasic.FileIO.FileSystem.DeleteFile is how auto-cleanup sends thinned autobackups to the
+       Recycle Bin (matches the shipped app). It is a framework assembly on net48 but a class library does not
+       reference it by default, so name it explicitly. -->
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualBasic" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Phase 5a of the WinForms -> WPF migration

The autobackup engine's brain, extracted into `Savedrake.Core` so the new WPF autobackup machinery (Phase 5b) can drive the **same** decision logic the shipped app uses. Mechanism (timers, the save watcher, WMI game events, the Dispatcher) lands in Phase 5b; this PR is the pure, testable core.

### New Core classes
- **`GameDetect.IsDd2Running()`** — reads Steam's `HKCU\...\Apps\2054970\Running` flag (verbatim from `CheckGameRunningStatus`).
- **`AutobackupPolicy.Decide(...)`** — the entire change-aware decision as one pure function. Preserves the shipped ordering exactly: game-running first, then the limit, then the change gate; plus the game-start bypass that lets the first backup of a session always fire.
- **`AutobackupCountStore.Read(path)`** — advisory count-file read, now crash-proof (missing/empty/garbled/locked -> 0). One intentional hardening over the shipped inline `File.ReadAllText`.
- **`AutobackupCleanup.Run(...)`** — auto-thinning that never touches manual backups, the `(Pre-Restore)` checkpoint, or pinned autobackups, and never removes a corrupt archive. Uses the same `RetentionPolicy.SelectAutobackupsToThin` selector.

### Safety
- **WinForms app untouched** — additive only (same approach as Phase 4a). The shipped restore/backup path is byte-for-byte unchanged.
- **Harness: 207 -> 239 assertions**, all green. Covers every `AutobackupPolicy` branch, count-store edge cases (including an exclusively write-locked file), cleanup exclusions + surplus removal, and a `GameDetect` no-throw smoke check.
- Release + Debug build clean (only the known/accepted NU1903 DotNetZip advisory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)