### PR TITLE
WPF Phase 6h: light parchment theme + live dark/light toggle

### DIFF
--- a/Savedrake.App/HotkeyDialog.xaml
+++ b/Savedrake.App/HotkeyDialog.xaml
@@ -5,18 +5,18 @@
         WindowStyle="None" AllowsTransparency="True" Background="Transparent"
         SizeToContent="WidthAndHeight" ResizeMode="NoResize"
         WindowStartupLocation="CenterOwner" ShowInTaskbar="False">
-    <Border Background="{StaticResource ShellBrush}" BorderBrush="{StaticResource AccentGoldBrush}"
+    <Border Background="{DynamicResource ShellBrush}" BorderBrush="{DynamicResource AccentGoldBrush}"
             BorderThickness="1" CornerRadius="12" Padding="24" Width="430">
         <StackPanel>
             <TextBlock Text="Set Backup Hotkey" FontSize="18" FontWeight="SemiBold"
-                       Foreground="{StaticResource AccentGoldBrush}" Margin="0,0,0,8" />
+                       Foreground="{DynamicResource AccentGoldBrush}" Margin="0,0,0,8" />
             <TextBlock Text="Hold Ctrl, Shift, or Alt and press a key. Press Enter to save, Esc to cancel."
-                       Foreground="{StaticResource TextSecondaryBrush}" FontSize="13" TextWrapping="Wrap"
+                       Foreground="{DynamicResource TextSecondaryBrush}" FontSize="13" TextWrapping="Wrap"
                        Margin="0,0,0,16" />
-            <Border Background="{StaticResource InputBrush}" BorderBrush="{StaticResource BorderBrush}"
+            <Border Background="{DynamicResource InputBrush}" BorderBrush="{DynamicResource BorderBrush}"
                     BorderThickness="1" CornerRadius="8" Padding="14,12" Margin="0,0,0,18">
                 <TextBlock x:Name="ComboReadout" Text="Press your keys…" FontSize="18" FontWeight="SemiBold"
-                           Foreground="{StaticResource AccentGoldBrush}" HorizontalAlignment="Center" />
+                           Foreground="{DynamicResource AccentGoldBrush}" HorizontalAlignment="Center" />
             </Border>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                 <Button Content="Clear hotkey" Style="{StaticResource DangerButton}" Padding="12,6" Click="Clear_Click" />

--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -11,7 +11,7 @@
         AllowsTransparency="False"
         ResizeMode="CanResize"
         WindowStartupLocation="CenterScreen"
-        Background="{StaticResource ShellBrush}"
+        Background="{DynamicResource ShellBrush}"
         TextOptions.TextFormattingMode="Display"
         UseLayoutRounding="True"
         SnapsToDevicePixels="True">
@@ -39,7 +39,7 @@
         </Grid.RowDefinitions>
 
         <!-- ============================ HEADER (draggable caption) ============================ -->
-        <Border Grid.Row="0" Background="{StaticResource BarBrush}" CornerRadius="10,10,0,0" Padding="14,8">
+        <Border Grid.Row="0" Background="{DynamicResource BarBrush}" CornerRadius="10,10,0,0" Padding="14,8">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />   <!-- brand token -->
@@ -50,23 +50,23 @@
 
                 <!-- 40px circular brand token: card-filled ellipse, thin gold-alpha stroke, gold serif 'S'. -->
                 <Grid Grid.Column="0" Width="40" Height="40" VerticalAlignment="Center">
-                    <Ellipse Fill="{StaticResource CardBrush}" Stroke="{StaticResource GoldRuleBrush}" StrokeThickness="1" />
+                    <Ellipse Fill="{DynamicResource CardBrush}" Stroke="{DynamicResource GoldRuleBrush}" StrokeThickness="1" />
                     <TextBlock Text="S" FontFamily="Georgia, Times New Roman" FontSize="22" FontWeight="SemiBold"
-                               Foreground="{StaticResource WordmarkBrush}"
+                               Foreground="{DynamicResource WordmarkBrush}"
                                HorizontalAlignment="Center" VerticalAlignment="Center" />
                 </Grid>
 
                 <!-- Wordmark in serif gold + small version. -->
                 <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" Margin="12,0,0,0">
                     <TextBlock Text="Savedrake" FontFamily="Georgia, Times New Roman" FontSize="26"
-                               Foreground="{StaticResource WordmarkBrush}" VerticalAlignment="Center">
+                               Foreground="{DynamicResource WordmarkBrush}" VerticalAlignment="Center">
                         <TextBlock.Resources>
                             <Style TargetType="TextBlock">
                                 <Setter Property="TextOptions.TextFormattingMode" Value="Ideal" />
                             </Style>
                         </TextBlock.Resources>
                     </TextBlock>
-                    <TextBlock Text="1.4.0" FontSize="12" Foreground="{StaticResource TextSecondaryBrush}"
+                    <TextBlock Text="1.4.0" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}"
                                VerticalAlignment="Bottom" Margin="8,0,0,5" />
                 </StackPanel>
 
@@ -96,6 +96,9 @@
                                                         RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
                                 </MenuItem>
                                 <MenuItem Header="Set backup hotkey…" Click="SetHotkey_Click" />
+                                <MenuItem Header="{Binding PlacementTarget.DataContext.ThemeMenuLabel,
+                                                  RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                          Click="ToggleTheme_Click" />
                                 <MenuItem Header="Minimize to system tray" IsCheckable="True"
                                           IsChecked="{Binding PlacementTarget.DataContext.MinimizeToTray,
                                                       RelativeSource={RelativeSource AncestorType=ContextMenu}, Mode=TwoWay}" />
@@ -132,7 +135,7 @@
         </Border>
 
         <!-- 1px gold hairline under the header. -->
-        <Border Grid.Row="1" Height="1" Background="{StaticResource GoldRuleBrush}" />
+        <Border Grid.Row="1" Height="1" Background="{DynamicResource GoldRuleBrush}" />
 
         <!-- ============================ CONTENT: three cards ============================ -->
         <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" Padding="0,12,0,0">
@@ -158,24 +161,24 @@
 
                             <!-- Save game row -->
                             <TextBlock Grid.Row="0" Grid.Column="0" Text="Save game" VerticalAlignment="Center"
-                                       FontSize="13" Foreground="{StaticResource TextSecondaryBrush}" />
+                                       FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
                             <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding SaveDir}" IsReadOnly="True"
                                      VerticalContentAlignment="Center" Padding="8,6" FontSize="12"
-                                     Background="{StaticResource InputBrush}" Foreground="{StaticResource TextBrush}"
-                                     BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" />
+                                     Background="{DynamicResource InputBrush}" Foreground="{DynamicResource TextBrush}"
+                                     BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" />
                             <Button Grid.Row="0" Grid.Column="3" Content="Browse" Style="{StaticResource OutlineButton}"
                                     Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseSaveCommand}"
                                     IsEnabled="{Binding ConfigEditable}" />
 
                             <!-- Backups row -->
                             <TextBlock Grid.Row="2" Grid.Column="0" Text="Backups" VerticalAlignment="Center"
-                                       FontSize="13" Foreground="{StaticResource TextSecondaryBrush}" />
+                                       FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
                             <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding BackupDir}" IsReadOnly="True"
                                      VerticalContentAlignment="Center" Padding="8,6" FontSize="12"
-                                     Background="{StaticResource InputBrush}" Foreground="{StaticResource TextBrush}"
-                                     BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" />
+                                     Background="{DynamicResource InputBrush}" Foreground="{DynamicResource TextBrush}"
+                                     BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" />
                             <TextBlock Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" Margin="10,0,0,0"
-                                       FontSize="12" Foreground="{StaticResource TextHintBrush}"
+                                       FontSize="12" Foreground="{DynamicResource TextHintBrush}"
                                        Text="{Binding BackupCount, StringFormat={}{0} backups}" />
                             <Button Grid.Row="2" Grid.Column="3" Content="Browse" Style="{StaticResource OutlineButton}"
                                     Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseBackupCommand}"
@@ -203,21 +206,21 @@
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <TextBlock Grid.Column="0" Text="Back up every" VerticalAlignment="Center" Margin="0,0,8,0"
-                                       FontSize="13" Foreground="{StaticResource TextSecondaryBrush}" />
+                                       FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
                             <TextBox Grid.Column="1" Width="120" Text="{Binding IntervalText}"
                                      VerticalContentAlignment="Center" Padding="8,5" FontSize="12"
-                                     Background="{StaticResource InputBrush}" Foreground="{StaticResource TextBrush}"
-                                     BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" />
+                                     Background="{DynamicResource InputBrush}" Foreground="{DynamicResource TextBrush}"
+                                     BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" />
                             <TextBlock Grid.Column="3" Text="Keep at most" VerticalAlignment="Center" Margin="0,0,8,0"
-                                       FontSize="13" Foreground="{StaticResource TextSecondaryBrush}" />
+                                       FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
                             <TextBox Grid.Column="4" Width="56" Text="{Binding MaxBackupsText}"
                                      VerticalContentAlignment="Center" Padding="8,5" FontSize="12"
-                                     Background="{StaticResource InputBrush}" Foreground="{StaticResource TextBrush}"
-                                     BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" />
+                                     Background="{DynamicResource InputBrush}" Foreground="{DynamicResource TextBrush}"
+                                     BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" />
                             <TextBlock Grid.Column="5" Text="backups" VerticalAlignment="Center" Margin="8,0,0,0"
-                                       FontSize="13" Foreground="{StaticResource TextSecondaryBrush}" />
+                                       FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
                         </Grid>
-                        <TextBlock Margin="26,6,0,0" FontSize="11" Foreground="{StaticResource TextHintBrush}"
+                        <TextBlock Margin="26,6,0,0" FontSize="11" Foreground="{DynamicResource TextHintBrush}"
                                    Text="Examples: 5 minutes, 30 minutes, 1 hour, 2 hours (minimum 5 minutes)." />
 
                         <!-- Options -->
@@ -259,9 +262,9 @@
                                   SelectionMode="Extended"
                                   KeyDown="BackupList_KeyDown"
                                   MouseDoubleClick="BackupList_MouseDoubleClick"
-                                  Background="{StaticResource CardBrush}"
-                                  BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
-                                  Foreground="{StaticResource TextBrush}"
+                                  Background="{DynamicResource CardBrush}"
+                                  BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
+                                  Foreground="{DynamicResource TextBrush}"
                                   ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                   MinHeight="180" MaxHeight="320">
                             <ListView.Resources>
@@ -277,9 +280,9 @@
                                     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                                     <Setter Property="Padding" Value="0" />
                                     <Setter Property="BorderThickness" Value="0,0,0,1" />
-                                    <Setter Property="BorderBrush" Value="{StaticResource RowSepBrush}" />
+                                    <Setter Property="BorderBrush" Value="{DynamicResource RowSepBrush}" />
                                     <Setter Property="Background" Value="Transparent" />
-                                    <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+                                    <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
                                     <Setter Property="Template">
                                         <Setter.Value>
                                             <ControlTemplate TargetType="ListViewItem">
@@ -290,10 +293,10 @@
                                                 </Border>
                                                 <ControlTemplate.Triggers>
                                                     <Trigger Property="IsMouseOver" Value="True">
-                                                        <Setter TargetName="bd" Property="Background" Value="{StaticResource CardAltBrush}" />
+                                                        <Setter TargetName="bd" Property="Background" Value="{DynamicResource CardAltBrush}" />
                                                     </Trigger>
                                                     <Trigger Property="IsSelected" Value="True">
-                                                        <Setter TargetName="bd" Property="Background" Value="{StaticResource SelectionBrush}" />
+                                                        <Setter TargetName="bd" Property="Background" Value="{DynamicResource SelectionBrush}" />
                                                     </Trigger>
                                                 </ControlTemplate.Triggers>
                                             </ControlTemplate>
@@ -347,7 +350,7 @@
 
                                         <!-- Status / pin pill. MultiBinding so it refreshes when Validate-all updates Status. -->
                                         <Border Grid.Column="2" Margin="10,0" Padding="8,2" CornerRadius="9"
-                                                Background="{StaticResource InputBrush}" VerticalAlignment="Center">
+                                                Background="{DynamicResource InputBrush}" VerticalAlignment="Center">
                                             <TextBlock FontSize="11">
                                                 <TextBlock.Text>
                                                     <MultiBinding Converter="{StaticResource PillText}">
@@ -366,7 +369,7 @@
 
                                         <!-- Friendly creation time, right-aligned and muted. -->
                                         <TextBlock Grid.Column="3" Text="{Binding FriendlyTime}" VerticalAlignment="Center"
-                                                   FontSize="12" Foreground="{StaticResource TextSecondaryBrush}"
+                                                   FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}"
                                                    TextAlignment="Right" MinWidth="80" />
                                     </Grid>
                                 </DataTemplate>
@@ -379,8 +382,8 @@
         </ScrollViewer>
 
         <!-- ============================ STATUS BAR ============================ -->
-        <Border Grid.Row="3" Background="{StaticResource BarBrush}" CornerRadius="0,0,10,10" Padding="14,7">
-            <TextBlock Text="{Binding StatusText}" FontSize="12" Foreground="{StaticResource TextSecondaryBrush}" />
+        <Border Grid.Row="3" Background="{DynamicResource BarBrush}" CornerRadius="0,0,10,10" Padding="14,7">
+            <TextBlock Text="{Binding StatusText}" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" />
         </Border>
     </Grid>
 </Window>

--- a/Savedrake.App/MainWindow.xaml.cs
+++ b/Savedrake.App/MainWindow.xaml.cs
@@ -20,9 +20,7 @@ namespace Savedrake.App
 
         private const int DWMWCP_ROUND = 2;
 
-        // The header/caption bar color (#241C14) as a Win32 COLORREF (0x00BBGGRR).
-        // R=0x24, G=0x1C, B=0x14  ->  0x00141C24
-        private const int CaptionColorRef = 0x00141C24;
+        // The caption colour now comes from ThemeManager.CaptionColorRef (theme-aware).
 
         [DllImport("dwmapi.dll", PreserveSig = true)]
         private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int attrValue, int attrSize);
@@ -44,6 +42,8 @@ namespace Savedrake.App
         {
             InitializeComponent();
             DataContext = new Savedrake.App.ViewModels.MainViewModel();
+            // Apply the saved theme before the first paint (no flash). Brush mutation repaints any existing controls.
+            ThemeManager.Apply((DataContext as Savedrake.App.ViewModels.MainViewModel)?.IsLightTheme ?? false);
             // Start the autobackup engine (WMI watcher) and re-engage a saved-on autobackup only once the window is
             // loaded, so any limit/invalid dialog from the immediate game-start backup has a real owner window. The
             // tray icon is created here too (after the window exists).
@@ -206,13 +206,13 @@ namespace Savedrake.App
                 IntPtr hwnd = new WindowInteropHelper(this).Handle;
                 if (hwnd == IntPtr.Zero) return;
 
-                int darkMode = 1;
+                int darkMode = ThemeManager.IsLight ? 0 : 1;
                 DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, ref darkMode, sizeof(int));
 
                 int corner = DWMWCP_ROUND;
                 DwmSetWindowAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, ref corner, sizeof(int));
 
-                int caption = CaptionColorRef;
+                int caption = ThemeManager.CaptionColorRef;
                 DwmSetWindowAttribute(hwnd, DWMWA_CAPTION_COLOR, ref caption, sizeof(int));
             }
             catch (Exception ex)
@@ -248,6 +248,16 @@ namespace Savedrake.App
         {
             if (DataContext is MainViewModel vm && vm.SelectedBackup != null)
                 vm.OpenBackupCommand.Execute(vm.SelectedBackup);
+        }
+
+        // File > Use light/dark theme: swap the palette live, persist, and re-tint the DWM caption.
+        private void ToggleTheme_Click(object sender, RoutedEventArgs e)
+        {
+            if (!(DataContext is Savedrake.App.ViewModels.MainViewModel vm)) return;
+            bool light = !vm.IsLightTheme;
+            ThemeManager.Apply(light);
+            vm.SetTheme(light);
+            ApplyDwmTheming();
         }
 
         // Open a header button's dropdown (File / Help) as a menu anchored under the button.

--- a/Savedrake.App/ThemeManager.cs
+++ b/Savedrake.App/ThemeManager.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Media;
+
+namespace Savedrake.App
+{
+    // Runtime light/dark theme switching. Every themed brush reference in the styles and controls is a DynamicResource
+    // (so it re-resolves when the resource changes — a StaticResource setter, by contrast, caches its value when the
+    // style is sealed and would NOT update). Switching themes replaces each brush resource in the merged Dark.xaml
+    // dictionary with a fresh SolidColorBrush of the other palette's colour; the DynamicResource references repaint
+    // live, with no window reload. Palettes are the LOCKED warm-dark (gold) and light (parchment + bronze) sets; the
+    // key insight for light mode is that gold becomes its dark sibling BRONZE for accents/text, with the bright gilt
+    // surviving only as the thin header rule (GoldRuleBrush, hardcoded and deliberately left out of the swap).
+    public static class ThemeManager
+    {
+        public static bool IsLight { get; private set; }
+
+        // brushKey -> (dark hex, light hex).
+        private static readonly Dictionary<string, (string dark, string light)> Map =
+            new Dictionary<string, (string, string)>
+            {
+                ["ShellBrush"] = ("#1F1811", "#E9E0CB"),
+                ["BarBrush"] = ("#241C14", "#E3D8BD"),
+                ["CardBrush"] = ("#2A2118", "#F5EFDF"),
+                ["CardAltBrush"] = ("#251D15", "#EFE7D2"),
+                ["InputBrush"] = ("#1A140C", "#FBF8EE"),
+                ["BorderBrush"] = ("#3A3025", "#D9CBA8"),
+                ["GoldDimOutlineBrush"] = ("#6B5A33", "#B89B5B"),
+                ["RowSepBrush"] = ("#2F261A", "#E3D9BF"),
+                ["SelectionBrush"] = ("#3E3223", "#DBCBA0"),
+                ["TextBrush"] = ("#E9E4D8", "#2E2A1F"),
+                ["TextSecondaryBrush"] = ("#A39B88", "#6E664F"),
+                ["TextHintBrush"] = ("#837B69", "#968C6F"),
+                ["AccentGoldBrush"] = ("#C8A24C", "#7E5E22"),
+                ["AccentTextBrush"] = ("#211A0E", "#F5EFDF"),
+                ["AccentDimBrush"] = ("#D3BE86", "#6E5320"),
+                ["WordmarkBrush"] = ("#D8B968", "#7E5E22"),
+                ["SuccessBrush"] = ("#8FB36A", "#3E6B33"),
+                ["DangerBrush"] = ("#C77B6F", "#9A3B2E"),
+            };
+
+        public static void Apply(bool light)
+        {
+            IsLight = light;
+            ResourceDictionary app = Application.Current?.Resources;
+            if (app == null) return;
+            foreach (var kv in Map)
+            {
+                Color c;
+                try { c = (Color)ColorConverter.ConvertFromString(light ? kv.Value.light : kv.Value.dark); }
+                catch { continue; }
+                SetBrush(app, kv.Key, new SolidColorBrush(c));
+            }
+        }
+
+        // Replace the brush on whichever merged dictionary owns the key (the brushes live in Themes/Dark.xaml).
+        private static void SetBrush(ResourceDictionary root, string key, Brush b)
+        {
+            foreach (ResourceDictionary md in root.MergedDictionaries)
+                if (md.Contains(key)) md[key] = b;
+        }
+
+        // The Win32 COLORREF (0x00BBGGRR) of the title-bar/caption colour for the current theme, so DWM tints the
+        // window caption to match (dark bar #241C14 or light bar #E3D8BD).
+        public static int CaptionColorRef => IsLight ? 0x00BDD8E3 : 0x00141C24;
+    }
+}

--- a/Savedrake.App/Themes/Dark.xaml
+++ b/Savedrake.App/Themes/Dark.xaml
@@ -53,15 +53,16 @@
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
     <SolidColorBrush x:Key="DangerBrush" Color="{StaticResource DangerColor}" />
 
-    <!-- A 60%-alpha gold for the hairline rule under the header. -->
-    <SolidColorBrush x:Key="GoldRuleBrush" Color="{StaticResource AccentGoldColor}" Opacity="0.6" />
+    <!-- A 60%-alpha gilt for the hairline rule under the header. Hardcoded so it stays gilt in BOTH themes (the bright
+         gilt survives only as the thin rule in light mode), unaffected by the theme swap below. -->
+    <SolidColorBrush x:Key="GoldRuleBrush" Color="#C8A24C" Opacity="0.6" />
 
     <!-- ===================== Reusable styles ===================== -->
 
     <!-- Card container: rounded espresso panel with a thin border. -->
     <Style x:Key="CardBorder" TargetType="Border">
-        <Setter Property="Background" Value="{StaticResource CardBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource CardBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="12" />
         <Setter Property="Padding" Value="18" />
@@ -72,20 +73,20 @@
     <Style x:Key="SectionTitle" TargetType="TextBlock">
         <Setter Property="FontSize" Value="16" />
         <Setter Property="FontWeight" Value="SemiBold" />
-        <Setter Property="Foreground" Value="{StaticResource AccentGoldBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource AccentGoldBrush}" />
         <Setter Property="Margin" Value="0,0,0,8" />
     </Style>
 
     <!-- Faint placeholder line for the empty card bodies in this shell. -->
     <Style x:Key="CardPlaceholder" TargetType="TextBlock">
         <Setter Property="FontSize" Value="13" />
-        <Setter Property="Foreground" Value="{StaticResource TextHintBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextHintBrush}" />
     </Style>
 
     <!-- Dark check box: espresso square that fills gold with a dark tick when checked. Implicit (applies to every
          CheckBox in the app); the warm-dark theme would otherwise render the OS default light box. -->
     <Style TargetType="CheckBox">
-        <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="Cursor" Value="Hand" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
@@ -95,10 +96,10 @@
                 <ControlTemplate TargetType="CheckBox">
                     <StackPanel Orientation="Horizontal" Background="Transparent">
                         <Border x:Name="box" Width="18" Height="18" CornerRadius="4" VerticalAlignment="Center"
-                                Background="{StaticResource InputBrush}"
-                                BorderBrush="{StaticResource BorderBrush}" BorderThickness="1">
+                                Background="{DynamicResource InputBrush}"
+                                BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1">
                             <Path x:Name="check" Width="11" Height="11" Stretch="Uniform"
-                                  Data="M 0,5 L 4,9 L 11,0" Stroke="{StaticResource AccentTextBrush}"
+                                  Data="M 0,5 L 4,9 L 11,0" Stroke="{DynamicResource AccentTextBrush}"
                                   StrokeThickness="2" Visibility="Collapsed"
                                   HorizontalAlignment="Center" VerticalAlignment="Center" />
                         </Border>
@@ -106,12 +107,12 @@
                     </StackPanel>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="True">
-                            <Setter TargetName="box" Property="Background" Value="{StaticResource AccentGoldBrush}" />
-                            <Setter TargetName="box" Property="BorderBrush" Value="{StaticResource AccentGoldBrush}" />
+                            <Setter TargetName="box" Property="Background" Value="{DynamicResource AccentGoldBrush}" />
+                            <Setter TargetName="box" Property="BorderBrush" Value="{DynamicResource AccentGoldBrush}" />
                             <Setter TargetName="check" Property="Visibility" Value="Visible" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="box" Property="BorderBrush" Value="{StaticResource AccentGoldBrush}" />
+                            <Setter TargetName="box" Property="BorderBrush" Value="{DynamicResource AccentGoldBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.45" />
@@ -125,10 +126,10 @@
     <!-- Dark context/dropdown menus (the OS default renders light). Reused by the list right-click menu and the
          File/Help header dropdowns. The MenuItem template covers flat items, submenu headers, and top-level headers. -->
     <Style TargetType="ContextMenu">
-        <Setter Property="Background" Value="{StaticResource BarBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource BarBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
         <Setter Property="HasDropShadow" Value="True" />
         <!-- Replace the default template so the light icon-gutter strip on the left is gone (a plain border + items
              host). The default ContextMenu template paints that gutter regardless of Background. -->
@@ -146,7 +147,7 @@
     </Style>
 
     <Style TargetType="Separator">
-        <Setter Property="Background" Value="{StaticResource RowSepBrush}" />
+        <Setter Property="Background" Value="{DynamicResource RowSepBrush}" />
         <Setter Property="Height" Value="1" />
         <Setter Property="Margin" Value="8,4" />
         <Setter Property="Template">
@@ -159,7 +160,7 @@
     </Style>
 
     <Style TargetType="MenuItem">
-        <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Height" Value="30" />
         <Setter Property="FontSize" Value="13" />
@@ -175,15 +176,15 @@
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <TextBlock Grid.Column="0" x:Name="check" Text="&#x2713;" FontSize="12" VerticalAlignment="Center"
-                                       Foreground="{StaticResource AccentGoldBrush}" Visibility="Hidden" />
+                                       Foreground="{DynamicResource AccentGoldBrush}" Visibility="Hidden" />
                             <ContentPresenter Grid.Column="1" ContentSource="Header" VerticalAlignment="Center"
                                               RecognizesAccessKey="True" />
                             <TextBlock Grid.Column="2" x:Name="arrow" Text="4" FontFamily="Marlett" FontSize="11"
                                        Margin="14,0,0,0" VerticalAlignment="Center" Visibility="Collapsed"
-                                       Foreground="{StaticResource TextSecondaryBrush}" />
+                                       Foreground="{DynamicResource TextSecondaryBrush}" />
                             <Popup x:Name="PART_Popup" Placement="Right" IsOpen="{TemplateBinding IsSubmenuOpen}"
                                    AllowsTransparency="True" Focusable="False" PopupAnimation="Fade">
-                                <Border Background="{StaticResource BarBrush}" BorderBrush="{StaticResource BorderBrush}"
+                                <Border Background="{DynamicResource BarBrush}" BorderBrush="{DynamicResource BorderBrush}"
                                         BorderThickness="1" CornerRadius="6" Padding="4">
                                     <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
                                 </Border>
@@ -201,7 +202,7 @@
                             <Setter TargetName="PART_Popup" Property="Placement" Value="Bottom" />
                         </Trigger>
                         <Trigger Property="IsHighlighted" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource SelectionBrush}" />
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource SelectionBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.4" />
@@ -214,8 +215,8 @@
 
     <!-- Primary gold button: filled gold, dark text. -->
     <Style x:Key="PrimaryButton" TargetType="Button">
-        <Setter Property="Foreground" Value="{StaticResource AccentTextBrush}" />
-        <Setter Property="Background" Value="{StaticResource AccentGoldBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource AccentTextBrush}" />
+        <Setter Property="Background" Value="{DynamicResource AccentGoldBrush}" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="FontWeight" Value="SemiBold" />
@@ -231,7 +232,7 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource AccentDimBrush}" />
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource AccentDimBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="bd" Property="Opacity" Value="0.45" />
@@ -244,9 +245,9 @@
 
     <!-- Gold-outline button: transparent fill, gold border + gold text. -->
     <Style x:Key="OutlineButton" TargetType="Button">
-        <Setter Property="Foreground" Value="{StaticResource AccentGoldBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource AccentGoldBrush}" />
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="BorderBrush" Value="{StaticResource GoldDimOutlineBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource GoldDimOutlineBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="FontWeight" Value="SemiBold" />
@@ -264,8 +265,8 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource SelectionBrush}" />
-                            <Setter TargetName="bd" Property="BorderBrush" Value="{StaticResource AccentGoldBrush}" />
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource SelectionBrush}" />
+                            <Setter TargetName="bd" Property="BorderBrush" Value="{DynamicResource AccentGoldBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="bd" Property="Opacity" Value="0.45" />
@@ -278,9 +279,9 @@
 
     <!-- Danger button: red-tinted outline, red text. -->
     <Style x:Key="DangerButton" TargetType="Button">
-        <Setter Property="Foreground" Value="{StaticResource DangerBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource DangerBrush}" />
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="BorderBrush" Value="{StaticResource DangerBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource DangerBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="FontWeight" Value="SemiBold" />
@@ -298,9 +299,9 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource DangerBrush}" />
-                            <Setter TargetName="bd" Property="TextElement.Foreground" Value="{StaticResource AccentTextBrush}" />
-                            <Setter Property="Foreground" Value="{StaticResource AccentTextBrush}" />
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource DangerBrush}" />
+                            <Setter TargetName="bd" Property="TextElement.Foreground" Value="{DynamicResource AccentTextBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource AccentTextBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="bd" Property="Opacity" Value="0.45" />
@@ -313,7 +314,7 @@
 
     <!-- Header text-menu button ("File", "Help"): flat, no chrome, light text. -->
     <Style x:Key="HeaderMenuButton" TargetType="Button">
-        <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="FontSize" Value="13" />
@@ -328,7 +329,7 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource SelectionBrush}" />
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource SelectionBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -338,7 +339,7 @@
 
     <!-- Caption window buttons (minimize / close): ~46x32, flat, glyph in light text. -->
     <Style x:Key="CaptionButton" TargetType="Button">
-        <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Width" Value="46" />
@@ -353,7 +354,7 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource SelectionBrush}" />
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource SelectionBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -371,8 +372,8 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource DangerBrush}" />
-                            <Setter Property="Foreground" Value="{StaticResource AccentTextBrush}" />
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource DangerBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource AccentTextBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -82,6 +82,15 @@ namespace Savedrake.App.ViewModels
 
         public bool UseTimestampName => !UseRandomName;
 
+        // Light vs dark theme (persisted as ThemeMode; default dark). ThemeMenuLabel drives the toggle's caption.
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(ThemeMenuLabel))]
+        private bool isLightTheme;
+
+        public string ThemeMenuLabel => IsLightTheme ? "Use dark theme" : "Use light theme";
+
+        public void SetTheme(bool light) { IsLightTheme = light; SaveSettings(); }
+
         // Last window size, restored on next launch (persisted as WindowWidth/WindowHeight). 0 = use the default.
         public int WindowWidth { get; private set; }
         public int WindowHeight { get; private set; }
@@ -227,6 +236,7 @@ namespace Savedrake.App.ViewModels
                 BackupOnSaveEnabled = ParseBool(root.Element("BackupOnSaveChange"));
                 MinimizeToTray = ParseBool(root.Element("CheckboxTray"));
                 UseRandomName = !ParseBool(root.Element("BackupFileName2")); // BackupFileName2 = time-stamped; default random
+                IsLightTheme = string.Equals((string)root.Element("ThemeMode"), "Light", StringComparison.OrdinalIgnoreCase);
                 WindowWidth = ParseIntOr(root.Element("WindowWidth"), 0);
                 WindowHeight = ParseIntOr(root.Element("WindowHeight"), 0);
 
@@ -285,6 +295,7 @@ namespace Savedrake.App.ViewModels
                 SetElement(root, "CheckboxTray", MinimizeToTray.ToString());
                 SetElement(root, "BackupFileName1", UseRandomName.ToString());
                 SetElement(root, "BackupFileName2", (!UseRandomName).ToString());
+                SetElement(root, "ThemeMode", IsLightTheme ? "Light" : "Dark");
                 if (WindowWidth > 0) SetElement(root, "WindowWidth", WindowWidth.ToString());
                 if (WindowHeight > 0) SetElement(root, "WindowHeight", WindowHeight.ToString());
 


### PR DESCRIPTION
## Phase 6h — light theme + live toggle

Adds the locked **light "parchment + bronze"** theme and a runtime toggle, completing dual-theme parity.

- **`ThemeManager`** swaps the theme by **replacing each brush resource** in the merged `Dark.xaml` dictionary with a fresh `SolidColorBrush` of the other palette. Every themed brush reference in the styles/controls is a **`DynamicResource`**, so they re-resolve and repaint live — *including* brushes used in sealed `Style` setters (a `StaticResource` setter caches its value at seal time and would **not** update, which is exactly why the first cut left the cards on the old colour). No window reload.
- **Palettes** are the LOCKED warm-dark (gold) and light (parchment + bronze) sets. Light mode turns gold into its dark sibling **BRONZE** for accents/text/buttons; the bright gilt survives only as the thin header rule (hardcoded, excluded from the swap).
- **File → "Use light/dark theme"** toggles live + persists `ThemeMode`; the menu label flips. The saved theme applies in the window ctor before first paint (no flash), and the DWM caption colour + immersive-dark flag follow the theme.

### Verification
- **WinForms + Core untouched.** Release + Debug build clean. Harness **251/0**.
- **Runtime checks** (throwaway folders): launching with `ThemeMode=Light` rendered the full parchment+bronze UI; toggling light↔dark via the menu swapped the **entire** UI live (window, all cards, inputs, buttons, list) with no crash; `ThemeMode` persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)