### PR TITLE
WPF: address all 8 final-review findings (2 medium + 6 low)

### DIFF
--- a/Savedrake.App/AutobackupController.cs
+++ b/Savedrake.App/AutobackupController.cs
@@ -136,11 +136,13 @@ namespace Savedrake.App
         {
             try
             {
-                WindowsIdentity currentUser = WindowsIdentity.GetCurrent();
+                string userSid;
+                using (WindowsIdentity currentUser = WindowsIdentity.GetCurrent())
+                    userSid = currentUser.User.Value;
                 string keyPath = @"Software\Valve\Steam\Apps\" + GameDetect.Dd2SteamAppId;
                 var query = new WqlEventQuery(string.Format(
                     "SELECT * FROM RegistryValueChangeEvent WHERE Hive='HKEY_USERS' AND KeyPath='{0}\\\\{1}' AND ValueName='Running'",
-                    currentUser.User.Value, keyPath.Replace("\\", "\\\\")));
+                    userSid, keyPath.Replace("\\", "\\\\")));
                 _gameWatcher = new ManagementEventWatcher(query);
                 _gameWatcher.EventArrived += OnGameRegistryChanged;
                 _gameWatcher.Start();

--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -251,7 +251,8 @@
                                 <Button Content="Back up now" Style="{StaticResource PrimaryButton}"
                                         Padding="14,7" Command="{Binding BackupCommand}" />
                                 <Button Content="Restore" Style="{StaticResource OutlineButton}"
-                                        Padding="14,7" Margin="8,0,0,0" Command="{Binding RestoreCommand}" />
+                                        Padding="14,7" Margin="8,0,0,0" Command="{Binding RestoreCommand}"
+                                        CommandParameter="{Binding SelectedItems, ElementName=BackupList}" />
                                 <Button Content="Delete" Style="{StaticResource DangerButton}"
                                         Padding="14,7" Margin="8,0,0,0" Command="{Binding DeleteCommand}"
                                         CommandParameter="{Binding SelectedItems, ElementName=BackupList}" />

--- a/Savedrake.App/MainWindow.xaml.cs
+++ b/Savedrake.App/MainWindow.xaml.cs
@@ -37,6 +37,7 @@ namespace Savedrake.App
 
         // The system-tray icon (WinForms NotifyIcon; UseWindowsForms is on). Only visible while minimized-to-tray.
         private System.Windows.Forms.NotifyIcon _tray;
+        private System.Drawing.Icon _trayIcon; // NotifyIcon doesn't own its Icon, so we dispose it ourselves
 
         public MainWindow()
         {
@@ -127,7 +128,7 @@ namespace Savedrake.App
             try
             {
                 var res = System.Windows.Application.GetResourceStream(new Uri("pack://application:,,,/savedrake.ico"));
-                if (res != null) using (var stream = res.Stream) _tray.Icon = new System.Drawing.Icon(stream);
+                if (res != null) using (var stream = res.Stream) { _trayIcon = new System.Drawing.Icon(stream); _tray.Icon = _trayIcon; }
             }
             catch { /* no icon -> NotifyIcon just won't show; non-fatal */ }
 
@@ -168,7 +169,8 @@ namespace Savedrake.App
         {
             UnregisterCurrentHotkey();
             try { _hwndSource?.RemoveHook(WndProc); } catch { }
-            try { if (_tray != null) { _tray.Visible = false; _tray.Dispose(); _tray = null; } } catch { }
+            try { if (_tray != null) { _tray.Visible = false; _tray.Icon = null; _tray.Dispose(); _tray = null; } } catch { }
+            try { if (_trayIcon != null) { _trayIcon.Dispose(); _trayIcon = null; } } catch { }
             // Persist the window size for next launch (RestoreBounds is the normal-state size even if minimized/maximized).
             if (DataContext is Savedrake.App.ViewModels.MainViewModel vm)
             {
@@ -195,7 +197,8 @@ namespace Savedrake.App
             }
             MessageBox.Show("Reset successful. Savedrake will now close.", "Reset Savedrake",
                 MessageBoxButton.OK, MessageBoxImage.Information);
-            try { if (_tray != null) { _tray.Visible = false; _tray.Dispose(); _tray = null; } } catch { }
+            try { if (_tray != null) { _tray.Visible = false; _tray.Icon = null; _tray.Dispose(); _tray = null; } } catch { }
+            try { if (_trayIcon != null) { _trayIcon.Dispose(); _trayIcon = null; } } catch { }
             Environment.Exit(0); // NOT Close() — that would run OnClosed -> SaveWindowSize and re-create the file
         }
 
@@ -266,6 +269,9 @@ namespace Savedrake.App
             ThemeManager.Apply(light);
             vm.SetTheme(light);
             ApplyDwmTheming();
+            // Rebuild the backup rows so their converter-painted dot/pill/name colours re-resolve against the new
+            // palette (the converters resolve concrete brush instances, so they don't follow the live brush swap).
+            vm.RefreshBackups();
         }
 
         // Open a header button's dropdown (File / Help) as a menu anchored under the button.

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -419,6 +419,16 @@ namespace Savedrake.App.ViewModels
         partial void OnCleanupEnabledChanged(bool value)
         {
             if (!_loaded) return;
+            // Turning automatic cleanup ON enables automatic removal of old autobackups, so ask first (parity with the
+            // shipped app). The revert re-enters with value=false, which persists and skips this confirm.
+            if (value && !_dialog.Confirm("Automatically clean up old autobackups",
+                    "Savedrake will keep your recent autobackups and a spread of older ones, then remove the extra " +
+                    "older autobackups so they don't pile up. Your manual backups and pinned backups are never " +
+                    "removed.\n\nTurn this on?"))
+            {
+                CleanupEnabled = false;
+                return;
+            }
             if (!value && RecycleEnabled) RecycleEnabled = false; // recycle only applies when cleanup is on
             SaveSettings();
         }
@@ -550,6 +560,13 @@ namespace Savedrake.App.ViewModels
                 _dialog.Error("Save location", "Your save folder can't be the same as your backup folder.");
                 return;
             }
+            // Advisory (parity): warn when the chosen folder isn't the default DD2 save layout. Not blocking — the
+            // backup itself still guards on real save data.
+            string p = picked.TrimEnd('\\', '/');
+            if (!p.EndsWith(@"\2054970\remote\win64_save", StringComparison.OrdinalIgnoreCase) &&
+                !_dialog.Confirm("Non-Default Path Selected",
+                    "The selected folder is not the default Dragon's Dogma 2 save folder (see Help). Use this folder anyway?"))
+                return;
             SaveDir = picked;
             SaveSettings();
             RefreshBackups();
@@ -593,23 +610,34 @@ namespace Savedrake.App.ViewModels
         private void Backup()
         {
             if (_isOperationInProgress) { _status.Set("Please wait, another operation is already running."); return; }
+            BackupResult result = null;
             _isOperationInProgress = true;
             try
             {
-                BackupResult r = BackupService.Backup(
+                result = BackupService.Backup(
                     new BackupRequest { LiveSaveDir = SaveDir, BackupDir = BackupDir, IsAutoBackup = false, RandomName = UseRandomName },
                     _dialog, _status);
-                if (r.Ok) _sound.Success(); else _sound.Error();
+                if (result.Ok) _sound.Success(); else _sound.Error();
             }
             finally { _isOperationInProgress = false; }
 
-            _autobackup.NotifyExternalBackup(); // advance the change-aware baseline so autobackup doesn't re-capture
+            // Advance the change-aware baseline ONLY on a successful backup (mirrors the WinForms reference, which set
+            // _lastAutoBackupFingerprint after the atomic publish, and matches the restore path). Advancing it on a
+            // FAILED manual backup would make the next autobackup tick skip the un-backed-up save, leaving recent
+            // progress unprotected until the next in-game save.
+            if (result != null && result.Ok) _autobackup.NotifyExternalBackup();
             RefreshBackups();
         }
 
         [RelayCommand]
-        private void Restore()
+        private void Restore(System.Collections.IList selected)
         {
+            // Restore is single-backup; with multi-select on, refuse rather than silently restoring the anchor.
+            if (selected != null && selected.Count > 1)
+            {
+                _dialog.Warn("Restore", "Please select only one backup to restore at a time.");
+                return;
+            }
             if (SelectedBackup == null)
             {
                 _dialog.Warn("Restore", "Please select a backup to restore first.");
@@ -775,8 +803,10 @@ namespace Savedrake.App.ViewModels
             _status.Set("Backup hotkey cleared.");
         }
 
+        // Case-insensitive so a WinForms-saved hotkey whose Keys enum name differs only in casing from the WPF Key
+        // enum (e.g. "Oemplus" -> Key.OemPlus, "Oemcomma" -> Key.OemComma) still round-trips on the first WPF launch.
         private static int KeyNameToVk(string name)
-            => !string.IsNullOrWhiteSpace(name) && System.Enum.TryParse(name, out System.Windows.Input.Key k)
+            => !string.IsNullOrWhiteSpace(name) && System.Enum.TryParse(name, true, out System.Windows.Input.Key k)
                ? System.Windows.Input.KeyInterop.VirtualKeyFromKey(k) : 0;
 
         private static string VkToKeyName(int vk)


### PR DESCRIPTION
## Final-review fixes — publish-readiness polish

A 6-dimension multi-agent adversarial review (threading/lifecycle, data-safety, persistence, resource/exception, UI/binding/theme, parity), 2-skeptic verified, judged the WPF app **publish-ready with no blockers**. This PR folds in all 8 confirmed findings.

### Medium
- **Failed manual backup wrongly advanced the autobackup baseline** — `Backup()` called `NotifyExternalBackup()` unconditionally, so a *failed* backup would make the next change-aware autobackup tick skip the un-backed-up save, leaving recent progress unprotected. Now gated on `result.Ok` (mirrors the WinForms reference + the restore path). **Same class as the earlier restore-baseline fix.**
- **Stale backup-row colours after a runtime theme swap** — the row converters resolve concrete brush instances, not the live-swapped brushes, so dot/name/pill colours didn't follow a light↔dark toggle. `ToggleTheme_Click` now calls `RefreshBackups()` to re-resolve them.

### Low / hygiene / parity
- A WinForms-saved **Oemplus/Oemcomma** hotkey was silently dropped on first WPF launch (case-sensitive `Enum.TryParse`); now case-insensitive so the binding round-trips.
- **`WindowsIdentity`** (game watcher) and the **tray HICON** are now disposed (were one-shot lifetime handle leaks).
- **Multi-select Restore** now refuses with a clear message instead of silently restoring the anchor.
- Enabling **automatic cleanup** asks for confirmation again (parity).
- **Browse-save** re-adds the one-time non-default-save-folder advisory (parity).

### Verification
- **WinForms + Core untouched.** Release + Debug build clean. Harness **261/0**. App launches clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)