### PR TITLE
WPF Phase 6d: File/Help menus + undo-restore + detect-save-folder + folder advisory

### DIFF
--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -614,6 +614,22 @@ namespace RestoreHarness
             Check("finds both DD2 Steam profiles", F(root).Count == 2);
 
             Check("missing steam root -> empty (no throw)", F(Path.Combine(work, "no_steam_" + Guid.NewGuid().ToString("N").Substring(0, 6))).Count == 0);
+
+            // Phase 6d: GetSteamRoot + the no-arg FindDd2SaveFolders (registry/filesystem). They must never throw and
+            // must return sane shapes regardless of whether Steam/DD2 are present on the build box.
+            var getRoot = CM("SaveScan", "GetSteamRoot");
+            var findAll = CM("SaveScan", "FindDd2SaveFolders");
+            bool threw = false; string sroot = null; System.Collections.Generic.List<string> all = null;
+            try
+            {
+                sroot = (string)getRoot.Invoke(null, null);
+                all = ((System.Collections.IEnumerable)findAll.Invoke(null, null)).Cast<string>().ToList();
+            }
+            catch { threw = true; }
+            Check("GetSteamRoot + FindDd2SaveFolders do not throw", !threw);
+            Check("GetSteamRoot is null or an existing directory", sroot == null || Directory.Exists(sroot), "root=" + sroot);
+            Check("FindDd2SaveFolders returns a non-null list", all != null);
+            Check("every detected save folder exists", all == null || all.All(Directory.Exists));
             Console.WriteLine();
         }
 

--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -72,8 +72,38 @@
                 <!-- Right-side controls: clickable (opt out of caption drag). -->
                 <StackPanel Grid.Column="3" Orientation="Horizontal" VerticalAlignment="Center"
                             shell:WindowChrome.IsHitTestVisibleInChrome="True">
-                    <Button Content="File" Style="{StaticResource HeaderMenuButton}" />
-                    <Button Content="Help" Style="{StaticResource HeaderMenuButton}" Margin="2,0,8,0" />
+                    <Button Content="File" Style="{StaticResource HeaderMenuButton}" Click="HeaderMenu_Click">
+                        <Button.ContextMenu>
+                            <ContextMenu>
+                                <MenuItem Header="Detect save folder"
+                                          Command="{Binding PlacementTarget.DataContext.DetectSaveFolderCommand,
+                                                    RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                <MenuItem Header="Undo last restore"
+                                          Command="{Binding PlacementTarget.DataContext.UndoLastRestoreCommand,
+                                                    RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                <Separator />
+                                <MenuItem Header="Exit"
+                                          Command="{Binding PlacementTarget.DataContext.ExitCommand,
+                                                    RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                            </ContextMenu>
+                        </Button.ContextMenu>
+                    </Button>
+                    <Button Content="Help" Style="{StaticResource HeaderMenuButton}" Margin="2,0,8,0" Click="HeaderMenu_Click">
+                        <Button.ContextMenu>
+                            <ContextMenu>
+                                <MenuItem Header="FAQ"
+                                          Command="{Binding PlacementTarget.DataContext.OpenFaqCommand,
+                                                    RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                <MenuItem Header="About"
+                                          Command="{Binding PlacementTarget.DataContext.OpenAboutCommand,
+                                                    RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                <Separator />
+                                <MenuItem Header="Open log folder"
+                                          Command="{Binding PlacementTarget.DataContext.OpenLogFolderCommand,
+                                                    RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                            </ContextMenu>
+                        </Button.ContextMenu>
+                    </Button>
                     <Button x:Name="MinimizeButton" Content="&#x2014;" Style="{StaticResource CaptionButton}"
                             ToolTip="Minimize" Click="MinimizeButton_Click" />
                     <Button x:Name="CloseButton" Content="&#x2715;" Style="{StaticResource CaptionCloseButton}"

--- a/Savedrake.App/MainWindow.xaml.cs
+++ b/Savedrake.App/MainWindow.xaml.cs
@@ -103,6 +103,17 @@ namespace Savedrake.App
                 vm.OpenBackupCommand.Execute(vm.SelectedBackup);
         }
 
+        // Open a header button's dropdown (File / Help) as a menu anchored under the button.
+        private void HeaderMenu_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button b && b.ContextMenu != null)
+            {
+                b.ContextMenu.PlacementTarget = b;
+                b.ContextMenu.Placement = System.Windows.Controls.Primitives.PlacementMode.Bottom;
+                b.ContextMenu.IsOpen = true;
+            }
+        }
+
         private void MinimizeButton_Click(object sender, RoutedEventArgs e)
         {
             WindowState = WindowState.Minimized;

--- a/Savedrake.App/Themes/Dark.xaml
+++ b/Savedrake.App/Themes/Dark.xaml
@@ -129,8 +129,20 @@
         <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
-        <Setter Property="Padding" Value="4" />
         <Setter Property="HasDropShadow" Value="True" />
+        <!-- Replace the default template so the light icon-gutter strip on the left is gone (a plain border + items
+             host). The default ContextMenu template paints that gutter regardless of Background. -->
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ContextMenu">
+                    <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="6" Padding="4"
+                            SnapsToDevicePixels="True">
+                        <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style TargetType="Separator">

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -467,6 +467,11 @@ namespace Savedrake.App.ViewModels
         {
             string picked = PickFolder(SaveDir);
             if (picked == null) return;
+            if (!string.IsNullOrWhiteSpace(BackupDir) && string.Equals(picked, BackupDir, StringComparison.OrdinalIgnoreCase))
+            {
+                _dialog.Error("Save location", "Your save folder can't be the same as your backup folder.");
+                return;
+            }
             SaveDir = picked;
             SaveSettings();
             RefreshBackups();
@@ -477,6 +482,18 @@ namespace Savedrake.App.ViewModels
         {
             string picked = PickFolder(BackupDir);
             if (picked == null) return;
+            // Validate against the save folder + surface the cloud / same-drive / inside-save advisory (Core).
+            if (!string.IsNullOrWhiteSpace(SaveDir))
+            {
+                if (string.Equals(picked, SaveDir, StringComparison.OrdinalIgnoreCase))
+                {
+                    _dialog.Error("Backup location", "The backup folder can't be the same as your save folder.");
+                    return;
+                }
+                string warning = SaveScan.BackupLocationWarning(SaveDir, picked);
+                if (warning != null && !_dialog.Confirm("Backup location", warning + "\n\nUse this folder anyway?"))
+                    return;
+            }
             BackupDir = picked;
             SaveSettings();
             RefreshBackups();
@@ -520,6 +537,14 @@ namespace Savedrake.App.ViewModels
                 _dialog.Warn("Restore", "Please select a backup to restore first.");
                 return;
             }
+            DoRestore(SelectedBackup.FullPath);
+        }
+
+        // The shared restore path (used by Restore and Undo-last-restore): runs the full transactional restore against
+        // a specific backup zip, holding the operation lock + suppressing the save watcher, and advances the
+        // change-aware baseline on success.
+        private void DoRestore(string backupZipPath)
+        {
             if (_isOperationInProgress) { _status.Set("Please wait, another operation is already running."); return; }
 
             RestoreResult result = null;
@@ -530,7 +555,7 @@ namespace Savedrake.App.ViewModels
                 result = RestoreService.Restore(
                     new RestoreRequest
                     {
-                        BackupZipPath = SelectedBackup.FullPath,
+                        BackupZipPath = backupZipPath,
                         LiveSaveDir = SaveDir,
                         BackupDir = BackupDir,
                         GameRunning = GameDetect.IsDd2Running()
@@ -551,6 +576,101 @@ namespace Savedrake.App.ViewModels
             if (result != null && result.Ok) _autobackup.NotifyExternalRestore();
             RefreshBackups();
         }
+
+        // ----- File / Help menu commands -----
+
+        // Roll the live save back to the automatic snapshot taken just before the last restore. Re-runs the full
+        // restore flow against that checkpoint (so the undo is itself snapshotted, and the Steam-Cloud guidance shows).
+        [RelayCommand]
+        private void UndoLastRestore()
+        {
+            if (string.IsNullOrWhiteSpace(BackupDir) || !Directory.Exists(BackupDir))
+            {
+                _dialog.Info("Undo last restore", "Please set your backup folder first.");
+                return;
+            }
+            string checkpoint = SaveScan.FindLatestPreRestoreCheckpoint(BackupDir);
+            if (checkpoint == null)
+            {
+                _dialog.Info("Nothing to undo",
+                    "There is no snapshot to undo. Savedrake automatically saves a snapshot of your current save each " +
+                    "time you restore a backup, so an undo only becomes available after a restore.");
+                return;
+            }
+            string when = Path.GetFileNameWithoutExtension(checkpoint).Replace("(Pre-Restore)", "").Trim();
+            if (!_dialog.Confirm("Undo last restore",
+                    "This rolls your save back to the snapshot Savedrake took just before your last restore" +
+                    (when.Length > 0 ? " (" + when + ")" : "") + ".\n\n" +
+                    "Your current save is snapshotted first, so you can redo.\n\nUndo the last restore?"))
+                return;
+            DoRestore(checkpoint);
+        }
+
+        // Auto-find the DD2 save folder via Steam and offer to set it. Only changes the folder on a Yes.
+        [RelayCommand]
+        private void DetectSaveFolder()
+        {
+            if (!ConfigEditable)
+            {
+                _dialog.Info("Detect save folder", "Turn off autobackup before changing the save folder.");
+                return;
+            }
+            List<string> found;
+            try { found = SaveScan.FindDd2SaveFolders(); } catch { found = new List<string>(); }
+            if (found.Count == 0)
+            {
+                _dialog.Info("Detect save folder",
+                    "Savedrake could not find a Dragon's Dogma 2 save folder automatically. Make sure Steam is installed " +
+                    "and you have run the game at least once, or set the folder with Browse.");
+                return;
+            }
+            string best = found[0];
+            string extra = found.Count > 1
+                ? "\n\n(" + (found.Count - 1) + " other Steam profile" + (found.Count > 2 ? "s were" : " was") +
+                  " also found; this is the most recently used.)"
+                : "";
+            if (_dialog.Confirm("Detect save folder", "Found your Dragon's Dogma 2 saves here:\n\n" + best + extra + "\n\nUse this folder?"))
+            {
+                SaveDir = best;
+                SaveSettings();
+                RefreshBackups();
+                _status.Set("Save game folder set automatically.");
+            }
+        }
+
+        [RelayCommand]
+        private void OpenFaq()
+        {
+            if (_dialog.Confirm("Open FAQ", "This will open the FAQ page on Nexusmods in your browser. Continue?"))
+                OpenUrl("https://www.nexusmods.com/dragonsdogma2/mods/772/?tab=posts");
+        }
+
+        [RelayCommand]
+        private void OpenAbout()
+        {
+            if (_dialog.Confirm("Open About", "This will open Savedrake's Nexusmods page in your browser. Continue?"))
+                OpenUrl("https://www.nexusmods.com/dragonsdogma2/mods/772?tab=description");
+        }
+
+        private void OpenUrl(string url)
+        {
+            try { System.Diagnostics.Process.Start(url); }
+            catch (Exception ex) { _dialog.Error("Open Link", "Could not open the link: " + ex.Message); }
+        }
+
+        [RelayCommand]
+        private void OpenLogFolder()
+        {
+            try
+            {
+                Directory.CreateDirectory(Log.Directory());
+                System.Diagnostics.Process.Start("explorer.exe", Log.Directory());
+            }
+            catch (Exception ex) { _dialog.Error("Open log folder", "Could not open the log folder: " + ex.Message); }
+        }
+
+        [RelayCommand]
+        private void Exit() => System.Windows.Application.Current?.Shutdown();
 
         // Send the selected backup(s) to the Recycle Bin (recoverable), supporting multi-select. The selection is
         // passed from the ListView so the toolbar button, the context menu, and the Delete key all act on the same set.

--- a/Savedrake.Core/SaveScan.cs
+++ b/Savedrake.Core/SaveScan.cs
@@ -35,6 +35,37 @@ namespace Savedrake
 
         private static DateTime DirLastWriteUtc(string d) { try { return Directory.GetLastWriteTimeUtc(d); } catch { return DateTime.MinValue; } }
 
+        // The Steam install root: HKCU\Software\Valve\Steam\SteamPath, falling back to %ProgramFiles(x86)%\Steam.
+        // Returns null if neither exists. Never throws. Moved from the WinForms app during the WPF migration so the
+        // "detect save folder" feature works the same in both shells.
+        public static string GetSteamRoot()
+        {
+            try
+            {
+                using (var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(@"Software\Valve\Steam"))
+                {
+                    string p = key?.GetValue("SteamPath") as string;
+                    if (!string.IsNullOrEmpty(p)) { p = p.Replace('/', '\\'); if (Directory.Exists(p)) return p; }
+                }
+            }
+            catch { }
+            try
+            {
+                string def = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam");
+                if (Directory.Exists(def)) return def;
+            }
+            catch { }
+            return null;
+        }
+
+        // All existing DD2 save folders on this machine (most-recently-used first), discovered under the detected
+        // Steam root. Empty list when Steam / the saves aren't found. Never throws.
+        public static List<string> FindDd2SaveFolders()
+        {
+            string root = GetSteamRoot();
+            return root != null ? FindDd2SaveFoldersUnder(root) : new List<string>();
+        }
+
         // QoL: a one-line caution about a chosen backup folder, or null if it's fine. Advisory, not blocking. Flags a
         // backup folder inside the save folder, in a cloud-synced folder (OneDrive/Dropbox/Google Drive — sync churn),
         // or on the same drive as the saves (one disk failure loses both). Pure/static so the harness can test it.


### PR DESCRIPTION
## Phase 6d — header menus + restore/detect/folder safety

### Core (`SaveScan`)
- **`GetSteamRoot()`** + **`FindDd2SaveFolders()`** extracted from the WinForms app (registry `SteamPath` → `%ProgramFiles(x86)%\Steam` fallback; most-recently-used DD2 save first). Additive — the WinForms copies are untouched.

### WPF
- **File and Help header buttons** open dark dropdown menus on click (`HeaderMenu_Click` anchors a themed `ContextMenu` under the button; bindings via `PlacementTarget.DataContext` — the reliable pattern, not DataContext inheritance).
- **File** → *Detect save folder* (offer the most-recent DD2 save, set on Yes), *Undo last restore* (`FindLatestPreRestoreCheckpoint` → re-run the full restore flow against that checkpoint via a shared `DoRestore`), *Exit*.
- **Help** → *FAQ* + *About* (open the Nexus pages after a confirm), *Open log folder*.
- **`BrowseSave` / `BrowseBackup`** validate (backup ≠ save) and surface the Core `BackupLocationWarning` advisory (inside-save / cloud-synced / same-drive) with a proceed-anyway confirm.

### Theme fix (also fixes the 6c list context menu)
The dark `ContextMenu` now uses a full ControlTemplate (border + items host) so WPF's default **light icon-gutter strip** on the left is gone — caught by a runtime check of the open menu.

### Verification
- **WinForms untouched.** Release + Debug build clean. Harness **247 → 251** (`GetSteamRoot` / `FindDd2SaveFolders` smoke tests).
- **Runtime check:** the File menu was invoked via UI Automation and screenshotted — it opens, renders dark with **no gutter**, and shows Detect / Undo / Exit with the separator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)