### PR TITLE
WPF Phase 7: cutover — retire WinForms from the build, harness independence, version unify

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run restore regression harness (${{ matrix.configuration }})
         shell: pwsh
         run: |
-          & ".\RestoreHarness\bin\RestoreHarness.exe" "Savedrake v1.2.3\bin\${{ matrix.configuration }}"
+          & ".\RestoreHarness\bin\RestoreHarness.exe"
           if ($LASTEXITCODE -ne 0) { Write-Error "Restore regression harness FAILED ($LASTEXITCODE)"; exit $LASTEXITCODE }
 
       - name: Upload Release artifacts
@@ -42,7 +42,7 @@ jobs:
         with:
           name: savedrake-release
           path: |
-            Savedrake v1.2.3/bin/Release/**
+            Savedrake.App/bin/Release/**
             updater/bin/Release/**
           if-no-files-found: warn
           retention-days: 7

--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -39,13 +39,9 @@ namespace RestoreHarness
     internal static class Program
     {
         static int passed = 0, failed = 0;
-        static Type T;
-        static Assembly Core;           // Savedrake.Core.dll — logic extracted during the WPF migration
-        static object inst;             // uninitialized Main (constructor NOT run)
+        static Assembly Core;           // Savedrake.Core (the compile-time-referenced assembly)
         static string work;             // harness scratch root
 
-        static MethodInfo SM(string n) { var m = T.GetMethod(n, BindingFlags.NonPublic | BindingFlags.Static); if (m == null) throw new Exception("static method not found: " + n); return m; }
-        static MethodInfo IM(string n) { var m = T.GetMethod(n, BindingFlags.NonPublic | BindingFlags.Instance); if (m == null) throw new Exception("instance method not found: " + n); return m; }
         // Public static method on a Savedrake.Core type, e.g. CM("IntervalParser","TryParse").
         static MethodInfo CM(string typeName, string method) { var t = Core.GetType("Savedrake." + typeName); if (t == null) throw new Exception("core type not found: Savedrake." + typeName); var m = t.GetMethod(method, BindingFlags.Public | BindingFlags.Static); if (m == null) throw new Exception("core method not found: " + typeName + "." + method); return m; }
 
@@ -57,47 +53,12 @@ namespace RestoreHarness
 
         static Exception Unwrap(Exception e) { return e is TargetInvocationException && e.InnerException != null ? e.InnerException : e; }
 
-        // Locate the built Savedrake.exe: an explicit arg wins; otherwise look next to this harness
-        // (..\..\Savedrake v1.2.3\bin\<cfg>) so it works from the repo build output and in CI without a machine path.
-        static string ResolveBin(string[] args)
-        {
-            if (args.Length > 0) return args[0];
-            string baseDir = AppDomain.CurrentDomain.BaseDirectory;
-            foreach (string cfg in new[] { "Release", "Debug" })
-            {
-                string p = Path.GetFullPath(Path.Combine(baseDir, "..", "..", "Savedrake v1.2.3", "bin", cfg));
-                if (File.Exists(Path.Combine(p, "Savedrake.exe"))) return p;
-            }
-            return Path.GetFullPath(Path.Combine(baseDir, "..", "..", "Savedrake v1.2.3", "bin", "Release"));
-        }
-
         static int Main(string[] args)
         {
-            string bin = ResolveBin(args);
-            string exe = Path.Combine(bin, "Savedrake.exe");
-            if (!File.Exists(exe))
-            {
-                Console.WriteLine("Savedrake.exe not found at: " + exe);
-                Console.WriteLine("Pass the build output dir as arg 1, e.g.  RestoreHarness.exe \"...\\Savedrake v1.2.3\\bin\\Release\"");
-                return 2;
-            }
-            AppDomain.CurrentDomain.AssemblyResolve += (s, e) =>
-            {
-                string nm = new AssemblyName(e.Name).Name;
-                string p = Path.Combine(bin, nm + ".dll");
-                return File.Exists(p) ? Assembly.LoadFrom(p) : null;
-            };
-
-            Console.WriteLine("Loading " + exe);
-            Assembly asm = Assembly.LoadFrom(exe);
-            T = asm.GetType("Savedrake.Main");
-            if (T == null) { Console.WriteLine("Could not find Savedrake.Main"); return 2; }
-            inst = FormatterServices.GetUninitializedObject(T); // no ctor → no UI/registry/WMI
-
-            // Logic extracted into Savedrake.Core during the WPF migration is exercised directly from the Core assembly.
-            string corePath = Path.Combine(bin, "Savedrake.Core.dll");
-            Core = File.Exists(corePath) ? Assembly.LoadFrom(corePath) : null;
-            if (Core == null) { Console.WriteLine("Could not load Savedrake.Core.dll at: " + corePath); return 2; }
+            // Post-cutover: the harness runs entirely against Savedrake.Core (referenced at compile time and loaded
+            // next to this exe by normal probing). It no longer loads the retired WinForms Savedrake.exe — every test
+            // exercises Core directly (the CM reflection helper points at this same compile-time Core assembly).
+            Core = typeof(Savedrake.RestoreEngine).Assembly;
 
             work = Path.Combine(Path.GetTempPath(), "sdk_restore_harness_" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(work);
@@ -1007,16 +968,17 @@ namespace RestoreHarness
 
         static void Test_SoundAssetsShipped()
         {
-            // PlayBackupSound resolves success.wav/error.wav from Application.StartupPath (the exe dir), so the
+            // SoundFeedback resolves success.wav/error.wav from the install dir (next to Savedrake.App.exe), so the
             // build must copy them there (Content + CopyToOutputDirectory). Guard against the csproj items being
             // dropped, which would silently kill all backup feedback sounds.
-            Console.WriteLine("== Sound assets shipped next to Savedrake.exe ==");
-            string dir = Path.GetDirectoryName(T.Assembly.Location);
+            Console.WriteLine("== Sound assets shipped next to Savedrake.App.exe ==");
+            string dir = ResolveAppBin();
+            if (dir == null) { Check("Savedrake.App build output found for sound-asset check", false, "ResolveAppBin() returned null"); Console.WriteLine(); return; }
             foreach (string wav in new[] { "success.wav", "error.wav" })
             {
                 string p = Path.Combine(dir, wav);
                 bool exists = File.Exists(p);
-                Check(wav + " present in build output", exists, p);
+                Check(wav + " present next to Savedrake.App.exe", exists, p);
                 if (exists)
                 {
                     byte[] head = new byte[12];
@@ -1026,23 +988,11 @@ namespace RestoreHarness
                     Check(wav + " is a valid RIFF/WAVE file", riffWave);
                 }
             }
-
-            // Phase 6a: the WPF app (Savedrake.App.exe) plays the same feedback sounds, resolved from its own install
-            // dir, so they must copy to the App's output too. Skipped if the App build output isn't present.
-            string appDir = ResolveAppBin();
-            if (appDir != null)
-            {
-                foreach (string wav in new[] { "success.wav", "error.wav" })
-                {
-                    string p = Path.Combine(appDir, wav);
-                    Check("Savedrake.App: " + wav + " present in build output", File.Exists(p), p);
-                }
-            }
             Console.WriteLine();
         }
 
-        // Locate the built Savedrake.App.exe output (sibling of the WinForms output), so the sound-asset test can
-        // confirm the WPF app ships the wavs too. Returns null if the App hasn't been built.
+        // Locate the built Savedrake.App.exe output so the sound-asset test can confirm the WPF app ships the wavs.
+        // Returns null if the App hasn't been built.
         static string ResolveAppBin()
         {
             string baseDir = AppDomain.CurrentDomain.BaseDirectory;

--- a/RestoreHarness/RestoreHarness.csproj
+++ b/RestoreHarness/RestoreHarness.csproj
@@ -37,5 +37,10 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- DotNetZip is consumed via the HintPath above; this packages.config makes `nuget restore` populate it into
+         ..\packages (previously the now-retired WinForms project's packages.config did that). -->
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/RestoreHarness/packages.config
+++ b/RestoreHarness/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="DotNetZip" version="1.16.0" targetFramework="net48" />
+</packages>

--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -66,7 +66,7 @@
                             </Style>
                         </TextBlock.Resources>
                     </TextBlock>
-                    <TextBlock Text="1.4.0" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}"
+                    <TextBlock Text="{Binding AppVersion}" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}"
                                VerticalAlignment="Bottom" Margin="8,0,0,5" />
                 </StackPanel>
 

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -101,6 +101,17 @@ namespace Savedrake.App.ViewModels
 
         public bool ConfigEditable => !AutobackupEnabled;
 
+        // The shipped version shown by the wordmark, from the assembly version (single source of truth, drives the
+        // update check too) — so a version bump updates the UI automatically instead of via a hardcoded string.
+        public string AppVersion
+        {
+            get
+            {
+                Version v = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
+                return v != null ? v.Major + "." + v.Minor + "." + v.Build : "1.4.0";
+            }
+        }
+
         // ----- Backups list -----
 
         public ObservableCollection<BackupRow> Backups { get; } = new ObservableCollection<BackupRow>();

--- a/Savedrake.sln
+++ b/Savedrake.sln
@@ -3,8 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Savedrake", "Savedrake v1.2.3\Savedrake.csproj", "{890F37B1-D5E4-4375-8790-D94BC4DCED9F}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Savedrake-Updater", "updater\Savedrake-Updater.csproj", "{4593632F-D6F1-425C-83B4-6B70FA3092A4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RestoreHarness", "RestoreHarness\RestoreHarness.csproj", "{097EDA73-C89A-4DC7-A5F2-0A79CBD658FD}"
@@ -19,10 +17,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{890F37B1-D5E4-4375-8790-D94BC4DCED9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{890F37B1-D5E4-4375-8790-D94BC4DCED9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{890F37B1-D5E4-4375-8790-D94BC4DCED9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{890F37B1-D5E4-4375-8790-D94BC4DCED9F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4593632F-D6F1-425C-83B4-6B70FA3092A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4593632F-D6F1-425C-83B4-6B70FA3092A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4593632F-D6F1-425C-83B4-6B70FA3092A4}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
## Phase 7 — cutover

The WPF app is feature-complete and parity-verified (Phases 0–6), so this makes it **the** Savedrake.

- **Harness independence:** `RestoreHarness` no longer loads the WinForms `Savedrake.exe`. Its `SM`/`IM` reflection helpers were already dead (every test exercises Core), so it now binds Core via the **compile-time reference** (`typeof(RestoreEngine).Assembly`) and finds the feedback wavs next to `Savedrake.App.exe`. Runs with no args. **263 → 261** (the two dropped assertions were the WinForms-dir wav checks; the App-dir checks remain).
- **Solution:** drops the `Savedrake` WinForms project — the solution now builds only `Savedrake.Core` + `Savedrake.App` + `Savedrake-Updater` + `RestoreHarness`. The WinForms project **files are kept** in the repo as history (no longer built/shipped).
- **CI (`build.yml`):** the harness step drops the WinForms-bin argument; the Release artifact is now `Savedrake.App/bin/Release` (+ the updater).
- **Version unify:** the header wordmark binds to the **assembly version** (1.4.0) instead of a hardcoded string — a future bump updates the UI + the update check from one place.

### Verification
- Solution builds clean **without WinForms** (Debug + Release). Harness **261/0**.
- The app launches post-cutover showing "Savedrake **1.4.0**" from the bound assembly version.

> The actual GitHub release (public artifact) is left for an explicit go-ahead. Next: package the distributable + a final adversarial review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)