### PR TITLE
WPF Phase 6f: global backup hotkey + recording dialog

### DIFF
--- a/Savedrake.App/HotkeyDialog.xaml
+++ b/Savedrake.App/HotkeyDialog.xaml
@@ -1,0 +1,29 @@
+<Window x:Class="Savedrake.App.HotkeyDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Set Backup Hotkey"
+        WindowStyle="None" AllowsTransparency="True" Background="Transparent"
+        SizeToContent="WidthAndHeight" ResizeMode="NoResize"
+        WindowStartupLocation="CenterOwner" ShowInTaskbar="False">
+    <Border Background="{StaticResource ShellBrush}" BorderBrush="{StaticResource AccentGoldBrush}"
+            BorderThickness="1" CornerRadius="12" Padding="24" Width="430">
+        <StackPanel>
+            <TextBlock Text="Set Backup Hotkey" FontSize="18" FontWeight="SemiBold"
+                       Foreground="{StaticResource AccentGoldBrush}" Margin="0,0,0,8" />
+            <TextBlock Text="Hold Ctrl, Shift, or Alt and press a key. Press Enter to save, Esc to cancel."
+                       Foreground="{StaticResource TextSecondaryBrush}" FontSize="13" TextWrapping="Wrap"
+                       Margin="0,0,0,16" />
+            <Border Background="{StaticResource InputBrush}" BorderBrush="{StaticResource BorderBrush}"
+                    BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,18">
+                <TextBlock x:Name="ComboReadout" Text="Press your keys…" FontSize="18" FontWeight="SemiBold"
+                           Foreground="{StaticResource AccentGoldBrush}" HorizontalAlignment="Center" />
+            </Border>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="Clear hotkey" Style="{StaticResource DangerButton}" Padding="12,6" Click="Clear_Click" />
+                <Button Content="Cancel" Style="{StaticResource OutlineButton}" Padding="12,6" Margin="8,0,0,0" Click="Cancel_Click" />
+                <Button x:Name="SaveBtn" Content="Save" Style="{StaticResource PrimaryButton}" Padding="14,6"
+                        Margin="8,0,0,0" Click="Save_Click" IsEnabled="False" />
+            </StackPanel>
+        </StackPanel>
+    </Border>
+</Window>

--- a/Savedrake.App/HotkeyDialog.xaml.cs
+++ b/Savedrake.App/HotkeyDialog.xaml.cs
@@ -1,0 +1,76 @@
+using System.Text;
+using System.Windows;
+using System.Windows.Input;
+
+namespace Savedrake.App
+{
+    public enum HotkeyDialogResult { Cancel, Save, Clear }
+
+    // A small themed modal that records a global-backup hotkey. Recording is done with WPF's own PreviewKeyDown while
+    // the dialog has focus — no global low-level keyboard hook is needed (that is only the WinForms way); the global
+    // REGISTRATION (so the hotkey fires when Savedrake is in the background) is done by the owner window via
+    // RegisterHotKey. Enter saves, Esc cancels; a modifier (Ctrl/Shift/Alt) is required before Save enables.
+    public partial class HotkeyDialog : Window
+    {
+        public bool Ctrl, Shift, Alt;
+        public int Vk;
+        public string Display;
+        public HotkeyDialogResult Outcome = HotkeyDialogResult.Cancel;
+
+        public HotkeyDialog(bool ctrl, bool shift, bool alt, int vk, string display)
+        {
+            InitializeComponent();
+            Ctrl = ctrl; Shift = shift; Alt = alt; Vk = vk; Display = display;
+            if (vk != 0 && !string.IsNullOrEmpty(display))
+            {
+                ComboReadout.Text = display;
+                SaveBtn.IsEnabled = (ctrl || shift || alt);
+            }
+            PreviewKeyDown += OnPreviewKeyDown;
+        }
+
+        private void OnPreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Return) { if (SaveBtn.IsEnabled) Commit(); e.Handled = true; return; }
+            if (e.Key == Key.Escape) { Outcome = HotkeyDialogResult.Cancel; Close(); e.Handled = true; return; }
+
+            // Alt-combinations arrive as Key.System with the real key in SystemKey.
+            Key key = e.Key == Key.System ? e.SystemKey : e.Key;
+
+            // Ignore a bare modifier press — wait for the actual key.
+            if (key == Key.LeftCtrl || key == Key.RightCtrl || key == Key.LeftShift || key == Key.RightShift ||
+                key == Key.LeftAlt || key == Key.RightAlt || key == Key.LWin || key == Key.RWin)
+            {
+                e.Handled = true; return;
+            }
+
+            int vk = KeyInterop.VirtualKeyFromKey(key);
+            if (vk == 0) { e.Handled = true; return; }
+
+            Ctrl = (Keyboard.Modifiers & ModifierKeys.Control) != 0;
+            Shift = (Keyboard.Modifiers & ModifierKeys.Shift) != 0;
+            Alt = (Keyboard.Modifiers & ModifierKeys.Alt) != 0;
+            Vk = vk;
+            Display = Format(Ctrl, Shift, Alt, key);
+            ComboReadout.Text = Display;
+            // Require at least one modifier so a bare key can't hijack a gameplay key system-wide.
+            SaveBtn.IsEnabled = (Ctrl || Shift || Alt);
+            e.Handled = true;
+        }
+
+        public static string Format(bool ctrl, bool shift, bool alt, Key key)
+        {
+            var sb = new StringBuilder();
+            if (ctrl) sb.Append("Ctrl + ");
+            if (shift) sb.Append("Shift + ");
+            if (alt) sb.Append("Alt + ");
+            sb.Append(key.ToString());
+            return sb.ToString();
+        }
+
+        private void Commit() { Outcome = HotkeyDialogResult.Save; Close(); }
+        private void Save_Click(object sender, RoutedEventArgs e) => Commit();
+        private void Cancel_Click(object sender, RoutedEventArgs e) { Outcome = HotkeyDialogResult.Cancel; Close(); }
+        private void Clear_Click(object sender, RoutedEventArgs e) { Outcome = HotkeyDialogResult.Clear; Close(); }
+    }
+}

--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -83,6 +83,7 @@
                                           Command="{Binding PlacementTarget.DataContext.UndoLastRestoreCommand,
                                                     RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
                                 <Separator />
+                                <MenuItem Header="Set backup hotkey…" Click="SetHotkey_Click" />
                                 <MenuItem Header="Minimize to system tray" IsCheckable="True"
                                           IsChecked="{Binding PlacementTarget.DataContext.MinimizeToTray,
                                                       RelativeSource={RelativeSource AncestorType=ContextMenu}, Mode=TwoWay}" />

--- a/Savedrake.App/MainWindow.xaml.cs
+++ b/Savedrake.App/MainWindow.xaml.cs
@@ -27,6 +27,16 @@ namespace Savedrake.App
         [DllImport("dwmapi.dll", PreserveSig = true)]
         private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int attrValue, int attrSize);
 
+        // ----- global backup hotkey (RegisterHotKey against this window; WM_HOTKEY -> BackupCommand) -----
+        [DllImport("user32.dll")] private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+        [DllImport("user32.dll")] private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+
+        private const uint MOD_ALT = 0x0001, MOD_CONTROL = 0x0002, MOD_SHIFT = 0x0004;
+        private const int WM_HOTKEY = 0x0312;
+        private const int HotkeyId = 0xB001;
+        private HwndSource _hwndSource;
+        private bool _hotkeyRegistered;
+
         // The system-tray icon (WinForms NotifyIcon; UseWindowsForms is on). Only visible while minimized-to-tray.
         private System.Windows.Forms.NotifyIcon _tray;
 
@@ -41,6 +51,7 @@ namespace Savedrake.App
             {
                 InitTray();
                 (DataContext as Savedrake.App.ViewModels.MainViewModel)?.Activate();
+                RegisterCurrentHotkey();
             };
         }
 
@@ -48,6 +59,57 @@ namespace Savedrake.App
         {
             base.OnSourceInitialized(e);
             ApplyDwmTheming();
+            _hwndSource = HwndSource.FromHwnd(new WindowInteropHelper(this).Handle);
+            _hwndSource?.AddHook(WndProc);
+        }
+
+        // Receives WM_HOTKEY for the registered global backup hotkey and fires a manual backup.
+        private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            if (msg == WM_HOTKEY && wParam.ToInt32() == HotkeyId)
+            {
+                if (DataContext is Savedrake.App.ViewModels.MainViewModel vm)
+                    vm.BackupCommand.Execute(null);
+                handled = true;
+            }
+            return IntPtr.Zero;
+        }
+
+        // (Re)register the global hotkey from the view model's saved combo. Refuses a modifier-less combo.
+        private void RegisterCurrentHotkey()
+        {
+            UnregisterCurrentHotkey();
+            if (!(DataContext is Savedrake.App.ViewModels.MainViewModel vm) || !vm.HotkeyEnabled || vm.HotkeyVk == 0) return;
+            IntPtr h = new WindowInteropHelper(this).Handle;
+            if (h == IntPtr.Zero) return;
+            uint mods = (uint)((vm.HotkeyCtrl ? MOD_CONTROL : 0) | (vm.HotkeyShift ? MOD_SHIFT : 0) | (vm.HotkeyAlt ? MOD_ALT : 0));
+            if (mods == 0) return; // never grab a bare key system-wide
+            _hotkeyRegistered = RegisterHotKey(h, HotkeyId, mods, (uint)vm.HotkeyVk);
+        }
+
+        private void UnregisterCurrentHotkey()
+        {
+            if (!_hotkeyRegistered) return;
+            try { UnregisterHotKey(new WindowInteropHelper(this).Handle, HotkeyId); } catch { }
+            _hotkeyRegistered = false;
+        }
+
+        // File > Set backup hotkey: open the recording dialog, then persist + (re)register or clear.
+        private void SetHotkey_Click(object sender, RoutedEventArgs e)
+        {
+            if (!(DataContext is Savedrake.App.ViewModels.MainViewModel vm)) return;
+            var dlg = new HotkeyDialog(vm.HotkeyCtrl, vm.HotkeyShift, vm.HotkeyAlt, vm.HotkeyVk, vm.HotkeyDisplay) { Owner = this };
+            dlg.ShowDialog();
+            if (dlg.Outcome == HotkeyDialogResult.Save)
+            {
+                vm.SetHotkey(dlg.Ctrl, dlg.Shift, dlg.Alt, dlg.Vk, dlg.Display);
+                RegisterCurrentHotkey();
+            }
+            else if (dlg.Outcome == HotkeyDialogResult.Clear)
+            {
+                vm.ClearHotkey();
+                UnregisterCurrentHotkey();
+            }
         }
 
         // Build the tray icon + its Show/Quit menu. Hidden until the window is minimized with "minimize to tray" on.
@@ -96,6 +158,8 @@ namespace Savedrake.App
         // and file-system watcher are stopped and disposed rather than lingering past the window.
         protected override void OnClosed(EventArgs e)
         {
+            UnregisterCurrentHotkey();
+            try { _hwndSource?.RemoveHook(WndProc); } catch { }
             try { if (_tray != null) { _tray.Visible = false; _tray.Dispose(); _tray = null; } } catch { }
             (DataContext as IDisposable)?.Dispose();
             base.OnClosed(e);

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -213,6 +213,19 @@ namespace Savedrake.App.ViewModels
                 RecycleEnabled = CleanupEnabled && ParseBool(root.Element("RemovedToRecycleBin"));
                 BackupOnSaveEnabled = ParseBool(root.Element("BackupOnSaveChange"));
                 MinimizeToTray = ParseBool(root.Element("CheckboxTray"));
+
+                // Backup hotkey (nested <Hotkey> block + CheckboxHot), shared with the WinForms shape.
+                var hk = root.Element("Hotkey");
+                if (hk != null)
+                {
+                    HotkeyCtrl = ParseBool(hk.Element("ControlPressed"));
+                    HotkeyShift = ParseBool(hk.Element("ShiftPressed"));
+                    HotkeyAlt = ParseBool(hk.Element("AltPressed"));
+                    HotkeyVk = KeyNameToVk((string)hk.Element("MainKey"));
+                    HotkeyDisplay = BuildHotkeyDisplay();
+                }
+                HotkeyEnabled = ParseBool(root.Element("CheckboxHot")) && HotkeyVk != 0;
+
                 AutobackupEnabled = ParseBool(root.Element("CheckboxAuto"));
             }
             catch { /* best-effort: defaults stand */ }
@@ -254,6 +267,17 @@ namespace Savedrake.App.ViewModels
                 SetElement(root, "RemovedToRecycleBin", RecycleEnabled.ToString());
                 SetElement(root, "BackupOnSaveChange", BackupOnSaveEnabled.ToString());
                 SetElement(root, "CheckboxTray", MinimizeToTray.ToString());
+
+                // Backup hotkey (nested <Hotkey> block + CheckboxHot + the display string in Textbox3).
+                var hk = root.Element("Hotkey");
+                if (hk == null) { hk = new System.Xml.Linq.XElement("Hotkey"); root.Add(hk); }
+                SetElement(hk, "MainKey", VkToKeyName(HotkeyVk));
+                SetElement(hk, "ControlPressed", HotkeyCtrl.ToString());
+                SetElement(hk, "ShiftPressed", HotkeyShift.ToString());
+                SetElement(hk, "AltPressed", HotkeyAlt.ToString());
+                SetElement(root, "CheckboxHot", HotkeyEnabled.ToString());
+                SetElement(root, "Textbox3", HotkeyDisplay ?? "");
+
                 SetIntervalElements(root);
 
                 doc.Save(SettingsFilePath);
@@ -683,6 +707,49 @@ namespace Savedrake.App.ViewModels
 
         [RelayCommand]
         private void Exit() => System.Windows.Application.Current?.Shutdown();
+
+        // ----- backup hotkey (state lives here + persists; the window does the Win32 RegisterHotKey) -----
+
+        public bool HotkeyCtrl { get; private set; }
+        public bool HotkeyShift { get; private set; }
+        public bool HotkeyAlt { get; private set; }
+        public int HotkeyVk { get; private set; }
+        public bool HotkeyEnabled { get; private set; }
+        public string HotkeyDisplay { get; private set; }
+
+        public void SetHotkey(bool ctrl, bool shift, bool alt, int vk, string display)
+        {
+            HotkeyCtrl = ctrl; HotkeyShift = shift; HotkeyAlt = alt; HotkeyVk = vk;
+            HotkeyDisplay = display; HotkeyEnabled = true;
+            SaveSettings();
+            _status.Set("Backup hotkey set to " + display + ".");
+        }
+
+        public void ClearHotkey()
+        {
+            HotkeyCtrl = HotkeyShift = HotkeyAlt = false; HotkeyVk = 0;
+            HotkeyDisplay = ""; HotkeyEnabled = false;
+            SaveSettings();
+            _status.Set("Backup hotkey cleared.");
+        }
+
+        private static int KeyNameToVk(string name)
+            => !string.IsNullOrWhiteSpace(name) && System.Enum.TryParse(name, out System.Windows.Input.Key k)
+               ? System.Windows.Input.KeyInterop.VirtualKeyFromKey(k) : 0;
+
+        private static string VkToKeyName(int vk)
+            => vk != 0 ? System.Windows.Input.KeyInterop.KeyFromVirtualKey(vk).ToString() : "";
+
+        private string BuildHotkeyDisplay()
+        {
+            if (HotkeyVk == 0) return "";
+            var sb = new System.Text.StringBuilder();
+            if (HotkeyCtrl) sb.Append("Ctrl + ");
+            if (HotkeyShift) sb.Append("Shift + ");
+            if (HotkeyAlt) sb.Append("Alt + ");
+            sb.Append(VkToKeyName(HotkeyVk));
+            return sb.ToString();
+        }
 
         // Send the selected backup(s) to the Recycle Bin (recoverable), supporting multi-select. The selection is
         // passed from the ListView so the toolbar button, the context menu, and the Delete key all act on the same set.


### PR DESCRIPTION
## Phase 6f — global backup hotkey

Brings the global backup hotkey to the WPF app at parity with the shipped app.

- The window **registers the saved combo** with `RegisterHotKey` against its own HWND and handles `WM_HOTKEY` via an `HwndSource` hook → fires `BackupCommand`, so the hotkey works **even when Savedrake is in the background**. Unregistered on close. Modifier-less combos are refused (never grab a bare gameplay key system-wide).
- New **`HotkeyDialog`** (themed) records a combo with WPF `PreviewKeyDown` while it has focus — **no global low-level keyboard hook needed** (unlike the WinForms `WH_KEYBOARD_LL` approach): Enter saves, Esc cancels, a modifier is required, and a **Clear hotkey** button removes it.
- **File → "Set backup hotkey…"** opens the dialog; the view model persists the combo in the shared `<Hotkey>` block (`MainKey` as the key name, e.g. `Q`, round-tripping the WinForms format) + `CheckboxHot` + `Textbox3`, and the window (re)registers it. Key↔vk maps via `KeyInterop`, so `(int)Keys.X == VK_X` keeps the user's existing Ctrl+Alt+Q working.

### Verification
- **WinForms + Core untouched.** Release + Debug build clean. Harness **251/0**.
- **End-to-end runtime check** (throwaway folders, pre-seeded Ctrl+Alt+B): with the app in the **background**, synthesizing the global Ctrl+Alt+B created a real backup zip in the sandbox (0 → 1) — proving registration + `WM_HOTKEY` → `BackupCommand` the whole way through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)