### PR TITLE
WPF Phase 6g: settings — Reset, backup name format, window size

### DIFF
--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -83,11 +83,24 @@
                                           Command="{Binding PlacementTarget.DataContext.UndoLastRestoreCommand,
                                                     RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
                                 <Separator />
+                                <MenuItem Header="Backup name format">
+                                    <MenuItem Header="Randomly generated"
+                                              IsChecked="{Binding PlacementTarget.DataContext.UseRandomName,
+                                                          RelativeSource={RelativeSource AncestorType=ContextMenu}, Mode=OneWay}"
+                                              Command="{Binding PlacementTarget.DataContext.NameFormatRandomCommand,
+                                                        RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                    <MenuItem Header="Time stamped"
+                                              IsChecked="{Binding PlacementTarget.DataContext.UseTimestampName,
+                                                          RelativeSource={RelativeSource AncestorType=ContextMenu}, Mode=OneWay}"
+                                              Command="{Binding PlacementTarget.DataContext.NameFormatTimestampCommand,
+                                                        RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                </MenuItem>
                                 <MenuItem Header="Set backup hotkey…" Click="SetHotkey_Click" />
                                 <MenuItem Header="Minimize to system tray" IsCheckable="True"
                                           IsChecked="{Binding PlacementTarget.DataContext.MinimizeToTray,
                                                       RelativeSource={RelativeSource AncestorType=ContextMenu}, Mode=TwoWay}" />
                                 <Separator />
+                                <MenuItem Header="Reset Savedrake…" Click="Reset_Click" />
                                 <MenuItem Header="Exit"
                                           Command="{Binding PlacementTarget.DataContext.ExitCommand,
                                                     RelativeSource={RelativeSource AncestorType=ContextMenu}}" />

--- a/Savedrake.App/MainWindow.xaml.cs
+++ b/Savedrake.App/MainWindow.xaml.cs
@@ -49,8 +49,14 @@ namespace Savedrake.App
             // tray icon is created here too (after the window exists).
             Loaded += (s, e) =>
             {
+                var vm = DataContext as Savedrake.App.ViewModels.MainViewModel;
+                if (vm != null && vm.WindowWidth > 0 && vm.WindowHeight > 0)
+                {
+                    Width = vm.WindowWidth;
+                    Height = vm.WindowHeight;
+                }
                 InitTray();
-                (DataContext as Savedrake.App.ViewModels.MainViewModel)?.Activate();
+                vm?.Activate();
                 RegisterCurrentHotkey();
             };
         }
@@ -161,8 +167,34 @@ namespace Savedrake.App
             UnregisterCurrentHotkey();
             try { _hwndSource?.RemoveHook(WndProc); } catch { }
             try { if (_tray != null) { _tray.Visible = false; _tray.Dispose(); _tray = null; } } catch { }
+            // Persist the window size for next launch (RestoreBounds is the normal-state size even if minimized/maximized).
+            if (DataContext is Savedrake.App.ViewModels.MainViewModel vm)
+            {
+                try { var b = RestoreBounds; if (b.Width > 0 && b.Height > 0) vm.SaveWindowSize((int)b.Width, (int)b.Height); } catch { }
+            }
             (DataContext as IDisposable)?.Dispose();
             base.OnClosed(e);
+        }
+
+        // File > Reset Savedrake: delete the persisted state and close (Environment.Exit so nothing re-creates it).
+        private void Reset_Click(object sender, RoutedEventArgs e)
+        {
+            if (!(DataContext is Savedrake.App.ViewModels.MainViewModel vm)) return;
+            if (MessageBox.Show("This will reset all Savedrake settings to default and close the app. Continue?",
+                    "Reset Savedrake", MessageBoxButton.YesNo, MessageBoxImage.Question) != MessageBoxResult.Yes)
+                return;
+
+            if (!vm.ResetState())
+            {
+                MessageBox.Show("Some settings files could not be deleted (they may be in use). Close Savedrake and " +
+                    "delete them from %APPDATA%\\Savedrake manually, or try again.",
+                    "Reset Incomplete", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+            MessageBox.Show("Reset successful. Savedrake will now close.", "Reset Savedrake",
+                MessageBoxButton.OK, MessageBoxImage.Information);
+            try { if (_tray != null) { _tray.Visible = false; _tray.Dispose(); _tray = null; } } catch { }
+            Environment.Exit(0); // NOT Close() — that would run OnClosed -> SaveWindowSize and re-create the file
         }
 
         // Ask DWM to round corners, go dark, and tint the caption to our bar color. Each call is guarded:

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -75,6 +75,17 @@ namespace Savedrake.App.ViewModels
         [ObservableProperty]
         private bool minimizeToTray;
 
+        // Backup file-name format: randomly generated (default) vs time-stamped (persisted as BackupFileName1/2).
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(UseTimestampName))]
+        private bool useRandomName = true;
+
+        public bool UseTimestampName => !UseRandomName;
+
+        // Last window size, restored on next launch (persisted as WindowWidth/WindowHeight). 0 = use the default.
+        public int WindowWidth { get; private set; }
+        public int WindowHeight { get; private set; }
+
         // Preset intervals offered in the editable interval box (the box also accepts free text like "12 minutes").
         public ObservableCollection<string> IntervalOptions { get; } =
             new ObservableCollection<string> { "5 minutes", "15 minutes", "30 minutes", "1 hour", "2 hours" };
@@ -154,7 +165,7 @@ namespace Savedrake.App.ViewModels
             try
             {
                 BackupResult r = BackupService.Backup(
-                    new BackupRequest { LiveSaveDir = SaveDir, BackupDir = BackupDir, IsAutoBackup = true, RandomName = true },
+                    new BackupRequest { LiveSaveDir = SaveDir, BackupDir = BackupDir, IsAutoBackup = true, RandomName = UseRandomName },
                     _dialog, _status);
                 if (r.Ok) _sound.Success(); else _sound.Error();
                 return r.Ok;
@@ -180,6 +191,8 @@ namespace Savedrake.App.ViewModels
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Savedrake");
 
         private static string SettingsFilePath => Path.Combine(AppDataDir, "savedrake_settings.xml");
+        private static string VersionFilePath => Path.Combine(AppDataDir, "version.txt");
+        private static string UpdaterXmlPath => Path.Combine(AppDataDir, "savedrake-updater.xml");
 
         // Read the folders + autobackup settings from the WinForms settings file if present. Read-only, dependency-free
         // (a small hand-rolled XML read), and never throws — missing/garbled settings just leave defaults in place.
@@ -213,6 +226,9 @@ namespace Savedrake.App.ViewModels
                 RecycleEnabled = CleanupEnabled && ParseBool(root.Element("RemovedToRecycleBin"));
                 BackupOnSaveEnabled = ParseBool(root.Element("BackupOnSaveChange"));
                 MinimizeToTray = ParseBool(root.Element("CheckboxTray"));
+                UseRandomName = !ParseBool(root.Element("BackupFileName2")); // BackupFileName2 = time-stamped; default random
+                WindowWidth = ParseIntOr(root.Element("WindowWidth"), 0);
+                WindowHeight = ParseIntOr(root.Element("WindowHeight"), 0);
 
                 // Backup hotkey (nested <Hotkey> block + CheckboxHot), shared with the WinForms shape.
                 var hk = root.Element("Hotkey");
@@ -267,6 +283,10 @@ namespace Savedrake.App.ViewModels
                 SetElement(root, "RemovedToRecycleBin", RecycleEnabled.ToString());
                 SetElement(root, "BackupOnSaveChange", BackupOnSaveEnabled.ToString());
                 SetElement(root, "CheckboxTray", MinimizeToTray.ToString());
+                SetElement(root, "BackupFileName1", UseRandomName.ToString());
+                SetElement(root, "BackupFileName2", (!UseRandomName).ToString());
+                if (WindowWidth > 0) SetElement(root, "WindowWidth", WindowWidth.ToString());
+                if (WindowHeight > 0) SetElement(root, "WindowHeight", WindowHeight.ToString());
 
                 // Backup hotkey (nested <Hotkey> block + CheckboxHot + the display string in Textbox3).
                 var hk = root.Element("Hotkey");
@@ -555,7 +575,7 @@ namespace Savedrake.App.ViewModels
             try
             {
                 BackupResult r = BackupService.Backup(
-                    new BackupRequest { LiveSaveDir = SaveDir, BackupDir = BackupDir, IsAutoBackup = false, RandomName = true },
+                    new BackupRequest { LiveSaveDir = SaveDir, BackupDir = BackupDir, IsAutoBackup = false, RandomName = UseRandomName },
                     _dialog, _status);
                 if (r.Ok) _sound.Success(); else _sound.Error();
             }
@@ -749,6 +769,37 @@ namespace Savedrake.App.ViewModels
             if (HotkeyAlt) sb.Append("Alt + ");
             sb.Append(VkToKeyName(HotkeyVk));
             return sb.ToString();
+        }
+
+        // ----- backup name format / window size / reset -----
+
+        partial void OnUseRandomNameChanged(bool value) { if (_loaded) SaveSettings(); }
+
+        [RelayCommand] private void NameFormatRandom() => UseRandomName = true;
+        [RelayCommand] private void NameFormatTimestamp() => UseRandomName = false;
+
+        // Persist the window size (called by the window on close so the next launch restores it).
+        public void SaveWindowSize(int width, int height)
+        {
+            if (width > 0) WindowWidth = width;
+            if (height > 0) WindowHeight = height;
+            SaveSettings();
+        }
+
+        // Reset: stop the autobackup engine and delete the persisted state files; returns true if all were removed.
+        // The caller then disposes the tray and Environment.Exit(0)s so nothing re-creates them. Disposing the
+        // controller (rather than toggling AutobackupEnabled) avoids a SaveSettings that would re-create the file we
+        // just deleted.
+        public bool ResetState()
+        {
+            try { _autobackup?.Dispose(); } catch { }
+            bool allDeleted = true;
+            foreach (string path in new[] { SettingsFilePath, CountFilePath, VersionFilePath, UpdaterXmlPath })
+            {
+                try { if (File.Exists(path)) File.Delete(path); }
+                catch { allDeleted = false; }
+            }
+            return allDeleted;
         }
 
         // Send the selected backup(s) to the Recycle Bin (recoverable), supporting multi-select. The selection is


### PR DESCRIPTION
## Phase 6g — settings essentials

- **File → Reset Savedrake**: confirms, then deletes the four `%APPDATA%\Savedrake` state files (settings, count, version, `savedrake-updater.xml`) and `Environment.Exit(0)`s so nothing re-creates them. Honest "Reset Incomplete" warning if a file is locked; the controller is disposed first (not toggled) so no `SaveSettings` re-creates the file we just deleted, and the tray icon is disposed so it doesn't ghost. **Only the AppData state files are touched — never saves or backups.**
- **File → Backup name format** submenu: "Randomly generated" (default) vs "Time stamped", feeding `BackupRequest.RandomName` for both manual and autobackups, persisted as `BackupFileName1/2`. The current choice shows a gold check.
- **Window size** is restored on launch and saved on close (`WindowWidth`/`WindowHeight`, via `RestoreBounds` so a minimized/maximized window still saves its normal size).

### Verification
- **WinForms + Core untouched.** Release + Debug build clean. Harness **251/0**.
- **Runtime check** (throwaway folders, `BackupFileName2=true`, hotkey-triggered): the backup was named `backup_260621114133.zip` — the time-stamped format, confirming the name-format setting flows through to `BackupService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)