### PR TITLE
WPF Phase 6i: updater pipeline (version check + version.txt + launch)

### DIFF
--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -140,6 +140,7 @@ namespace RestoreHarness
                 Test_AutobackupCountStore();   // Phase 5: forgiving read of the autobackup count file (missing/garbled -> 0)
                 Test_AutobackupCleanup();   // Phase 5: auto-thinning excludes manual/pre-restore/pinned, removes surplus autos
                 Test_GameDetect();   // Phase 5: DD2 running-state registry read returns a bool and never throws
+                Test_UpdateCheck();   // Phase 6i: update version parsing (strip v, 2-4 numeric parts) + comparison
             }
             catch (Exception ex)
             {
@@ -977,6 +978,30 @@ namespace RestoreHarness
             try { result = GameDetect.IsDd2Running(); } catch { threw = true; }
             Check("IsDd2Running() does not throw on a box without DD2", !threw);
             Check("IsDd2Running() reports not-running when the key is absent", result == false);
+            Console.WriteLine();
+        }
+
+        static void Test_UpdateCheck()
+        {
+            // Phase 6i: TryParseVersion is the pure half of the update check — strip a leading 'v', require 2-4
+            // numeric parts. A higher tag drives UpdateAvailable; an equal/unparsable tag must never claim an update.
+            Console.WriteLine("== Phase 6i: update version parsing ==");
+            Check("plain 1.2.3 parses", UpdateCheck.TryParseVersion("1.2.3", out Version v1) && v1.ToString() == "1.2.3");
+            Check("v-prefixed v1.2.5 parses (v stripped)", UpdateCheck.TryParseVersion("v1.2.5", out Version v2) && v2.ToString() == "1.2.5");
+            Check("uppercase V2.0 parses", UpdateCheck.TryParseVersion("V2.0", out Version _));
+            Check("two-part 1.4 parses", UpdateCheck.TryParseVersion("1.4", out Version _));
+            Check("four-part 1.2.3.4 parses", UpdateCheck.TryParseVersion("1.2.3.4", out Version _));
+            Check("single part 1 -> invalid", !UpdateCheck.TryParseVersion("1", out Version _));
+            Check("five parts -> invalid", !UpdateCheck.TryParseVersion("1.2.3.4.5", out Version _));
+            Check("non-numeric part -> invalid", !UpdateCheck.TryParseVersion("1.x.3", out Version _));
+            Check("empty -> invalid", !UpdateCheck.TryParseVersion("", out Version _));
+            Check("garbage -> invalid", !UpdateCheck.TryParseVersion("vNext", out Version _));
+
+            UpdateCheck.TryParseVersion("1.2.3", out Version cur);
+            UpdateCheck.TryParseVersion("1.3.0", out Version newer);
+            UpdateCheck.TryParseVersion("1.2.3", out Version same);
+            Check("a higher release tag compares greater (update available)", newer > cur);
+            Check("an equal tag is not greater (no phantom update)", !(same > cur));
             Console.WriteLine();
         }
 

--- a/Savedrake.App/AppUpdater.cs
+++ b/Savedrake.App/AppUpdater.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace Savedrake.App
+{
+    // The app side of the update flow (the version compare itself is Savedrake.UpdateCheck in Core). Writes the
+    // version-handshake file the external Savedrake-Updater.exe reads, runs a silent check at startup, a feedback-y
+    // check from Help > Check for Updates, and launches the updater when a newer release exists. Ported from the
+    // WinForms ExecuteUpdateProcess / CreateVersionText, same owner/repo and same user-facing messages.
+    internal static class AppUpdater
+    {
+        private const string Owner = "sammorrison9800";
+        private const string Repo = "Savedrake";
+
+        private static string AppDataDir =>
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Savedrake");
+        private static string VersionFilePath => Path.Combine(AppDataDir, "version.txt");
+        private static string UpdaterXmlPath => Path.Combine(AppDataDir, "savedrake-updater.xml");
+
+        public static string CurrentVersion =>
+            System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.0";
+
+        // Best-effort write of %APPDATA%\Savedrake\version.txt so the external updater knows the installed version.
+        public static void WriteVersionFile()
+        {
+            try
+            {
+                if (UpdateCheck.TryParseVersion(CurrentVersion, out Version v))
+                {
+                    Directory.CreateDirectory(AppDataDir);
+                    File.WriteAllText(VersionFilePath, v.ToString());
+                }
+            }
+            catch { /* read-only working dir etc. — non-fatal */ }
+        }
+
+        // The user opted out of the startup auto-check (savedrake-updater.xml <CheckBox1>true</CheckBox1>).
+        private static bool SkipStartupCheck()
+        {
+            try
+            {
+                if (!File.Exists(UpdaterXmlPath)) return false;
+                var root = System.Xml.Linq.XElement.Load(UpdaterXmlPath);
+                var cb = root.Element("CheckBox1");
+                return cb != null && bool.TryParse(cb.Value, out bool b) && b;
+            }
+            catch { return false; }
+        }
+
+        // Startup check: silent unless an update exists (then launch the updater). Never nags on up-to-date / offline.
+        public static async Task RunStartupCheckAsync()
+        {
+            if (SkipStartupCheck()) return;
+            try
+            {
+                UpdateCheck.Result r = await UpdateCheck.CheckAsync(CurrentVersion, Owner, Repo);
+                if (r.UpdateAvailable) LaunchUpdater();
+            }
+            catch { /* never let a background update check surface an error */ }
+        }
+
+        // Manual "Check for Updates": always give feedback (up to date / couldn't check / launching the updater).
+        public static async Task RunManualCheckAsync()
+        {
+            UpdateCheck.Result r;
+            try { r = await UpdateCheck.CheckAsync(CurrentVersion, Owner, Repo); }
+            catch { r = new UpdateCheck.Result { ApiError = true }; }
+
+            if (r.UpdateAvailable)
+                LaunchUpdater();
+            else if (r.ApiError)
+                MessageBox.Show("Could not check for updates. Please check your internet connection and try again.",
+                    "Update Check Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
+            else
+                MessageBox.Show("Your Savedrake is up to date.", "No Updates Available",
+                    MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        // Launch the external updater, resolved next to this exe (not the working directory). Mirrors the WinForms
+        // message when it can't be found.
+        private static void LaunchUpdater()
+        {
+            try { System.Diagnostics.Process.Start(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Savedrake-Updater.exe")); }
+            catch
+            {
+                MessageBox.Show("A new update is available, but Savedrake-Updater.exe could not be started. Make sure the " +
+                    "file is present in the Savedrake folder.", "Savedrake-Updater.exe Missing",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+        }
+    }
+}

--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -113,6 +113,8 @@
                     <Button Content="Help" Style="{StaticResource HeaderMenuButton}" Margin="2,0,8,0" Click="HeaderMenu_Click">
                         <Button.ContextMenu>
                             <ContextMenu>
+                                <MenuItem Header="Check for updates" Click="CheckUpdates_Click" />
+                                <Separator />
                                 <MenuItem Header="FAQ"
                                           Command="{Binding PlacementTarget.DataContext.OpenFaqCommand,
                                                     RelativeSource={RelativeSource AncestorType=ContextMenu}}" />

--- a/Savedrake.App/MainWindow.xaml.cs
+++ b/Savedrake.App/MainWindow.xaml.cs
@@ -58,6 +58,8 @@ namespace Savedrake.App
                 InitTray();
                 vm?.Activate();
                 RegisterCurrentHotkey();
+                AppUpdater.WriteVersionFile();        // version-handshake file for the external updater
+                _ = AppUpdater.RunStartupCheckAsync(); // silent unless a newer release exists
             };
         }
 
@@ -248,6 +250,12 @@ namespace Savedrake.App
         {
             if (DataContext is MainViewModel vm && vm.SelectedBackup != null)
                 vm.OpenBackupCommand.Execute(vm.SelectedBackup);
+        }
+
+        // Help > Check for Updates: a manual check that always reports its result.
+        private async void CheckUpdates_Click(object sender, RoutedEventArgs e)
+        {
+            await AppUpdater.RunManualCheckAsync();
         }
 
         // File > Use light/dark theme: swap the palette live, persist, and re-tint the DWM caption.

--- a/Savedrake.App/Savedrake.App.csproj
+++ b/Savedrake.App/Savedrake.App.csproj
@@ -19,6 +19,11 @@
     <RootNamespace>Savedrake.App</RootNamespace>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <ApplicationIcon>savedrake.ico</ApplicationIcon>
+    <!-- The shipped version. Drives the update check (must be >= the latest GitHub release so a fresh dev build does
+         not see a phantom update) and the version-handshake file the external updater reads. Matches the wordmark. -->
+    <Version>1.4.0</Version>
+    <AssemblyVersion>1.4.0.0</AssemblyVersion>
+    <FileVersion>1.4.0.0</FileVersion>
   </PropertyGroup>
 
   <!-- The window/taskbar/tray icon. Bundled as a Resource so the Window.Icon pack URI can load it, and set as the

--- a/Savedrake.Core/Savedrake.Core.csproj
+++ b/Savedrake.Core/Savedrake.Core.csproj
@@ -30,4 +30,9 @@
     <Reference Include="Microsoft.VisualBasic" />
   </ItemGroup>
 
+  <!-- System.Net.Http: the GitHub "latest release" query in the update check. Framework assembly on net48. -->
+  <ItemGroup>
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
 </Project>

--- a/Savedrake.Core/UpdateCheck.cs
+++ b/Savedrake.Core/UpdateCheck.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace Savedrake
+{
+    // Update-availability check, lifted out of the WinForms app during the WPF migration. TryParseVersion is the pure,
+    // harness-tested half (strip a leading 'v', require 2-4 numeric parts); CheckAsync queries the GitHub "latest
+    // release" API and compares. The result drives whether the app launches the external Savedrake-Updater.exe. All
+    // failures (offline, timeout, non-200, missing tag) fail SAFE: ApiError is set and UpdateAvailable stays false, so
+    // a connectivity hiccup never nags the user with a phantom update.
+    public static class UpdateCheck
+    {
+        public static bool TryParseVersion(string versionString, out Version version)
+        {
+            version = null;
+            if (string.IsNullOrEmpty(versionString)) return false;
+
+            // GitHub release tags are conventionally prefixed with 'v' (e.g. "v1.2.5"). Strip it.
+            if (versionString.Length > 1 && (versionString[0] == 'v' || versionString[0] == 'V'))
+                versionString = versionString.Substring(1);
+
+            string[] parts = versionString.Split('.');
+            if (parts.Length < 2 || parts.Length > 4) return false;
+            foreach (string part in parts)
+                if (!int.TryParse(part, out int _)) return false;
+
+            try { version = new Version(versionString); return true; }
+            catch (ArgumentException) { return false; }
+        }
+
+        public sealed class Result
+        {
+            public bool UpdateAvailable;
+            public bool ApiError;
+            public string LatestTag;
+            public string CurrentVersion;
+        }
+
+        public static async Task<Result> CheckAsync(string currentVersion, string owner, string repo)
+        {
+            var r = new Result { CurrentVersion = currentVersion };
+            if (!TryParseVersion(currentVersion, out Version current)) return r;
+
+            string tag = await GetLatestTagAsync(owner, repo, apiErr => r.ApiError = apiErr);
+            r.LatestTag = tag;
+            if (TryParseVersion(tag, out Version latest))
+                r.UpdateAvailable = latest > current;
+            return r;
+        }
+
+        private static async Task<string> GetLatestTagAsync(string owner, string repo, Action<bool> setApiError)
+        {
+            setApiError(false);
+            string apiUrl = "https://api.github.com/repos/" + owner + "/" + repo + "/releases/latest";
+            try
+            {
+                using (var client = new HttpClient())
+                {
+                    client.Timeout = TimeSpan.FromSeconds(15); // a stalled connection must not hang the default ~100s
+                    client.DefaultRequestHeaders.Add("User-Agent", "Savedrake Update Checker");
+                    using (HttpResponseMessage response = await client.GetAsync(apiUrl))
+                    {
+                        response.EnsureSuccessStatusCode();
+                        string body = await response.Content.ReadAsStringAsync();
+                        // Null-safe: a 200 whose JSON lacks tag_name returns null (treated as "no version" -> up to date).
+                        return JObject.Parse(body).Value<string>("tag_name");
+                    }
+                }
+            }
+            catch
+            {
+                setApiError(true); // offline / DNS / refused / timeout / parse error — fail safe
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Phase 6i — self-update

Brings the update flow to the WPF app at parity with the shipped app.

### Core (`Savedrake.UpdateCheck`)
- **`TryParseVersion`** (strip a leading `v`, require 2-4 numeric parts) + **`CheckAsync`**, which queries the GitHub "latest release" API (15s timeout, UA header) and compares. Every failure fails **safe** (`ApiError` set, `UpdateAvailable` stays false) so a connectivity hiccup never shows a phantom update. Harness **+12** assertions (251 → 263).

### App (`AppUpdater`)
- Writes `%APPDATA%\Savedrake\version.txt` (the handshake the external updater reads).
- **Silent startup auto-check** (skippable via `savedrake-updater.xml` `CheckBox1`) that launches `Savedrake-Updater.exe` only when a newer release exists.
- **Help → Check for Updates**: a manual check that always reports up-to-date / couldn't-check / launches the updater. Same "Savedrake-Updater.exe Missing" message as the shipped app.

Also sets the `Savedrake.App` assembly version to **1.4.0** (was the default `1.0.0.0`, which read as older than the `1.3.0` GitHub release and would have nagged on every launch). Final version unification lands in Phase 7.

### Verification
- **WinForms untouched.** Release + Debug build clean. Harness **263/0**.
- A real launch wrote `version.txt=1.4.0.0` and the startup check stayed **silent** (1.4.0 > the 1.3.0 release — no phantom update, no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)