### PR TITLE
WPF Phase 5b: autobackup engine + game detection + watcher + threading

### DIFF
--- a/Savedrake.App/AutobackupController.cs
+++ b/Savedrake.App/AutobackupController.cs
@@ -1,0 +1,397 @@
+using System;
+using System.IO;
+using System.Management;
+using System.Security.Principal;
+using System.Windows;
+using System.Windows.Threading;
+
+namespace Savedrake.App
+{
+    // The configuration + effects the AutobackupController reads from. Implemented by MainViewModel so the controller
+    // stays free of MVVM/XAML details and can be reasoned about (and, in principle, faked) on its own.
+    internal interface IAutobackupHost
+    {
+        string SaveDir { get; }
+        string BackupDir { get; }
+        bool AutobackupEnabled { get; }
+        TimeSpan AutobackupInterval { get; }   // already validated to the >= 5 min floor by the host
+        bool IntervalValid { get; }
+        int MaxAutobackups { get; }
+        bool MaxAutobackupsValid { get; }
+        bool CleanupEnabled { get; }
+        bool RecycleEnabled { get; }
+        bool BackupOnSaveEnabled { get; }
+        string CountFilePath { get; }
+        bool IsOperationInProgress { get; }    // a manual backup/restore is mid-flight
+
+        IDialogService Dialog { get; }
+        IStatusSink Status { get; }
+
+        bool PerformAutobackup();   // take one autobackup now (BackupService, IsAutoBackup=true); true on success
+        void OnBackupsChanged();    // the backup set changed -> refresh the list
+        void ForceDisableAutobackup(); // turn the enable toggle off (limit reached / DD2 missing)
+    }
+
+    // The WPF autobackup engine. The shipped WinForms app ran the same feature on a System.Timers.Timer (marshalled
+    // to the UI via SynchronizingObject), a FileSystemWatcher + a WinForms quiesce timer, and a WMI
+    // ManagementEventWatcher on Steam's "Running" registry value. This re-expresses that machinery for WPF:
+    //   * the interval + quiesce timers are DispatcherTimers, which fire on the UI thread directly (no marshalling),
+    //   * the FileSystemWatcher and WMI events fire on background threads and are marshalled onto the UI thread via
+    //     the Dispatcher (BeginInvoke, never a blocking Invoke, so a background thread can't deadlock against Dispose).
+    // The DECISION is AutobackupPolicy.Decide in Core; everything here is the mechanism that gathers the live inputs,
+    // asks the policy, and carries out the answer. The re-entrancy guard is preserved because a failure dialog inside
+    // a backup pumps the Dispatcher queue, so a queued tick / watcher event can re-enter.
+    internal sealed class AutobackupController : IDisposable
+    {
+        private readonly IAutobackupHost _host;
+        private readonly Dispatcher _dispatcher;
+
+        private DispatcherTimer _intervalTimer;
+        private DispatcherTimer _quiesceTimer;       // debounces a burst of save writes into one backup
+        private FileSystemWatcher _saveWatcher;
+        private ManagementEventWatcher _gameWatcher;
+
+        private bool _autoBackupInProgress;          // re-entrancy guard (UI thread only)
+        private bool _running;                        // DD2 is currently running and the engine is active
+        private string _lastFingerprint;             // change-aware baseline
+        private volatile bool _suppressSaveWatcher;  // set by the host around a restore so we ignore our own writes
+        private bool _noGame;                         // the WMI watcher could not be created (DD2 not a Steam app here)
+        private bool _disposed;
+
+        public AutobackupController(IAutobackupHost host)
+        {
+            _host = host;
+            _dispatcher = Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
+        }
+
+        // True when DD2 is not present as a Steam app on this machine (the WMI registry watcher failed to start). The
+        // host uses this to refuse enabling autobackup with a clear message rather than silently doing nothing.
+        public bool NoGame => _noGame;
+
+        // The host sets this true for the duration of a manual restore (which writes into the save folder) so the
+        // save watcher does not treat the restore's own writes as a fresh save and back them up.
+        public bool SuppressSaveWatcher { get => _suppressSaveWatcher; set => _suppressSaveWatcher = value; }
+
+        // Begin watching DD2's running state. Call once at startup.
+        public void Start() => InitializeGameWatcher();
+
+        // ----- entry points the host calls when the user changes configuration -----
+
+        // The master enable toggle flipped, or the save/backup folder or the interval changed while enabled.
+        // Re-evaluates the whole feature from the live state.
+        public void OnEnableOrConfigChanged()
+        {
+            if (_host.AutobackupEnabled)
+            {
+                OnGameStatusChanged(GameDetect.IsDd2Running());
+            }
+            else
+            {
+                StopIntervalTimer();
+                StopSaveWatcher();
+                // Drop the baseline so a later re-enable re-baselines cleanly against whatever the save folder is then.
+                _lastFingerprint = null;
+            }
+        }
+
+        // The "back up the moment the game saves" option toggled. Start/stop just the watcher (the interval timer,
+        // the fallback, is unaffected).
+        public void OnBackupOnSaveChanged()
+        {
+            if (_host.AutobackupEnabled && _host.BackupOnSaveEnabled && GameDetect.IsDd2Running())
+                StartSaveWatcher();
+            else
+                StopSaveWatcher();
+        }
+
+        // The interval text changed while autobackup is on. If DD2 is running (the timer is live), re-arm it with the
+        // new interval without taking an immediate backup. A no-op when paused (the timer re-reads the interval when
+        // the game next starts).
+        public void ApplyIntervalChange()
+        {
+            if (_host.AutobackupEnabled && _running) StartIntervalTimer();
+        }
+
+        // The user just took a manual backup: advance the baseline so the next autobackup attempt does not re-capture
+        // an unchanged save (matches the WinForms baseline advance inside BackupOperation, which ran for manual backups
+        // too). Harmless when autobackup is off.
+        public void NotifyExternalBackup()
+        {
+            try { _lastFingerprint = Fingerprint.ComputeSaveFingerprint(_host.SaveDir); } catch { }
+        }
+
+        // ----- game-state watcher (WMI on Steam's "Running" registry value) -----
+
+        private void InitializeGameWatcher()
+        {
+            try
+            {
+                WindowsIdentity currentUser = WindowsIdentity.GetCurrent();
+                string keyPath = @"Software\Valve\Steam\Apps\" + GameDetect.Dd2SteamAppId;
+                var query = new WqlEventQuery(string.Format(
+                    "SELECT * FROM RegistryValueChangeEvent WHERE Hive='HKEY_USERS' AND KeyPath='{0}\\\\{1}' AND ValueName='Running'",
+                    currentUser.User.Value, keyPath.Replace("\\", "\\\\")));
+                _gameWatcher = new ManagementEventWatcher(query);
+                _gameWatcher.EventArrived += OnGameRegistryChanged;
+                _gameWatcher.Start();
+            }
+            catch
+            {
+                _noGame = true; // DD2 not a Steam app here / WMI unavailable — autobackup can't function
+            }
+        }
+
+        private void OnGameRegistryChanged(object sender, EventArrivedEventArgs e)
+        {
+            // WMI delivers this on a worker thread. Marshal onto the UI thread with BeginInvoke (not Invoke) so the
+            // WMI thread never blocks on the UI thread — a blocking Invoke racing Dispose() could deadlock.
+            if (_disposed) return;
+            try
+            {
+                _dispatcher.BeginInvoke(new Action(() =>
+                {
+                    if (_disposed) return;
+                    OnGameStatusChanged(GameDetect.IsDd2Running());
+                }));
+            }
+            catch (Exception) { /* dispatcher shutting down */ }
+        }
+
+        // ----- the game-state transition (mirror of WinForms OnGameStatusChanged) -----
+
+        private void OnGameStatusChanged(bool running)
+        {
+            if (!_host.AutobackupEnabled)
+            {
+                _running = false;
+                StopIntervalTimer();
+                StopSaveWatcher();
+                return;
+            }
+
+            _running = running;
+            if (running)
+            {
+                StartIntervalTimer();
+                StartSaveWatcher(); // also capture instantly on each save, if the user opted in
+
+                // Null the baseline at game-start so the first backup of the session always fires (it is taken with
+                // the change gate bypassed); the next attempt then establishes the real baseline.
+                _lastFingerprint = null;
+                RunChangeAwareAutobackup(bypassChangeGate: true);
+
+                if (_host.AutobackupEnabled) // still on (the immediate backup may have hit the limit and disabled it)
+                    _host.Status.Set("Game running. Autobackup is on.");
+            }
+            else
+            {
+                StopIntervalTimer();
+                StopSaveWatcher();
+                _host.Status.Set("Game not running. Autobackup paused.");
+            }
+        }
+
+        // ----- one change-aware attempt (mirror of RunChangeAwareAutobackup) -----
+
+        private void RunChangeAwareAutobackup(bool bypassChangeGate = false)
+        {
+            if (_autoBackupInProgress) return;          // re-entrancy guard
+            if (_host.IsOperationInProgress) return;    // a manual backup/restore is mid-flight
+            _autoBackupInProgress = true;
+            try
+            {
+                bool running = GameDetect.IsDd2Running();
+                int count = AutobackupCountStore.Read(_host.CountFilePath);
+                string currentFp = bypassChangeGate ? null : Fingerprint.ComputeSaveFingerprint(_host.SaveDir);
+
+                AutobackupAction action = AutobackupPolicy.Decide(
+                    running,
+                    _host.MaxAutobackupsValid,
+                    count,
+                    _host.MaxAutobackups,
+                    _host.CleanupEnabled,
+                    currentFp,
+                    _lastFingerprint,
+                    bypassChangeGate);
+
+                switch (action)
+                {
+                    case AutobackupAction.PauseGameNotRunning:
+                        StopIntervalTimer();
+                        StopSaveWatcher();
+                        _host.Status.Set("Game not running. Autobackup paused.");
+                        break;
+
+                    case AutobackupAction.InvalidLimit:
+                        _host.Dialog.Error("Autobackup", "Please enter a valid whole number for the autobackup limit.");
+                        break;
+
+                    case AutobackupAction.LimitReached:
+                        StopIntervalTimer(); // stop BEFORE the modal so no further tick is armed
+                        StopSaveWatcher();
+                        _host.ForceDisableAutobackup();
+                        _host.Dialog.Info("Autobackup",
+                            "The maximum number of " + _host.MaxAutobackups + " autobackups has been reached. " +
+                            "To keep going, raise \"Keep at most\" in the Autobackup panel.");
+                        break;
+
+                    case AutobackupAction.SkipNotReady:
+                        _host.Status.Set("Autobackup: save folder not ready, will retry.");
+                        break;
+
+                    case AutobackupAction.SkipNoChange:
+                        _host.Status.Set("Autobackup: no save changes since the last backup.");
+                        break;
+
+                    case AutobackupAction.DoBackup:
+                        if (_host.PerformAutobackup())
+                        {
+                            // Advance the baseline from the current save (matches the WinForms baseline advance inside
+                            // BackupOperation), then thin old autobackups if the user enabled cleanup.
+                            _lastFingerprint = Fingerprint.ComputeSaveFingerprint(_host.SaveDir);
+                            if (_host.CleanupEnabled)
+                            {
+                                int removed = AutobackupCleanup.Run(_host.BackupDir, _host.MaxAutobackups, _host.RecycleEnabled, DateTime.UtcNow.Ticks);
+                                if (removed > 0)
+                                    _host.Status.Set(removed == 1 ? "Removed 1 old autobackup." : ("Removed " + removed + " old autobackups."));
+                            }
+                            _host.OnBackupsChanged();
+                        }
+                        break;
+                }
+            }
+            finally
+            {
+                _autoBackupInProgress = false;
+            }
+        }
+
+        // ----- interval timer (the fallback trigger) -----
+
+        private void StartIntervalTimer()
+        {
+            if (!_host.IntervalValid) { StopIntervalTimer(); return; }
+            if (_intervalTimer == null)
+            {
+                _intervalTimer = new DispatcherTimer();
+                _intervalTimer.Tick += (s, e) => RunChangeAwareAutobackup();
+            }
+            _intervalTimer.Interval = _host.AutobackupInterval;
+            _intervalTimer.Start();
+        }
+
+        private void StopIntervalTimer()
+        {
+            try { _intervalTimer?.Stop(); } catch { }
+        }
+
+        // ----- save-folder watcher (instant capture) -----
+
+        private void StartSaveWatcher()
+        {
+            if (!_host.BackupOnSaveEnabled) return;
+            string dir = _host.SaveDir;
+            if (string.IsNullOrWhiteSpace(dir) || !Directory.Exists(dir)) return;
+            try
+            {
+                StopSaveWatcher(); // ensure a single clean instance (also tears down any previous quiesce timer)
+                _quiesceTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(4) }; // wait for writes to settle
+                _quiesceTimer.Tick += OnQuiesceElapsed;
+                _saveWatcher = new FileSystemWatcher(dir)
+                {
+                    IncludeSubdirectories = true,
+                    NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.Size | NotifyFilters.CreationTime,
+                    InternalBufferSize = 64 * 1024
+                };
+                _saveWatcher.Changed += OnSaveChanged;
+                _saveWatcher.Created += OnSaveChanged;
+                _saveWatcher.Deleted += OnSaveChanged;
+                _saveWatcher.Renamed += OnSaveChanged;
+                _saveWatcher.Error += OnSaveWatcherError;
+                _saveWatcher.EnableRaisingEvents = true;
+            }
+            catch (Exception ex)
+            {
+                Log.Warn("Could not start the save watcher (the interval timer remains the fallback): " + ex.Message);
+                StopSaveWatcher();
+            }
+        }
+
+        private void StopSaveWatcher()
+        {
+            if (_quiesceTimer != null)
+            {
+                try { _quiesceTimer.Stop(); } catch { }
+                try { _quiesceTimer.Tick -= OnQuiesceElapsed; } catch { }
+                _quiesceTimer = null;
+            }
+            if (_saveWatcher != null)
+            {
+                try { _saveWatcher.EnableRaisingEvents = false; } catch { }
+                try
+                {
+                    _saveWatcher.Changed -= OnSaveChanged;
+                    _saveWatcher.Created -= OnSaveChanged;
+                    _saveWatcher.Deleted -= OnSaveChanged;
+                    _saveWatcher.Renamed -= OnSaveChanged;
+                    _saveWatcher.Error -= OnSaveWatcherError;
+                }
+                catch { }
+                try { _saveWatcher.Dispose(); } catch { }
+                _saveWatcher = null;
+            }
+        }
+
+        // Watcher events fire on a ThreadPool thread. Ignore our own restore writes; otherwise marshal to the UI
+        // thread and (re)start the debounce, so a burst of writes collapses into one backup once the save has settled.
+        private void OnSaveChanged(object sender, FileSystemEventArgs e)
+        {
+            if (_suppressSaveWatcher) return;
+            try { _dispatcher.BeginInvoke(new Action(RestartQuiesce)); } catch (Exception) { }
+        }
+
+        private void RestartQuiesce()
+        {
+            // A marshalled event can land after StopSaveWatcher nulled the timer (shutdown / game exit / toggle off).
+            if (_quiesceTimer == null) return;
+            try { _quiesceTimer.Stop(); _quiesceTimer.Start(); } catch (Exception) { }
+        }
+
+        private void OnQuiesceElapsed(object sender, EventArgs e)
+        {
+            if (_quiesceTimer == null) return;
+            try { _quiesceTimer.Stop(); } catch (Exception) { return; }
+            if (_suppressSaveWatcher) return;
+            if (!_host.AutobackupEnabled) return;
+            // A backup or restore is mid-flight: wait another quiet window rather than overlapping it.
+            if (_host.IsOperationInProgress) { try { _quiesceTimer.Start(); } catch (Exception) { } return; }
+            RunChangeAwareAutobackup();
+        }
+
+        // A watcher Error (e.g. InternalBufferOverflow) means events may have been dropped. Re-arm the watcher; the
+        // interval timer covers anything missed in the meantime.
+        private void OnSaveWatcherError(object sender, ErrorEventArgs e)
+        {
+            Log.Warn("Save watcher error, re-arming: " + (e.GetException() != null ? e.GetException().Message : "unknown"));
+            try { _dispatcher.BeginInvoke(new Action(() => { StopSaveWatcher(); StartSaveWatcher(); })); } catch (Exception) { }
+        }
+
+        public void Dispose()
+        {
+            _disposed = true;
+            try
+            {
+                if (_gameWatcher != null)
+                {
+                    _gameWatcher.EventArrived -= OnGameRegistryChanged;
+                    _gameWatcher.Stop();
+                    _gameWatcher.Dispose();
+                    _gameWatcher = null;
+                }
+            }
+            catch { }
+            StopIntervalTimer();
+            StopSaveWatcher();
+        }
+    }
+}

--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -115,7 +115,8 @@
                                      Background="{StaticResource InputBrush}" Foreground="{StaticResource TextBrush}"
                                      BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" />
                             <Button Grid.Row="0" Grid.Column="3" Content="Browse" Style="{StaticResource OutlineButton}"
-                                    Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseSaveCommand}" />
+                                    Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseSaveCommand}"
+                                    IsEnabled="{Binding ConfigEditable}" />
 
                             <!-- Backups row -->
                             <TextBlock Grid.Row="2" Grid.Column="0" Text="Backups" VerticalAlignment="Center"
@@ -128,7 +129,8 @@
                                        FontSize="12" Foreground="{StaticResource TextHintBrush}"
                                        Text="{Binding BackupCount, StringFormat={}{0} backups}" />
                             <Button Grid.Row="2" Grid.Column="3" Content="Browse" Style="{StaticResource OutlineButton}"
-                                    Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseBackupCommand}" />
+                                    Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseBackupCommand}"
+                                    IsEnabled="{Binding ConfigEditable}" />
                         </Grid>
                     </StackPanel>
                 </Border>
@@ -137,8 +139,46 @@
                 <Border Style="{StaticResource CardBorder}">
                     <StackPanel>
                         <TextBlock Text="Autobackup" Style="{StaticResource SectionTitle}" />
-                        <TextBlock Text="Autobackup settings — coming in the next update."
-                                   Style="{StaticResource CardPlaceholder}" />
+
+                        <CheckBox Content="Back up automatically while Dragon's Dogma 2 is running"
+                                  IsChecked="{Binding AutobackupEnabled}" Margin="0,2,0,0" />
+
+                        <!-- Interval + limit. Locked while autobackup is on (matches the shipped app). -->
+                        <Grid Margin="26,12,0,0" IsEnabled="{Binding ConfigEditable}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="26" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="Back up every" VerticalAlignment="Center" Margin="0,0,8,0"
+                                       FontSize="13" Foreground="{StaticResource TextSecondaryBrush}" />
+                            <TextBox Grid.Column="1" Width="120" Text="{Binding IntervalText}"
+                                     VerticalContentAlignment="Center" Padding="8,5" FontSize="12"
+                                     Background="{StaticResource InputBrush}" Foreground="{StaticResource TextBrush}"
+                                     BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" />
+                            <TextBlock Grid.Column="3" Text="Keep at most" VerticalAlignment="Center" Margin="0,0,8,0"
+                                       FontSize="13" Foreground="{StaticResource TextSecondaryBrush}" />
+                            <TextBox Grid.Column="4" Width="56" Text="{Binding MaxBackupsText}"
+                                     VerticalContentAlignment="Center" Padding="8,5" FontSize="12"
+                                     Background="{StaticResource InputBrush}" Foreground="{StaticResource TextBrush}"
+                                     BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" />
+                            <TextBlock Grid.Column="5" Text="backups" VerticalAlignment="Center" Margin="8,0,0,0"
+                                       FontSize="13" Foreground="{StaticResource TextSecondaryBrush}" />
+                        </Grid>
+                        <TextBlock Margin="26,6,0,0" FontSize="11" Foreground="{StaticResource TextHintBrush}"
+                                   Text="Examples: 5 minutes, 30 minutes, 1 hour, 2 hours (minimum 5 minutes)." />
+
+                        <!-- Options -->
+                        <CheckBox Content="Remove the oldest autobackups once the limit is reached"
+                                  IsChecked="{Binding CleanupEnabled}" Margin="0,16,0,0" />
+                        <CheckBox Content="Send removed autobackups to the Recycle Bin"
+                                  IsChecked="{Binding RecycleEnabled}" IsEnabled="{Binding CleanupEnabled}"
+                                  Margin="26,8,0,0" />
+                        <CheckBox Content="Also back up the instant the game saves"
+                                  IsChecked="{Binding BackupOnSaveEnabled}" Margin="0,12,0,0" />
                     </StackPanel>
                 </Border>
 

--- a/Savedrake.App/MainWindow.xaml.cs
+++ b/Savedrake.App/MainWindow.xaml.cs
@@ -36,6 +36,14 @@ namespace Savedrake.App
             ApplyDwmTheming();
         }
 
+        // Tear down the view model on close so the autobackup engine's WMI game watcher, timers, and file-system
+        // watcher are stopped and disposed rather than lingering past the window.
+        protected override void OnClosed(EventArgs e)
+        {
+            (DataContext as IDisposable)?.Dispose();
+            base.OnClosed(e);
+        }
+
         // Ask DWM to round corners, go dark, and tint the caption to our bar color. Each call is guarded:
         // older Windows builds simply return a non-zero HRESULT, which we ignore.
         private void ApplyDwmTheming()

--- a/Savedrake.App/Savedrake.App.csproj
+++ b/Savedrake.App/Savedrake.App.csproj
@@ -24,6 +24,12 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
   </ItemGroup>
 
+  <!-- System.Management: the WMI ManagementEventWatcher the autobackup engine uses to learn the moment DD2 starts
+       or stops (it watches Steam's "Running" registry value). Framework assembly on net48, named explicitly. -->
+  <ItemGroup>
+    <Reference Include="System.Management" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Savedrake.Core\Savedrake.Core.csproj" />
   </ItemGroup>

--- a/Savedrake.App/Themes/Dark.xaml
+++ b/Savedrake.App/Themes/Dark.xaml
@@ -82,6 +82,46 @@
         <Setter Property="Foreground" Value="{StaticResource TextHintBrush}" />
     </Style>
 
+    <!-- Dark check box: espresso square that fills gold with a dark tick when checked. Implicit (applies to every
+         CheckBox in the app); the warm-dark theme would otherwise render the OS default light box. -->
+    <Style TargetType="CheckBox">
+        <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="CheckBox">
+                    <StackPanel Orientation="Horizontal" Background="Transparent">
+                        <Border x:Name="box" Width="18" Height="18" CornerRadius="4" VerticalAlignment="Center"
+                                Background="{StaticResource InputBrush}"
+                                BorderBrush="{StaticResource BorderBrush}" BorderThickness="1">
+                            <Path x:Name="check" Width="11" Height="11" Stretch="Uniform"
+                                  Data="M 0,5 L 4,9 L 11,0" Stroke="{StaticResource AccentTextBrush}"
+                                  StrokeThickness="2" Visibility="Collapsed"
+                                  HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Border>
+                        <ContentPresenter Margin="8,0,0,0" VerticalAlignment="Center" />
+                    </StackPanel>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="box" Property="Background" Value="{StaticResource AccentGoldBrush}" />
+                            <Setter TargetName="box" Property="BorderBrush" Value="{StaticResource AccentGoldBrush}" />
+                            <Setter TargetName="check" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="box" Property="BorderBrush" Value="{StaticResource AccentGoldBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.45" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!-- Primary gold button: filled gold, dark text. -->
     <Style x:Key="PrimaryButton" TargetType="Button">
         <Setter Property="Foreground" Value="{StaticResource AccentTextBrush}" />

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -21,28 +21,64 @@ namespace Savedrake.App.ViewModels
         public string FullPath { get; set; }
     }
 
-    // The main workflow view model (Phase 4b). Drives the Folders + Backups cards and routes the Backup / Restore /
-    // Delete actions through the UI-agnostic Core services (BackupService / RestoreService) using the WPF dialog +
-    // status implementations below. MVVM via CommunityToolkit.Mvvm source generators.
-    public partial class MainViewModel : ObservableObject
+    // The main workflow view model. Drives the Folders + Autobackup + Backups cards and routes the Backup / Restore /
+    // Delete actions through the UI-agnostic Core services (BackupService / RestoreService). The autobackup engine
+    // (Phase 5) lives in AutobackupController; this view model is its IAutobackupHost — it supplies the live config
+    // and the effects (take a backup, refresh the list, flip the toggle). MVVM via CommunityToolkit.Mvvm.
+    public partial class MainViewModel : ObservableObject, IAutobackupHost, IDisposable
     {
         private readonly IDialogService _dialog;
         private readonly IStatusSink _status;
+        private readonly AutobackupController _autobackup;
 
-        // The two folders the workflow operates on.
+        private bool _loaded;               // false during initial settings load so property hooks don't react
+        private bool _inEnableChange;       // re-entrancy guard while the enable toggle is being processed/reverted
+        private bool _isOperationInProgress; // a manual backup/restore (or an autobackup) is mid-flight
+
+        // ----- Folders -----
+
         [ObservableProperty]
         private string saveDir;
 
         [ObservableProperty]
         private string backupDir;
 
-        // The backup list shown in the Backups card (newest first), and the current selection.
+        // ----- Autobackup config (bound to the Autobackup card) -----
+
+        // Master enable. ConfigEditable is the inverse, so the folder/interval/limit inputs lock while it is on.
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(ConfigEditable))]
+        private bool autobackupEnabled;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(IntervalValid))]
+        private string intervalText = "30 minutes";
+
+        [ObservableProperty]
+        private string maxBackupsText = "10";
+
+        [ObservableProperty]
+        private bool cleanupEnabled;
+
+        [ObservableProperty]
+        private bool recycleEnabled;
+
+        [ObservableProperty]
+        private bool backupOnSaveEnabled;
+
+        // Preset intervals offered in the editable interval box (the box also accepts free text like "12 minutes").
+        public ObservableCollection<string> IntervalOptions { get; } =
+            new ObservableCollection<string> { "5 minutes", "15 minutes", "30 minutes", "1 hour", "2 hours" };
+
+        public bool ConfigEditable => !AutobackupEnabled;
+
+        // ----- Backups list -----
+
         public ObservableCollection<BackupRow> Backups { get; } = new ObservableCollection<BackupRow>();
 
         [ObservableProperty]
         private BackupRow selectedBackup;
 
-        // Status-bar text (bound) and the count shown beside the Backups folder path.
         [ObservableProperty]
         private string statusText = "Ready.";
 
@@ -53,36 +89,117 @@ namespace Savedrake.App.ViewModels
         {
             _dialog = new WpfDialogService();
             _status = new StatusSink(this);
+            _autobackup = new AutobackupController(this);
 
             LoadSettings();
             RefreshBackups();
+
+            _autobackup.Start();              // begin watching DD2's running state
+            EngageAutobackupIfEnabled();      // re-engage a saved-on autobackup (quietly, before hooks go live)
+            _loaded = true;
         }
 
-        // ----- settings (read-only reuse of the WinForms savedrake_settings.xml, best-effort) -----
+        // ================= IAutobackupHost (live config + effects the controller reads) =================
+
+        public TimeSpan AutobackupInterval =>
+            IntervalParser.TryParse(IntervalText, out TimeSpan ts) ? ts : TimeSpan.Zero;
+
+        public bool IntervalValid =>
+            IntervalParser.TryParse(IntervalText, out TimeSpan ts) && ts >= TimeSpan.FromMinutes(5);
+
+        public int MaxAutobackups => int.TryParse(MaxBackupsText, out int n) ? n : 0;
+
+        public bool MaxAutobackupsValid => int.TryParse(MaxBackupsText, out _);
+
+        public string CountFilePath => Path.Combine(AppDataDir, "count_of_autobackups.txt");
+
+        public bool IsOperationInProgress => _isOperationInProgress;
+
+        public IDialogService Dialog => _dialog;
+
+        public IStatusSink Status => _status;
+
+        // Take one autobackup now. Holds the operation lock for its duration so a manual click or another trigger
+        // can't overlap it (the controller's re-entrancy guard covers the in-thread case; this covers the lock the
+        // manual commands check).
+        public bool PerformAutobackup()
+        {
+            bool prev = _isOperationInProgress;
+            _isOperationInProgress = true;
+            try
+            {
+                BackupResult r = BackupService.Backup(
+                    new BackupRequest { LiveSaveDir = SaveDir, BackupDir = BackupDir, IsAutoBackup = true, RandomName = true },
+                    _dialog, _status);
+                return r.Ok;
+            }
+            finally { _isOperationInProgress = prev; }
+        }
+
+        public void OnBackupsChanged() => RefreshBackups();
+
+        // Turn the enable toggle off without re-running the enable logic (the controller has already stopped the
+        // timers when it calls this — limit reached / DD2 missing). Just flip the UI flag and persist.
+        public void ForceDisableAutobackup()
+        {
+            _inEnableChange = true;
+            try { AutobackupEnabled = false; }
+            finally { _inEnableChange = false; }
+            SaveSettings();
+        }
+
+        // ================= settings (shared savedrake_settings.xml, best-effort) =================
 
         private static string AppDataDir => Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Savedrake");
 
         private static string SettingsFilePath => Path.Combine(AppDataDir, "savedrake_settings.xml");
 
-        // Read SaveDir / BackupDir from the WinForms settings file's <Textbox1> / <Textbox2> if present. Read-only,
-        // dependency-free (a tiny hand-rolled XML read so we don't pull in the WinForms AppSettings type). Never throws.
+        // Read the folders + autobackup settings from the WinForms settings file if present. Read-only, dependency-free
+        // (a small hand-rolled XML read), and never throws — missing/garbled settings just leave defaults in place.
         private void LoadSettings()
         {
             try
             {
                 if (!File.Exists(SettingsFilePath)) return;
                 var doc = System.Xml.Linq.XDocument.Load(SettingsFilePath);
-                string t1 = (string)doc.Root?.Element("Textbox1");
-                string t2 = (string)doc.Root?.Element("Textbox2");
+                var root = doc.Root;
+                if (root == null) return;
+
+                string t1 = (string)root.Element("Textbox1");
+                string t2 = (string)root.Element("Textbox2");
                 if (!string.IsNullOrWhiteSpace(t1)) SaveDir = t1;
                 if (!string.IsNullOrWhiteSpace(t2)) BackupDir = t2;
+
+                string limit = (string)root.Element("AutoBackupLimit");
+                if (!string.IsNullOrWhiteSpace(limit)) MaxBackupsText = limit;
+
+                // Interval: reuse the WinForms ComboboxList + ComboboxSelectedIndex shape if present.
+                var listEl = root.Element("ComboboxList");
+                if (listEl != null)
+                {
+                    var items = listEl.Elements("Item").Select(e => (string)e).Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
+                    int idx = ParseIntOr(root.Element("ComboboxSelectedIndex"), 0);
+                    if (items.Count > 0 && idx >= 0 && idx < items.Count) IntervalText = items[idx];
+                }
+
+                CleanupEnabled = ParseBool(root.Element("AutoCleanupOldBackups"));
+                RecycleEnabled = CleanupEnabled && ParseBool(root.Element("RemovedToRecycleBin"));
+                BackupOnSaveEnabled = ParseBool(root.Element("BackupOnSaveChange"));
+                AutobackupEnabled = ParseBool(root.Element("CheckboxAuto"));
             }
-            catch { /* best-effort: missing/garbled settings just leave the fields blank */ }
+            catch { /* best-effort: defaults stand */ }
         }
 
-        // Persist the two folders into the same <Textbox1>/<Textbox2> shape the WinForms app reads, preserving any
-        // other elements already present. Best-effort: a write failure must never break the workflow.
+        private static bool ParseBool(System.Xml.Linq.XElement el)
+            => el != null && bool.TryParse(el.Value, out bool b) && b;
+
+        private static int ParseIntOr(System.Xml.Linq.XElement el, int fallback)
+            => (el != null && int.TryParse(el.Value, out int n)) ? n : fallback;
+
+        // Persist the folders + autobackup settings into the same element shape the WinForms app uses, preserving any
+        // other elements already present (window size, theme, hotkey, ...). Best-effort: a write failure never breaks
+        // the workflow.
         private void SaveSettings()
         {
             try
@@ -101,11 +218,34 @@ namespace Savedrake.App.ViewModels
 
                 var root = doc.Root ?? new System.Xml.Linq.XElement("AppSettings");
                 if (doc.Root == null) doc.Add(root);
+
                 SetElement(root, "Textbox1", SaveDir ?? "");
                 SetElement(root, "Textbox2", BackupDir ?? "");
+                SetElement(root, "AutoBackupLimit", MaxBackupsText ?? "");
+                SetElement(root, "CheckboxAuto", AutobackupEnabled.ToString());
+                SetElement(root, "AutoCleanupOldBackups", CleanupEnabled.ToString());
+                SetElement(root, "RemovedToRecycleBin", RecycleEnabled.ToString());
+                SetElement(root, "BackupOnSaveChange", BackupOnSaveEnabled.ToString());
+                SetIntervalElements(root);
+
                 doc.Save(SettingsFilePath);
             }
             catch { /* best-effort persistence */ }
+        }
+
+        // Write the chosen interval back in the WinForms ComboboxList + ComboboxSelectedIndex shape so the two apps
+        // stay file-compatible. The list is the current preset set (with the chosen value ensured present).
+        private void SetIntervalElements(System.Xml.Linq.XElement root)
+        {
+            var items = IntervalOptions.ToList();
+            if (!string.IsNullOrWhiteSpace(IntervalText) && !items.Contains(IntervalText)) items.Insert(0, IntervalText);
+            int idx = Math.Max(0, items.IndexOf(IntervalText ?? ""));
+
+            var listEl = root.Element("ComboboxList");
+            if (listEl == null) { listEl = new System.Xml.Linq.XElement("ComboboxList"); root.Add(listEl); }
+            listEl.RemoveNodes();
+            foreach (string s in items) listEl.Add(new System.Xml.Linq.XElement("Item", s));
+            SetElement(root, "ComboboxSelectedIndex", idx.ToString());
         }
 
         private static void SetElement(System.Xml.Linq.XElement root, string name, string value)
@@ -115,7 +255,126 @@ namespace Savedrake.App.ViewModels
             else el.Value = value;
         }
 
-        // ----- backup list -----
+        // ================= autobackup enable / config hooks =================
+
+        // Re-engage a saved-on autobackup at startup, quietly (no modal prompts): if DD2 is missing or the folders /
+        // interval / limit are not valid, just leave it off.
+        private void EngageAutobackupIfEnabled()
+        {
+            if (!AutobackupEnabled) return;
+            if (_autobackup.NoGame || !ValidateAutobackupDirectories(silent: true))
+            {
+                AutobackupEnabled = false;
+                return;
+            }
+            _autobackup.OnEnableOrConfigChanged();
+        }
+
+        partial void OnAutobackupEnabledChanged(bool value)
+        {
+            if (!_loaded || _inEnableChange) return;
+            _inEnableChange = true;
+            try
+            {
+                if (value)
+                {
+                    if (_autobackup.NoGame)
+                    {
+                        _dialog.Warn("Autobackup Unavailable",
+                            "Dragon's Dogma 2 appears to be missing from your Steam library. Autobackup works with " +
+                            "the Steam version of the game and can't run without it.");
+                        AutobackupEnabled = false;
+                        return;
+                    }
+                    if (!ValidateAutobackupDirectories())
+                    {
+                        AutobackupEnabled = false;
+                        return;
+                    }
+                    _autobackup.OnEnableOrConfigChanged();
+                }
+                else
+                {
+                    _autobackup.OnEnableOrConfigChanged();
+                    _status.Set("Autobackup disabled.");
+                }
+                SaveSettings();
+            }
+            finally { _inEnableChange = false; }
+        }
+
+        partial void OnIntervalTextChanged(string value)
+        {
+            if (!_loaded) return;
+            SaveSettings();
+            _autobackup.ApplyIntervalChange();
+        }
+
+        partial void OnMaxBackupsTextChanged(string value)
+        {
+            if (!_loaded) return;
+            SaveSettings();
+        }
+
+        partial void OnCleanupEnabledChanged(bool value)
+        {
+            if (!_loaded) return;
+            if (!value && RecycleEnabled) RecycleEnabled = false; // recycle only applies when cleanup is on
+            SaveSettings();
+        }
+
+        partial void OnRecycleEnabledChanged(bool value)
+        {
+            if (!_loaded) return;
+            SaveSettings();
+        }
+
+        partial void OnBackupOnSaveEnabledChanged(bool value)
+        {
+            if (!_loaded) return;
+            SaveSettings();
+            _autobackup.OnBackupOnSaveChanged();
+        }
+
+        // Directory + interval + limit validity for enabling autobackup. silent = startup re-engage (no prompts).
+        private bool ValidateAutobackupDirectories(bool silent = false)
+        {
+            if (string.IsNullOrWhiteSpace(SaveDir) || !Directory.Exists(SaveDir))
+            {
+                if (!silent) _dialog.Error("Error", "Please select a valid Savegame location first.");
+                return false;
+            }
+            if (string.IsNullOrWhiteSpace(BackupDir))
+            {
+                if (!silent) _dialog.Error("Error", "Please select a Backup location.");
+                return false;
+            }
+            if (SaveDir.Equals(BackupDir, StringComparison.OrdinalIgnoreCase))
+            {
+                if (!silent) _dialog.Error("Error", "The Savegame and Backup locations cannot be the same.");
+                return false;
+            }
+            if (!Directory.Exists(BackupDir))
+            {
+                if (silent) return false;
+                if (!_dialog.Confirm("Create Directory", "The backup location does not exist. Create it?")) return false;
+                try { Directory.CreateDirectory(BackupDir); }
+                catch (Exception ex) { _dialog.Error("Error", "Could not create the backup location: " + ex.Message); return false; }
+            }
+            if (!IntervalValid)
+            {
+                if (!silent) _dialog.Error("Error", "Please choose an autobackup interval of at least 5 minutes.");
+                return false;
+            }
+            if (!MaxAutobackupsValid)
+            {
+                if (!silent) _dialog.Error("Error", "Please enter a valid whole number for the autobackup limit.");
+                return false;
+            }
+            return true;
+        }
+
+        // ================= backup list =================
 
         // Rebuild the Backups list from the *.zip files in BackupDir, newest first, exactly like the WinForms
         // LoadBackupHistory: open each zip, "Protected" if it carries a manifest else "Legacy", friendly creation
@@ -136,7 +395,6 @@ namespace Savedrake.App.ViewModels
             try { zipFiles = Directory.GetFiles(dir, "*.zip"); }
             catch { zipFiles = new string[0]; }
 
-            // Newest first by creation time (same ordering as LoadBackupHistory).
             Array.Sort(zipFiles, (x, y) => File.GetCreationTime(y).CompareTo(File.GetCreationTime(x)));
 
             foreach (string path in zipFiles)
@@ -166,7 +424,7 @@ namespace Savedrake.App.ViewModels
             BackupCount = Backups.Count.ToString();
         }
 
-        // ----- folder pickers -----
+        // ================= folder pickers =================
 
         [RelayCommand]
         private void BrowseSave()
@@ -198,20 +456,22 @@ namespace Savedrake.App.ViewModels
             }
         }
 
-        // ----- workflow actions -----
+        // ================= workflow actions =================
 
         [RelayCommand]
         private void Backup()
         {
-            BackupService.Backup(
-                new BackupRequest
-                {
-                    LiveSaveDir = SaveDir,
-                    BackupDir = BackupDir,
-                    IsAutoBackup = false,
-                    RandomName = true
-                },
-                _dialog, _status);
+            if (_isOperationInProgress) { _status.Set("Please wait, another operation is already running."); return; }
+            _isOperationInProgress = true;
+            try
+            {
+                BackupService.Backup(
+                    new BackupRequest { LiveSaveDir = SaveDir, BackupDir = BackupDir, IsAutoBackup = false, RandomName = true },
+                    _dialog, _status);
+            }
+            finally { _isOperationInProgress = false; }
+
+            _autobackup.NotifyExternalBackup(); // advance the change-aware baseline so autobackup doesn't re-capture
             RefreshBackups();
         }
 
@@ -223,30 +483,28 @@ namespace Savedrake.App.ViewModels
                 _dialog.Warn("Restore", "Please select a backup to restore first.");
                 return;
             }
+            if (_isOperationInProgress) { _status.Set("Please wait, another operation is already running."); return; }
 
-            RestoreService.Restore(
-                new RestoreRequest
-                {
-                    BackupZipPath = SelectedBackup.FullPath,
-                    LiveSaveDir = SaveDir,
-                    BackupDir = BackupDir,
-                    GameRunning = IsGameRunning()
-                },
-                _dialog, _status);
-            RefreshBackups();
-        }
-
-        // Best-effort game-running check: a plain process-name probe. The WinForms CheckGameRunningStatus is more
-        // thorough (it also inspects window state); a process check is sufficient for the restore guard for now.
-        // TODO (Phase 5): replace with the full CheckGameRunningStatus parity check.
-        private static bool IsGameRunning()
-        {
+            _isOperationInProgress = true;
+            _autobackup.SuppressSaveWatcher = true; // the restore writes into the save folder — don't auto-back that up
             try
             {
-                return System.Diagnostics.Process.GetProcessesByName("DD2").Length > 0
-                    || System.Diagnostics.Process.GetProcessesByName("DD2-game").Length > 0;
+                RestoreService.Restore(
+                    new RestoreRequest
+                    {
+                        BackupZipPath = SelectedBackup.FullPath,
+                        LiveSaveDir = SaveDir,
+                        BackupDir = BackupDir,
+                        GameRunning = GameDetect.IsDd2Running()
+                    },
+                    _dialog, _status);
             }
-            catch { return false; }
+            finally
+            {
+                _isOperationInProgress = false;
+                _autobackup.SuppressSaveWatcher = false;
+            }
+            RefreshBackups();
         }
 
         [RelayCommand]
@@ -259,8 +517,7 @@ namespace Savedrake.App.ViewModels
             }
 
             BackupRow row = SelectedBackup;
-            if (!_dialog.Confirm("Delete Backup",
-                    "Delete this backup permanently?\n\n" + row.FileName))
+            if (!_dialog.Confirm("Delete Backup", "Delete this backup permanently?\n\n" + row.FileName))
                 return;
 
             try
@@ -275,18 +532,16 @@ namespace Savedrake.App.ViewModels
             RefreshBackups();
         }
 
-        // ----- WPF service implementations -----
+        public void Dispose() => _autobackup?.Dispose();
+
+        // ================= WPF service implementations =================
 
         // Modal dialogs via System.Windows.MessageBox. Confirm uses YesNo (Yes == affirmative, matching the WinForms
-        // DialogResult.Yes convention the Core services were transcribed against); Info/Warn/Error map to the
-        // matching MessageBox icons.
+        // DialogResult.Yes convention the Core services were transcribed against).
         private sealed class WpfDialogService : IDialogService
         {
             public bool Confirm(string title, string message)
-            {
-                return MessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxImage.Question)
-                       == MessageBoxResult.Yes;
-            }
+                => MessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes;
 
             public void Info(string title, string message)
                 => MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Information);
@@ -298,8 +553,7 @@ namespace Savedrake.App.ViewModels
                 => MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Error);
         }
 
-        // Routes each Core Status.Text write into the bound StatusText property, marshalled to the UI thread (a
-        // backup/restore may set status from a non-UI context in later phases).
+        // Routes each Core Status.Text write into the bound StatusText property, marshalled to the UI thread.
         private sealed class StatusSink : IStatusSink
         {
             private readonly MainViewModel _vm;


### PR DESCRIPTION
## Phase 5b of the WinForms -> WPF migration

Brings **autobackup** to the WPF app at parity with the shipped WinForms app, driving the harness-proven Core decision logic from Phase 5a.

### New `AutobackupController` (Savedrake.App)
Re-expresses the WinForms autobackup machinery for WPF, entirely on the UI thread:
- **Interval + quiesce timers** are `DispatcherTimer`s (fire on the UI thread directly — no `SynchronizingObject` marshalling needed).
- **FileSystemWatcher** (instant capture) and the **WMI `ManagementEventWatcher`** (learns the moment DD2 starts/stops via Steam's `Running` registry value) fire on background threads and marshal onto the UI thread with `Dispatcher.BeginInvoke` — never a blocking `Invoke`, so a background thread can't deadlock against `Dispose()`.
- The **re-entrancy guard + operation lock** are preserved: a failure/limit dialog pumps the Dispatcher queue, so a queued tick/watcher event can re-enter — the guard skips it.
- The decision itself (change-aware gate, count, limit, cleanup, game-start bypass) is **all Core**: `AutobackupPolicy` / `AutobackupCountStore` / `AutobackupCleanup` / `GameDetect` / `Fingerprint`.

### `MainViewModel` is the controller's `IAutobackupHost`
Bound autobackup state (enable, interval, limit, clean-up, recycle, back-up-on-save), enable validation, settings persistence in the shared `savedrake_settings.xml` shape, and the operation lock / watcher suppression around manual backup & restore. The restore game-check now uses `GameDetect.IsDd2Running()` (registry parity) instead of the process-name probe.

### UI
The Autobackup card placeholder is replaced with the real controls (a themed dark `CheckBox` style was added to match the warm-dark palette). The folder/interval/limit inputs lock while autobackup is on. The window disposes the view model (and the engine) on close.

### Verification
- **WinForms + Core untouched** — only `Savedrake.App` files changed.
- Release + Debug build clean (only the known/accepted NU1903 DotNetZip advisory). Harness **239/0**.
- **Sandboxed end-to-end run** (throwaway folders, *never* the real DD2 saves): the app auto-engaged autobackup from settings, detected the game as not running, paused with the correct status, locked the inputs, and wrote **no** backup. Screenshot reviewed — the card renders on-theme with the dark gold-check boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)