### PR TITLE
WPF Phase 6c: backup-list management (rename / pin / validate / recycle delete)

### DIFF
--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -24,8 +24,8 @@
         <!-- Display-only converters for the Backups list rows. -->
         <vm:PinnedToBrushConverter x:Key="PinDotBrush" OnKey="AccentGoldBrush" OffKey="TextSecondaryBrush" />
         <vm:PinnedToBrushConverter x:Key="PinNameBrush" OnKey="AccentGoldBrush" OffKey="TextBrush" />
-        <vm:RowToPillTextConverter x:Key="PillText" />
-        <vm:RowToPillBrushConverter x:Key="PillBrush" />
+        <vm:PinStatusToPillTextConverter x:Key="PillText" />
+        <vm:PinStatusToPillBrushConverter x:Key="PillBrush" />
     </Window.Resources>
 
     <!-- Outer margin so the espresso shell shows around the content. -->
@@ -199,13 +199,17 @@
                                 <Button Content="Restore" Style="{StaticResource OutlineButton}"
                                         Padding="14,7" Margin="8,0,0,0" Command="{Binding RestoreCommand}" />
                                 <Button Content="Delete" Style="{StaticResource DangerButton}"
-                                        Padding="14,7" Margin="8,0,0,0" Command="{Binding DeleteCommand}" />
+                                        Padding="14,7" Margin="8,0,0,0" Command="{Binding DeleteCommand}"
+                                        CommandParameter="{Binding SelectedItems, ElementName=BackupList}" />
                             </StackPanel>
                         </Grid>
 
-                        <!-- Backup list: dark, header-less, custom row template. -->
-                        <ListView ItemsSource="{Binding Backups}"
+                        <!-- Backup list: dark, header-less, custom row template. Multi-select for delete. -->
+                        <ListView x:Name="BackupList" ItemsSource="{Binding Backups}"
                                   SelectedItem="{Binding SelectedBackup, Mode=TwoWay}"
+                                  SelectionMode="Extended"
+                                  KeyDown="BackupList_KeyDown"
+                                  MouseDoubleClick="BackupList_MouseDoubleClick"
                                   Background="{StaticResource CardBrush}"
                                   BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
                                   Foreground="{StaticResource TextBrush}"
@@ -249,16 +253,26 @@
                                 </Style>
                             </ListView.ItemContainerStyle>
 
-                            <!-- Right-click actions. Delete is wired; the rest are stubs for a later phase. -->
+                            <!-- Right-click actions. Bound through the ListView's PlacementTarget to the view model. -->
                             <ListView.ContextMenu>
                                 <ContextMenu>
-                                    <MenuItem Header="Rename" IsEnabled="False" />
+                                    <MenuItem Header="Rename"
+                                              Command="{Binding PlacementTarget.DataContext.RenameCommand,
+                                                        RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                    <MenuItem Header="{Binding PlacementTarget.DataContext.PinMenuLabel,
+                                                      RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                              Command="{Binding PlacementTarget.DataContext.PinCommand,
+                                                        RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                    <Separator />
                                     <MenuItem Header="Delete"
                                               Command="{Binding PlacementTarget.DataContext.DeleteCommand,
+                                                        RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                              CommandParameter="{Binding PlacementTarget.SelectedItems,
                                                         RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
-                                    <MenuItem Header="Pin" IsEnabled="False" />
                                     <Separator />
-                                    <MenuItem Header="Validate all" IsEnabled="False" />
+                                    <MenuItem Header="Validate all"
+                                              Command="{Binding PlacementTarget.DataContext.ValidateAllCommand,
+                                                        RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
                                 </ContextMenu>
                             </ListView.ContextMenu>
 
@@ -282,12 +296,23 @@
                                                    FontSize="13" TextTrimming="CharacterEllipsis"
                                                    Foreground="{Binding IsPinned, Converter={StaticResource PinNameBrush}}" />
 
-                                        <!-- Status / pin pill. -->
+                                        <!-- Status / pin pill. MultiBinding so it refreshes when Validate-all updates Status. -->
                                         <Border Grid.Column="2" Margin="10,0" Padding="8,2" CornerRadius="9"
                                                 Background="{StaticResource InputBrush}" VerticalAlignment="Center">
-                                            <TextBlock Text="{Binding Converter={StaticResource PillText}}"
-                                                       FontSize="11"
-                                                       Foreground="{Binding Converter={StaticResource PillBrush}}" />
+                                            <TextBlock FontSize="11">
+                                                <TextBlock.Text>
+                                                    <MultiBinding Converter="{StaticResource PillText}">
+                                                        <Binding Path="IsPinned" />
+                                                        <Binding Path="Status" />
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                                <TextBlock.Foreground>
+                                                    <MultiBinding Converter="{StaticResource PillBrush}">
+                                                        <Binding Path="IsPinned" />
+                                                        <Binding Path="Status" />
+                                                    </MultiBinding>
+                                                </TextBlock.Foreground>
+                                            </TextBlock>
                                         </Border>
 
                                         <!-- Friendly creation time, right-aligned and muted. -->

--- a/Savedrake.App/MainWindow.xaml.cs
+++ b/Savedrake.App/MainWindow.xaml.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Interop;
+using Savedrake.App.ViewModels;
 
 namespace Savedrake.App
 {
@@ -70,6 +73,34 @@ namespace Savedrake.App
                 try { Savedrake.Log.Error("DWM theming failed (non-fatal).", ex); }
                 catch { }
             }
+        }
+
+        // Backup-list keyboard shortcuts: Delete -> recycle selected, F2 -> rename, Ctrl+A -> select all.
+        private void BackupList_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (!(DataContext is MainViewModel vm)) return;
+            if (e.Key == Key.Delete)
+            {
+                vm.DeleteCommand.Execute(BackupList.SelectedItems);
+                e.Handled = true;
+            }
+            else if (e.Key == Key.F2)
+            {
+                vm.RenameCommand.Execute(null);
+                e.Handled = true;
+            }
+            else if (e.Key == Key.A && (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control)
+            {
+                BackupList.SelectAll();
+                e.Handled = true;
+            }
+        }
+
+        // Double-click a row to open the backup zip. Guarded so a double-click on empty space is a no-op.
+        private void BackupList_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is MainViewModel vm && vm.SelectedBackup != null)
+                vm.OpenBackupCommand.Execute(vm.SelectedBackup);
         }
 
         private void MinimizeButton_Click(object sender, RoutedEventArgs e)

--- a/Savedrake.App/Savedrake.App.csproj
+++ b/Savedrake.App/Savedrake.App.csproj
@@ -30,6 +30,12 @@
     <Reference Include="System.Management" />
   </ItemGroup>
 
+  <!-- Microsoft.VisualBasic: FileIO.FileSystem.DeleteFile (send a deleted backup to the Recycle Bin, so deletes are
+       recoverable) and Interaction.InputBox (the rename prompt). Framework assembly on net48, named explicitly. -->
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualBasic" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Savedrake.Core\Savedrake.Core.csproj" />
   </ItemGroup>

--- a/Savedrake.App/Themes/Dark.xaml
+++ b/Savedrake.App/Themes/Dark.xaml
@@ -122,6 +122,78 @@
         </Setter>
     </Style>
 
+    <!-- Dark context/dropdown menus (the OS default renders light). Reused by the list right-click menu and the
+         File/Help header dropdowns. The MenuItem template covers flat items, submenu headers, and top-level headers. -->
+    <Style TargetType="ContextMenu">
+        <Setter Property="Background" Value="{StaticResource BarBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+        <Setter Property="Padding" Value="4" />
+        <Setter Property="HasDropShadow" Value="True" />
+    </Style>
+
+    <Style TargetType="Separator">
+        <Setter Property="Background" Value="{StaticResource RowSepBrush}" />
+        <Setter Property="Height" Value="1" />
+        <Setter Property="Margin" Value="8,4" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Separator">
+                    <Border Background="{TemplateBinding Background}" Height="1" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="MenuItem">
+        <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Height" Value="30" />
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="MenuItem">
+                    <Border x:Name="bd" Background="{TemplateBinding Background}" CornerRadius="5" Padding="10,0"
+                            SnapsToDevicePixels="True">
+                        <Grid VerticalAlignment="Center" MinWidth="120">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <ContentPresenter Grid.Column="0" ContentSource="Header" VerticalAlignment="Center"
+                                              RecognizesAccessKey="True" />
+                            <TextBlock Grid.Column="1" x:Name="arrow" Text="4" FontFamily="Marlett" FontSize="11"
+                                       Margin="14,0,0,0" VerticalAlignment="Center" Visibility="Collapsed"
+                                       Foreground="{StaticResource TextSecondaryBrush}" />
+                            <Popup x:Name="PART_Popup" Placement="Right" IsOpen="{TemplateBinding IsSubmenuOpen}"
+                                   AllowsTransparency="True" Focusable="False" PopupAnimation="Fade">
+                                <Border Background="{StaticResource BarBrush}" BorderBrush="{StaticResource BorderBrush}"
+                                        BorderThickness="1" CornerRadius="6" Padding="4">
+                                    <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
+                                </Border>
+                            </Popup>
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="Role" Value="SubmenuHeader">
+                            <Setter TargetName="arrow" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                        <Trigger Property="Role" Value="TopLevelHeader">
+                            <Setter TargetName="PART_Popup" Property="Placement" Value="Bottom" />
+                        </Trigger>
+                        <Trigger Property="IsHighlighted" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{StaticResource SelectionBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.4" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!-- Primary gold button: filled gold, dark text. -->
     <Style x:Key="PrimaryButton" TargetType="Button">
         <Setter Property="Foreground" Value="{StaticResource AccentTextBrush}" />

--- a/Savedrake.App/ViewModels/BackupRowConverters.cs
+++ b/Savedrake.App/ViewModels/BackupRowConverters.cs
@@ -28,40 +28,45 @@ namespace Savedrake.App.ViewModels
             => Binding.DoNothing;
     }
 
-    // A BackupRow -> the pill TEXT: "pinned" when pinned, otherwise the lower-cased status ("protected" / "legacy").
-    public sealed class RowToPillTextConverter : IValueConverter
+    // (IsPinned, Status) -> the pill TEXT: "pinned" when pinned, otherwise the lower-cased status ("protected",
+    // "legacy", "validated", "corrupt", "missing"). A MultiBinding so the pill refreshes when "Validate all" upgrades
+    // an observable Status in place.
+    public sealed class PinStatusToPillTextConverter : IMultiValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            var row = value as BackupRow;
-            if (row == null) return "";
-            if (row.IsPinned) return "pinned";
-            return (row.Status ?? "").ToLowerInvariant();
+            bool pinned = values.Length > 0 && values[0] is bool b && b;
+            if (pinned) return "pinned";
+            string status = values.Length > 1 ? values[1] as string : null;
+            return (status ?? "").ToLowerInvariant();
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-            => Binding.DoNothing;
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+            => null;
     }
 
-    // A BackupRow -> the pill FOREGROUND brush: gold when pinned, green ("Success") when Protected, muted
-    // (TextSecondary) for Legacy / anything else.
-    public sealed class RowToPillBrushConverter : IValueConverter
+    // (IsPinned, Status) -> the pill FOREGROUND brush: gold when pinned; green for a healthy backup
+    // (Protected / Validated); red for a broken one (Corrupt / Missing); muted for Legacy or anything else.
+    public sealed class PinStatusToPillBrushConverter : IMultiValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            var row = value as BackupRow;
-            string key = "TextSecondaryBrush";
-            if (row != null)
-            {
-                if (row.IsPinned) key = "AccentGoldBrush";
-                else if (string.Equals(row.Status, "Protected", StringComparison.OrdinalIgnoreCase)) key = "SuccessBrush";
-                else key = "TextSecondaryBrush";
-            }
+            bool pinned = values.Length > 0 && values[0] is bool b && b;
+            string status = values.Length > 1 ? values[1] as string : null;
+
+            string key;
+            if (pinned) key = "AccentGoldBrush";
+            else if (Eq(status, "Protected") || Eq(status, "Validated")) key = "SuccessBrush";
+            else if (Eq(status, "Corrupt") || Eq(status, "Missing")) key = "DangerBrush";
+            else key = "TextSecondaryBrush";
+
             object res = System.Windows.Application.Current?.TryFindResource(key);
             return res ?? Binding.DoNothing;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-            => Binding.DoNothing;
+        private static bool Eq(string a, string b) => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+            => null;
     }
 }

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
@@ -10,15 +11,18 @@ using CommunityToolkit.Mvvm.Input;
 namespace Savedrake.App.ViewModels
 {
     // One row in the Backups list. Mirrors the WinForms LoadBackupHistory columns (file name, friendly time,
-    // integrity status) plus the pin state, with the full path kept for Restore/Delete. Plain DTO — the list is
-    // rebuilt wholesale by RefreshBackups, so no per-row change notification is needed.
-    public sealed class BackupRow
+    // integrity status) plus the pin state, with the full path kept for Restore/Delete. Status is observable so
+    // "Validate all" can upgrade each row's integrity in place (Protected/Legacy -> Validated/Legacy/Corrupt/Missing)
+    // without rebuilding the list; the other fields are set once at creation (rename/pin rebuild the list).
+    public partial class BackupRow : ObservableObject
     {
         public string FileName { get; set; }
         public string FriendlyTime { get; set; }
-        public string Status { get; set; }   // "Protected" (has manifest) or "Legacy"
         public bool IsPinned { get; set; }
         public string FullPath { get; set; }
+
+        [ObservableProperty]
+        private string status;   // "Protected"/"Legacy" at load; "Validated"/"Corrupt"/"Missing" after Validate all
     }
 
     // The main workflow view model. Drives the Folders + Autobackup + Backups cards and routes the Backup / Restore /
@@ -78,7 +82,11 @@ namespace Savedrake.App.ViewModels
         public ObservableCollection<BackupRow> Backups { get; } = new ObservableCollection<BackupRow>();
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PinMenuLabel))]
         private BackupRow selectedBackup;
+
+        // Dynamic context-menu label: "Unpin" when the selected backup is pinned, otherwise "Pin".
+        public string PinMenuLabel => (SelectedBackup != null && SelectedBackup.IsPinned) ? "Unpin" : "Pin";
 
         [ObservableProperty]
         private string statusText = "Ready.";
@@ -544,38 +552,142 @@ namespace Savedrake.App.ViewModels
             RefreshBackups();
         }
 
+        // Send the selected backup(s) to the Recycle Bin (recoverable), supporting multi-select. The selection is
+        // passed from the ListView so the toolbar button, the context menu, and the Delete key all act on the same set.
         [RelayCommand]
-        private void Delete()
+        private void Delete(System.Collections.IList selected)
         {
-            if (SelectedBackup == null)
-            {
-                _dialog.Warn("Delete", "Please select a backup to delete first.");
-                return;
-            }
+            // Snapshot the selection now (the live SelectedItems collection mutates as the list rebuilds below).
+            List<BackupRow> rows = (selected != null ? selected.Cast<BackupRow>()
+                                    : (SelectedBackup != null ? new[] { SelectedBackup } : Enumerable.Empty<BackupRow>()))
+                                   .Where(r => r != null).ToList();
+            if (rows.Count == 0) { _dialog.Warn("Delete", "Please select one or more backups to delete first."); return; }
             if (_isOperationInProgress) { _status.Set("Please wait, another operation is already running."); return; }
 
-            BackupRow row = SelectedBackup;
-
             // Hold the operation lock across the whole delete, including the confirm dialog. The modal pumps the
-            // Dispatcher queue, so without the lock a queued autobackup tick could fire and rebuild the list (nulling
-            // SelectedBackup) mid-delete.
+            // Dispatcher queue, so without the lock a queued autobackup tick could rebuild the list mid-delete.
             _isOperationInProgress = true;
             try
             {
-                if (!_dialog.Confirm("Delete Backup", "Delete this backup permanently?\n\n" + row.FileName))
+                string plural = rows.Count > 1 ? "s" : "";
+                if (!_dialog.Confirm("Delete Backup" + plural,
+                        "Send the selected backup" + plural + " to the Recycle Bin?\n\n" +
+                        string.Join("\n", rows.Select(r => r.FileName))))
                     return;
-                try
+
+                int deleted = 0;
+                foreach (BackupRow row in rows)
                 {
-                    File.Delete(row.FullPath);
-                    _status.Set("Backup deleted.");
+                    try
+                    {
+                        Microsoft.VisualBasic.FileIO.FileSystem.DeleteFile(row.FullPath,
+                            Microsoft.VisualBasic.FileIO.UIOption.OnlyErrorDialogs,
+                            Microsoft.VisualBasic.FileIO.RecycleOption.SendToRecycleBin);
+                        deleted++;
+                    }
+                    catch (Exception ex)
+                    {
+                        _dialog.Error("Delete Failed", "Could not delete " + row.FileName + ": " + ex.Message);
+                    }
                 }
-                catch (Exception ex)
-                {
-                    _dialog.Error("Delete Failed", "Could not delete the backup: " + ex.Message);
-                }
+                _status.Set(deleted == 1 ? "Backup sent to the Recycle Bin." : (deleted + " backups sent to the Recycle Bin."));
             }
             finally { _isOperationInProgress = false; }
             RefreshBackups();
+        }
+
+        // Rename the selected backup on disk (keeps the .zip extension; renaming a pinned backup drops the pin, matching
+        // the shipped app). Single-select only.
+        [RelayCommand]
+        private void Rename()
+        {
+            BackupRow row = SelectedBackup;
+            if (row == null) { _dialog.Warn("Rename", "Please select one backup to rename first."); return; }
+            if (_isOperationInProgress) { _status.Set("Please wait, another operation is already running."); return; }
+
+            string ext = Path.GetExtension(row.FileName);
+            string input = Microsoft.VisualBasic.Interaction.InputBox(
+                "Enter a new name for this backup:", "Rename Backup", Path.GetFileNameWithoutExtension(row.FileName));
+            if (string.IsNullOrWhiteSpace(input)) return; // cancelled / empty
+
+            string newName = Path.GetFileNameWithoutExtension(input.Trim()) + ext;
+            if (string.Equals(newName, row.FileName, StringComparison.Ordinal)) return;
+
+            _isOperationInProgress = true;
+            try
+            {
+                string target = BackupNaming.MakeUniquePath(Path.Combine(Path.GetDirectoryName(row.FullPath), newName));
+                File.Move(row.FullPath, target);
+                _status.Set("Backup renamed.");
+            }
+            catch (Exception ex) { _dialog.Error("Rename Failed", "Could not rename the backup: " + ex.Message); }
+            finally { _isOperationInProgress = false; }
+            RefreshBackups();
+        }
+
+        // Toggle the selected backup's pinned state (a " [PINNED]" filename token). Pinned backups are protected from
+        // automatic cleanup and excluded from the autobackup limit. Single-select only.
+        [RelayCommand]
+        private void Pin()
+        {
+            BackupRow row = SelectedBackup;
+            if (row == null) { _dialog.Warn("Pin backup", "Select one backup to pin or unpin."); return; }
+            if (_isOperationInProgress) { _status.Set("Please wait, another operation is already running."); return; }
+
+            _isOperationInProgress = true;
+            try
+            {
+                if (!File.Exists(row.FullPath)) return;
+                bool pinned = Pinning.IsPinnedBackup(Path.GetFileName(row.FullPath));
+                string target = pinned ? Pinning.UnpinnedPath(row.FullPath) : Pinning.PinnedPath(row.FullPath);
+                if (!string.Equals(target, row.FullPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    target = BackupNaming.MakeUniquePath(target); // never clobber an existing backup
+                    File.Move(row.FullPath, target);
+                }
+                _status.Set(pinned ? "Backup unpinned." : "Backup pinned. It won't be removed by automatic cleanup.");
+            }
+            catch (Exception ex) { _dialog.Error("Pin backup", "Could not change the pinned state: " + ex.Message); }
+            finally { _isOperationInProgress = false; }
+            RefreshBackups();
+        }
+
+        // Full integrity check of every backup: each row's Status is upgraded in place to Validated / Legacy / Corrupt
+        // / Missing (the pill recolours live), with a tally and a warning if any failed.
+        [RelayCommand]
+        private void ValidateAll()
+        {
+            if (Backups.Count == 0) { _dialog.Info("Validate Backups", "There are no backups to validate."); return; }
+
+            _status.Set("Validating backups...");
+            int validated = 0, legacy = 0, failed = 0;
+            System.Windows.Input.Mouse.OverrideCursor = System.Windows.Input.Cursors.Wait;
+            try
+            {
+                foreach (BackupRow row in Backups)
+                {
+                    string state = File.Exists(row.FullPath) ? Manifest.ClassifyBackupFully(row.FullPath) : "Missing";
+                    row.Status = state;
+                    if (state == "Validated") validated++;
+                    else if (state == "Legacy") legacy++;
+                    else failed++;
+                }
+            }
+            finally { System.Windows.Input.Mouse.OverrideCursor = null; }
+
+            _status.Set("Validated " + Backups.Count + " backups: " + validated + " OK, " + legacy + " legacy, " + failed + " failed.");
+            if (failed > 0)
+                _dialog.Warn("Validation", failed + " backup(s) failed validation and may not be restorable.");
+        }
+
+        // Open the backup zip in the default handler (double-click on a row).
+        [RelayCommand]
+        private void OpenBackup(BackupRow row)
+        {
+            row = row ?? SelectedBackup;
+            if (row == null || string.IsNullOrEmpty(row.FullPath)) return;
+            try { System.Diagnostics.Process.Start(row.FullPath); }
+            catch (Exception ex) { _dialog.Error("Open Backup", "Could not open the backup: " + ex.Message); }
         }
 
         public void Dispose() => _autobackup?.Dispose();


### PR DESCRIPTION
## Phase 6c — backup-list management parity

Brings the WPF backup list to parity with the shipped WinForms right-click menu + keyboard shortcuts, all driven by the existing harness-proven Core helpers.

- **Recycle-Bin delete + multi-select** — `Delete` now sends backups to the Recycle Bin (recoverable) instead of a permanent `File.Delete`, and acts on the full selection (the ListView's `SelectedItems` flows to the toolbar button, the context menu, and the Delete key). The confirm lists every name.
- **Rename** (context menu / F2) — `File.Move` keeping the `.zip` extension, `BackupNaming.MakeUniquePath` on a clash. Renaming a pinned backup drops the pin (matches the shipped app).
- **Pin / Unpin** (context menu, dynamic label, single-select) — `Pinning.PinnedPath`/`UnpinnedPath` + `MakeUniquePath`.
- **Validate all** (context menu) — `Manifest.ClassifyBackupFully` per row, upgrading each to **Validated / Legacy / Corrupt / Missing**. `BackupRow.Status` is now observable and the pill recolours live via a `MultiBinding` (green = healthy, red = Corrupt/Missing, gold = pinned, muted = legacy).
- **Double-click** opens the zip; `SelectionMode=Extended`; **Del / F2 / Ctrl+A** shortcuts.
- **Dark `ContextMenu` / `MenuItem` / `Separator` theme styles** (the OS default renders light); the `MenuItem` template also supports submenus, ready for the File/Help header dropdowns next.

> The in-app **undo-delete** (Shell32 restore from the Recycle Bin) is deferred to a focused follow-up — recycle-bin delete already makes deletes OS-recoverable.

### Verification
- **WinForms + Core untouched.** Release + Debug build clean. Harness **247/0** (no Core change).
- Sandboxed launch (throwaway folders + copied backups, never the real saves): the list rendered with the live `MultiBinding` pills and the app ran healthy (process responding, no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)