### PR TITLE
WPF: output Savedrake.exe (drop-in for the retired WinForms exe + auto-update continuity)

### DIFF
--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -991,7 +991,7 @@ namespace RestoreHarness
             Console.WriteLine();
         }
 
-        // Locate the built Savedrake.App.exe output so the sound-asset test can confirm the WPF app ships the wavs.
+        // Locate the built WPF app output (now Savedrake.exe) so the sound-asset test can confirm the wavs ship.
         // Returns null if the App hasn't been built.
         static string ResolveAppBin()
         {
@@ -999,7 +999,7 @@ namespace RestoreHarness
             foreach (string cfg in new[] { "Release", "Debug" })
             {
                 string p = Path.GetFullPath(Path.Combine(baseDir, "..", "..", "Savedrake.App", "bin", cfg));
-                if (File.Exists(Path.Combine(p, "Savedrake.App.exe"))) return p;
+                if (File.Exists(Path.Combine(p, "Savedrake.exe"))) return p; // WPF app builds Savedrake.exe post-rename
             }
             return null;
         }

--- a/Savedrake.App/Savedrake.App.csproj
+++ b/Savedrake.App/Savedrake.App.csproj
@@ -15,7 +15,11 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <LangVersion>8.0</LangVersion>
-    <AssemblyName>Savedrake.App</AssemblyName>
+    <!-- Output exe is Savedrake.exe (not Savedrake.App.exe): the WPF app is now a drop-in replacement for the retired
+         WinForms Savedrake.exe, so the external Savedrake-Updater.exe (which targets/launches "Savedrake.exe") and an
+         auto-update from an existing v1.3.0 install land the WPF app correctly. The code namespace stays Savedrake.App
+         (RootNamespace), which is independent of the output exe name. -->
+    <AssemblyName>Savedrake</AssemblyName>
     <RootNamespace>Savedrake.App</RootNamespace>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <ApplicationIcon>savedrake.ico</ApplicationIcon>


### PR DESCRIPTION
## Output `Savedrake.exe` — drop-in replacement + auto-update continuity

Renames the WPF app's output from `Savedrake.App.exe` → **`Savedrake.exe`** (`AssemblyName` only; the code namespace stays `Savedrake.App` via `RootNamespace`). This closes the one gap I'd flagged as needing a decision: the external updater targets `Savedrake.exe`, so without this an auto-update from an existing **v1.3.0** install would replace the wrong file.

With the rename:
- The external **`Savedrake-Updater.exe`** — which resolves/launches `Savedrake.exe`, verifies `update.zip` contains a `Savedrake.exe` entry, then extracts every non-skipped file over the install — updates an existing v1.3.0 install **straight onto the WPF app**. It needs **no change** (it already extracts the full package, so the new WPF dependencies land).
- Shortcuts / file associations / muscle memory pointing at `Savedrake.exe` keep working.
- `RestoreHarness.ResolveAppBin` now looks for `Savedrake.exe`.

### Verification
- **WinForms + Core untouched.** Release + Debug build produce `Savedrake.exe` (+ `Savedrake.exe.config`). Harness **261/0**.
- The built `Savedrake.exe` **launches clean** — BAML / pack-URI resources resolve correctly under the new assembly name (window title "Savedrake"), so the rename didn't break resource loading.
- A **clean-extract package** containing `Savedrake.exe` launches self-contained.

> The actual release packaging (an `update.zip` carrying the WPF dependency set) + the public release remain owner-gated; this is the code prerequisite that makes them correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)