### PR TITLE
WPF Phase 6b: autobackup correctness + lifecycle hardening (audit fixes)

### DIFF
--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -882,6 +882,31 @@ namespace RestoreHarness
                 fs.Write(B("5"), 0, 1);
                 Check("exclusively-locked file -> 0 (no throw)", AutobackupCountStore.Read(f) == 0);
             }
+
+            // Phase 6b: the critical fix — the count must be WRITTEN, not just read, or the "Keep at most N" limit
+            // never triggers. Write round-trips; CountAutobackups matches the WinForms filter (non-pinned (Auto)/auto
+            // zips only); RecomputeAndWrite makes Read agree with the files on disk.
+            string g = Path.Combine(dir, "count2.txt");
+            AutobackupCountStore.Write(g, 42);
+            Check("Write then Read round-trips", AutobackupCountStore.Read(g) == 42);
+            AutobackupCountStore.Write(null, 1); // must not throw on a null path
+            Check("Write(null) is a no-op (no throw)", true);
+
+            string cdir = NewDir("count_recompute");
+            MakeZip(Path.Combine(cdir, "(Auto) a.zip"), z => z.AddEntry("x", B("1")));
+            MakeZip(Path.Combine(cdir, "(Auto) b.zip"), z => z.AddEntry("x", B("1")));
+            MakeZip(Path.Combine(cdir, "autobackup_240101.zip"), z => z.AddEntry("x", B("1")));   // "auto" prefix counts
+            MakeZip(Path.Combine(cdir, "(Auto) pinned [PINNED].zip"), z => z.AddEntry("x", B("1"))); // pinned excluded
+            MakeZip(Path.Combine(cdir, "ManualBackup.zip"), z => z.AddEntry("x", B("1")));          // manual excluded
+            MakeZip(Path.Combine(cdir, "(Pre-Restore) cp.zip"), z => z.AddEntry("x", B("1")));      // checkpoint excluded
+            Check("CountAutobackups counts only non-pinned (Auto)/auto zips", AutobackupCountStore.CountAutobackups(cdir) == 3,
+                "got " + AutobackupCountStore.CountAutobackups(cdir));
+            Check("CountAutobackups on a missing dir -> 0", AutobackupCountStore.CountAutobackups(Path.Combine(cdir, "nope")) == 0);
+
+            string cf = Path.Combine(cdir, "count_of_autobackups.txt");
+            int written = AutobackupCountStore.RecomputeAndWrite(cdir, cf);
+            Check("RecomputeAndWrite returns the live count", written == 3, "got " + written);
+            Check("RecomputeAndWrite persists so Read agrees with disk", AutobackupCountStore.Read(cf) == 3);
             Console.WriteLine();
         }
 

--- a/Savedrake.App/AutobackupController.cs
+++ b/Savedrake.App/AutobackupController.cs
@@ -116,7 +116,16 @@ namespace Savedrake.App
         // The user just took a manual backup: advance the baseline so the next autobackup attempt does not re-capture
         // an unchanged save (matches the WinForms baseline advance inside BackupOperation, which ran for manual backups
         // too). Harmless when autobackup is off.
-        public void NotifyExternalBackup()
+        public void NotifyExternalBackup() => AdvanceBaselineToCurrentSave();
+
+        // A restore just SUCCEEDED: advance the change-aware baseline to the restored save so a late FileSystemWatcher
+        // event from the restore's own writes (MoveDirContents / ClearReadOnlyRecursive) resolves to SkipNoChange
+        // instead of capturing the just-restored save as a brand-new autobackup. Mirrors the WinForms reference, which
+        // sets _lastAutoBackupFingerprint = ComputeSaveFingerprint(...) right after a successful RestoreTransactional.
+        // The caller gates this on RestoreResult.Ok so the baseline only moves when the save actually changed.
+        public void NotifyExternalRestore() => AdvanceBaselineToCurrentSave();
+
+        private void AdvanceBaselineToCurrentSave()
         {
             try { _lastFingerprint = Fingerprint.ComputeSaveFingerprint(_host.SaveDir); } catch { }
         }

--- a/Savedrake.App/AutobackupController.cs
+++ b/Savedrake.App/AutobackupController.cs
@@ -22,6 +22,7 @@ namespace Savedrake.App
         bool RecycleEnabled { get; }
         bool BackupOnSaveEnabled { get; }
         string CountFilePath { get; }
+        string IntervalDisplay { get; }        // the interval as the user typed it, for status text ("30 minutes")
         bool IsOperationInProgress { get; }    // a manual backup/restore is mid-flight
 
         IDialogService Dialog { get; }
@@ -181,7 +182,7 @@ namespace Savedrake.App
                 RunChangeAwareAutobackup(bypassChangeGate: true);
 
                 if (_host.AutobackupEnabled) // still on (the immediate backup may have hit the limit and disabled it)
-                    _host.Status.Set("Game running. Autobackup is on.");
+                    _host.Status.Set("Game running. Autobackup began every " + _host.IntervalDisplay + ".");
             }
             else
             {
@@ -289,6 +290,7 @@ namespace Savedrake.App
 
         private void StartSaveWatcher()
         {
+            if (_disposed) return; // never resurrect the watcher after shutdown
             if (!_host.BackupOnSaveEnabled) return;
             string dir = _host.SaveDir;
             if (string.IsNullOrWhiteSpace(dir) || !Directory.Exists(dir)) return;
@@ -346,20 +348,20 @@ namespace Savedrake.App
         // thread and (re)start the debounce, so a burst of writes collapses into one backup once the save has settled.
         private void OnSaveChanged(object sender, FileSystemEventArgs e)
         {
-            if (_suppressSaveWatcher) return;
+            if (_disposed || _suppressSaveWatcher) return;
             try { _dispatcher.BeginInvoke(new Action(RestartQuiesce)); } catch (Exception) { }
         }
 
         private void RestartQuiesce()
         {
             // A marshalled event can land after StopSaveWatcher nulled the timer (shutdown / game exit / toggle off).
-            if (_quiesceTimer == null) return;
+            if (_disposed || _quiesceTimer == null) return;
             try { _quiesceTimer.Stop(); _quiesceTimer.Start(); } catch (Exception) { }
         }
 
         private void OnQuiesceElapsed(object sender, EventArgs e)
         {
-            if (_quiesceTimer == null) return;
+            if (_disposed || _quiesceTimer == null) return;
             try { _quiesceTimer.Stop(); } catch (Exception) { return; }
             if (_suppressSaveWatcher) return;
             if (!_host.AutobackupEnabled) return;
@@ -372,8 +374,9 @@ namespace Savedrake.App
         // interval timer covers anything missed in the meantime.
         private void OnSaveWatcherError(object sender, ErrorEventArgs e)
         {
+            if (_disposed) return;
             Log.Warn("Save watcher error, re-arming: " + (e.GetException() != null ? e.GetException().Message : "unknown"));
-            try { _dispatcher.BeginInvoke(new Action(() => { StopSaveWatcher(); StartSaveWatcher(); })); } catch (Exception) { }
+            try { _dispatcher.BeginInvoke(new Action(() => { if (_disposed) return; StopSaveWatcher(); StartSaveWatcher(); })); } catch (Exception) { }
         }
 
         public void Dispose()

--- a/Savedrake.App/MainWindow.xaml.cs
+++ b/Savedrake.App/MainWindow.xaml.cs
@@ -28,6 +28,9 @@ namespace Savedrake.App
         {
             InitializeComponent();
             DataContext = new Savedrake.App.ViewModels.MainViewModel();
+            // Start the autobackup engine (WMI watcher) and re-engage a saved-on autobackup only once the window is
+            // loaded, so any limit/invalid dialog from the immediate game-start backup has a real owner window.
+            Loaded += (s, e) => (DataContext as Savedrake.App.ViewModels.MainViewModel)?.Activate();
         }
 
         protected override void OnSourceInitialized(EventArgs e)

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -94,10 +94,18 @@ namespace Savedrake.App.ViewModels
 
             LoadSettings();
             RefreshBackups();
-
-            _autobackup.Start();              // begin watching DD2's running state
-            EngageAutobackupIfEnabled();      // re-engage a saved-on autobackup (quietly, before hooks go live)
             _loaded = true;
+            // The WMI watcher and any saved-on autobackup re-engage are deferred to Activate(), which the window calls
+            // once it exists — so a limit/invalid dialog from the immediate game-start backup has a real owner window
+            // and the WMI watcher can't fire a status change mid-construction.
+        }
+
+        // Called by the window once it is loaded. Starts watching DD2's running state and re-engages a saved-on
+        // autobackup. Kept off the constructor so any modal it raises owns the (now-real) window.
+        public void Activate()
+        {
+            _autobackup.Start();
+            EngageAutobackupIfEnabled();
         }
 
         // ================= IAutobackupHost (live config + effects the controller reads) =================
@@ -110,9 +118,13 @@ namespace Savedrake.App.ViewModels
 
         public int MaxAutobackups => int.TryParse(MaxBackupsText, out int n) ? n : 0;
 
-        public bool MaxAutobackupsValid => int.TryParse(MaxBackupsText, out _);
+        // A valid limit is a positive whole number. A zero/negative limit would let autobackup engage and then
+        // immediately self-disable with a nonsensical "maximum number of 0 autobackups reached" message.
+        public bool MaxAutobackupsValid => int.TryParse(MaxBackupsText, out int n) && n >= 1;
 
         public string CountFilePath => Path.Combine(AppDataDir, "count_of_autobackups.txt");
+
+        public string IntervalDisplay => string.IsNullOrWhiteSpace(IntervalText) ? "the set interval" : IntervalText.Trim();
 
         public bool IsOperationInProgress => _isOperationInProgress;
 
@@ -266,7 +278,13 @@ namespace Savedrake.App.ViewModels
             if (!AutobackupEnabled) return;
             if (_autobackup.NoGame || !ValidateAutobackupDirectories(silent: true))
             {
-                AutobackupEnabled = false;
+                // Saved-on autobackup can't engage (DD2 missing or the folders/interval/limit are no longer valid).
+                // Turn it off WITHOUT re-running the enable hooks, and persist so the on-disk CheckboxAuto matches
+                // the UI (otherwise the shared settings file would keep claiming autobackup is on).
+                _inEnableChange = true;
+                try { AutobackupEnabled = false; }
+                finally { _inEnableChange = false; }
+                SaveSettings();
                 return;
             }
             _autobackup.OnEnableOrConfigChanged();
@@ -390,6 +408,9 @@ namespace Savedrake.App.ViewModels
             {
                 BackupCount = "0";
                 SelectedBackup = null;
+                // No valid backup folder -> the on-disk autobackup count is zero. Keep the count file honest so a
+                // later re-point doesn't inherit a stale count.
+                AutobackupCountStore.Write(CountFilePath, 0);
                 return;
             }
 
@@ -424,6 +445,11 @@ namespace Savedrake.App.ViewModels
             }
 
             BackupCount = Backups.Count.ToString();
+
+            // Recompute and persist the autobackup count (non-pinned "(Auto)"/"auto" zips) so the "Keep at most N"
+            // limit is enforced against the real files on disk. This is the writer the autobackup engine reads back;
+            // without it the limit never triggers. Mirrors WinForms LoadBackupHistory.
+            AutobackupCountStore.RecomputeAndWrite(dir, CountFilePath);
         }
 
         // ================= folder pickers =================
@@ -507,6 +533,9 @@ namespace Savedrake.App.ViewModels
                 _isOperationInProgress = false;
                 _autobackup.SuppressSaveWatcher = false;
             }
+            // Re-baseline the change-aware fingerprint to the now-restored save so the next autobackup tick doesn't
+            // immediately re-capture it (and any trailing watcher event for the restore's own writes finds no change).
+            _autobackup.NotifyExternalBackup();
             RefreshBackups();
         }
 
@@ -518,20 +547,29 @@ namespace Savedrake.App.ViewModels
                 _dialog.Warn("Delete", "Please select a backup to delete first.");
                 return;
             }
+            if (_isOperationInProgress) { _status.Set("Please wait, another operation is already running."); return; }
 
             BackupRow row = SelectedBackup;
-            if (!_dialog.Confirm("Delete Backup", "Delete this backup permanently?\n\n" + row.FileName))
-                return;
 
+            // Hold the operation lock across the whole delete, including the confirm dialog. The modal pumps the
+            // Dispatcher queue, so without the lock a queued autobackup tick could fire and rebuild the list (nulling
+            // SelectedBackup) mid-delete.
+            _isOperationInProgress = true;
             try
             {
-                File.Delete(row.FullPath);
-                _status.Set("Backup deleted.");
+                if (!_dialog.Confirm("Delete Backup", "Delete this backup permanently?\n\n" + row.FileName))
+                    return;
+                try
+                {
+                    File.Delete(row.FullPath);
+                    _status.Set("Backup deleted.");
+                }
+                catch (Exception ex)
+                {
+                    _dialog.Error("Delete Failed", "Could not delete the backup: " + ex.Message);
+                }
             }
-            catch (Exception ex)
-            {
-                _dialog.Error("Delete Failed", "Could not delete the backup: " + ex.Message);
-            }
+            finally { _isOperationInProgress = false; }
             RefreshBackups();
         }
 

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -514,11 +514,12 @@ namespace Savedrake.App.ViewModels
             }
             if (_isOperationInProgress) { _status.Set("Please wait, another operation is already running."); return; }
 
+            RestoreResult result = null;
             _isOperationInProgress = true;
             _autobackup.SuppressSaveWatcher = true; // the restore writes into the save folder — don't auto-back that up
             try
             {
-                RestoreService.Restore(
+                result = RestoreService.Restore(
                     new RestoreRequest
                     {
                         BackupZipPath = SelectedBackup.FullPath,
@@ -533,9 +534,13 @@ namespace Savedrake.App.ViewModels
                 _isOperationInProgress = false;
                 _autobackup.SuppressSaveWatcher = false;
             }
-            // Re-baseline the change-aware fingerprint to the now-restored save so the next autobackup tick doesn't
-            // immediately re-capture it (and any trailing watcher event for the restore's own writes finds no change).
-            _autobackup.NotifyExternalBackup();
+            // On a SUCCESSFUL restore, advance the change-aware baseline to the now-restored save (mirrors the WinForms
+            // reference, which set _lastAutoBackupFingerprint after a successful RestoreTransactional). SuppressSaveWatcher
+            // is cleared in the finally above, so a trailing FileSystemWatcher event from the restore's own writes can
+            // still arrive and, ~4s later, run the change-aware gate; with the baseline now equal to the restored
+            // content that gate resolves to SkipNoChange instead of capturing a redundant autobackup. Gated on Ok so the
+            // baseline only moves when the save actually changed (on failure the restore rolled back to the original).
+            if (result != null && result.Ok) _autobackup.NotifyExternalRestore();
             RefreshBackups();
         }
 

--- a/Savedrake.Core/AutobackupCountStore.cs
+++ b/Savedrake.Core/AutobackupCountStore.cs
@@ -3,11 +3,12 @@ using System.IO;
 namespace Savedrake
 {
     // The persisted "how many autobackups exist" counter. It is a single integer in a text file under the app data
-    // directory; the autobackup limit is enforced against it. Reading is deliberately forgiving: a missing, empty,
-    // garbled, or transiently locked file reads as 0 rather than throwing, because the count is advisory (the real
-    // source of truth is the files on disk, recomputed after every backup) and a read hiccup must never crash or
-    // wedge the autobackup loop. This is the one intentional hardening over the shipped inline read, which had no
-    // guard around File.ReadAllText.
+    // directory; the autobackup limit is enforced against it. The real source of truth is the files on disk: the
+    // count is RECOMPUTED from the backup folder and written back after every backup/restore/delete/cleanup, so the
+    // file is only ever a cache. Reading is deliberately forgiving (missing/garbled/locked -> 0) and writing is
+    // best-effort (a write hiccup must never crash or wedge the autobackup loop). Recompute matches the shipped
+    // WinForms LoadBackupHistory exactly: count = zips named "(Auto)"/"auto" and NOT pinned (pinned autobackups are
+    // protected from cleanup and excluded from the limit).
     public static class AutobackupCountStore
     {
         public static int Read(string countFilePath)
@@ -25,6 +26,46 @@ namespace Savedrake
                 // Locked / unreadable count file: treat as 0. Worst case is one extra eligible attempt, which the
                 // change-aware gate and the on-disk recount immediately correct.
             }
+            return count;
+        }
+
+        // Best-effort persist of the count. A write failure is swallowed: the count is a cache, not a source of truth.
+        public static void Write(string countFilePath, int count)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(countFilePath))
+                    File.WriteAllText(countFilePath, count.ToString());
+            }
+            catch { }
+        }
+
+        // The on-disk autobackup count: zips whose name starts with "(Auto)" or "auto" and are not pinned. Matches
+        // WinForms LoadBackupHistory's autoBackupFiles filter byte-for-byte. Never throws (an unreadable folder -> 0).
+        public static int CountAutobackups(string backupDir)
+        {
+            if (string.IsNullOrWhiteSpace(backupDir) || !Directory.Exists(backupDir)) return 0;
+            int n = 0;
+            try
+            {
+                foreach (string file in Directory.GetFiles(backupDir, "*.zip"))
+                {
+                    string name = Path.GetFileName(file);
+                    if (!(name.StartsWith("(Auto)") || name.StartsWith("auto"))) continue;
+                    if (Pinning.IsPinnedBackup(name)) continue;
+                    n++;
+                }
+            }
+            catch { }
+            return n;
+        }
+
+        // Recompute the autobackup count from the backup folder and write it to the count file. Returns the count.
+        // This is what keeps the "Keep at most N" limit honest; the WPF app calls it after refreshing the backup list.
+        public static int RecomputeAndWrite(string backupDir, string countFilePath)
+        {
+            int count = CountAutobackups(backupDir);
+            Write(countFilePath, count);
             return count;
         }
     }


### PR DESCRIPTION
## Phase 6b — correctness fixes from a multi-agent adversarial audit

A workflow of parity-enumeration + adversarial bug-hunting agents (with 2-skeptic verification per finding) reviewed the Phase 5 autobackup engine. This PR fixes the confirmed bugs.

### CRITICAL — "Keep at most N" never enforced
The autobackup count file was **read but never written**, so `AutobackupCountStore.Read` always returned 0 and the limit never triggered (fresh installs back up forever; an upgrade with a stale high count could disable autobackup permanently).
- Core `AutobackupCountStore` gains `Write` / `CountAutobackups` / `RecomputeAndWrite` — `count = non-pinned "(Auto)"/"auto" zips`, matching WinForms `LoadBackupHistory` byte-for-byte.
- `MainViewModel.RefreshBackups` recomputes + writes the count after every backup/restore/delete, so the limit is enforced against the real files on disk.

### HIGH — save-watcher could resurrect after Dispose
The FileSystemWatcher/quiesce/error-rearm path had no `_disposed` guard (only the WMI path did), so an event marshalled during/after `Dispose()` could re-create the watcher and fire a backup post-shutdown, leaking a live watcher + timer. Added `_disposed` guards across `OnSaveChanged`, `RestartQuiesce`, `OnQuiesceElapsed`, `StartSaveWatcher`, and the `OnSaveWatcherError` re-arm.

### MEDIUM
- **Modal in constructor:** the immediate game-start backup's limit/invalid dialog ran inside the view-model constructor (owner-less, before the window existed). Engine start + saved-on re-engage are deferred to a new `Activate()` the window calls on `Loaded`.
- **Delete lock:** `Delete` now holds the operation lock across its confirm modal, so a queued autobackup tick can't rebuild the list (nulling `SelectedBackup`) mid-delete.
- **Positive limit floor:** the limit must be `>= 1`; a 0/negative value no longer engages-then-instantly-disables with a nonsensical "maximum number of 0 autobackups" message.

### LOW
- Game-running status restores the interval (`...began every 30 minutes.`).
- A saved-on autobackup that can't re-engage at startup now persists `CheckboxAuto=false` so the shared settings file matches the UI.
- After a successful restore, the change-aware baseline is advanced to the restored save (no redundant immediate re-capture; closes the watcher-suppress window).

### Verification
- **WinForms untouched.** Release + Debug build clean.
- Harness **241 → 247** (new `Write` / `CountAutobackups` / `RecomputeAndWrite` tests).
- **Sandboxed runtime check** (throwaway folders, never the real saves): a backup folder of 3 non-pinned autos + 1 pinned + 1 manual produced `count_of_autobackups.txt = 3`, and the deferred `Activate()` launched cleanly with the game-not-running pause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)