### PR TITLE
fix(wpf): single scrollbar + collapsible config cards

### DIFF
--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -22,6 +22,8 @@
     </WindowChrome.WindowChrome>
 
     <Window.Resources>
+        <!-- Folds the collapsible card bodies (Folders / Autobackup) on a bool. -->
+        <BooleanToVisibilityConverter x:Key="BoolToVis" />
         <!-- Display-only converters for the Backups list rows. -->
         <vm:PinnedToBrushConverter x:Key="PinDotBrush" OnKey="AccentGoldBrush" OffKey="TextSecondaryBrush" />
         <vm:PinnedToBrushConverter x:Key="PinNameBrush" OnKey="AccentGoldBrush" OffKey="TextBrush" />
@@ -139,61 +141,82 @@
         <!-- 1px gold hairline under the header. -->
         <Border Grid.Row="1" Height="1" Background="{DynamicResource GoldRuleBrush}" />
 
-        <!-- ============================ CONTENT: three cards ============================ -->
-        <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" Padding="0,12,0,0">
-            <StackPanel>
+        <!-- ============================ CONTENT: config cards + backup list ============================ -->
+        <!-- A fixed 3-row grid (not a scrolling stack): the two config cards size to content, and the Backups list fills
+             the rest as the single scroll region. This avoids the nested-scrollbar problem (an outer ScrollViewer plus
+             the ListView's own scrollbar would show two bars side by side). The config cards fold away (carets) to give
+             the list more room. -->
+        <Grid Grid.Row="2" Margin="0,12,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />   <!-- Folders (collapsible) -->
+                <RowDefinition Height="Auto" />   <!-- Autobackup (collapsible) -->
+                <RowDefinition Height="*" />      <!-- Backups list: fills, the only scroll region -->
+            </Grid.RowDefinitions>
 
-                <!-- Folders -->
-                <Border Style="{StaticResource CardBorder}">
-                    <StackPanel>
-                        <TextBlock Text="Folders" Style="{StaticResource SectionTitle}" />
+            <!-- Folders -->
+            <Border Grid.Row="0" Style="{StaticResource CardBorder}">
+                <StackPanel>
+                    <Button Style="{StaticResource CardHeaderToggle}" Command="{Binding ToggleFoldersCommand}"
+                            ToolTip="Show or hide the folder paths">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{Binding FoldersCaret}" Style="{StaticResource SectionCaret}" />
+                            <TextBlock Text="Folders" Style="{StaticResource SectionTitle}" Margin="6,0,0,0" />
+                        </StackPanel>
+                    </Button>
 
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="90" />    <!-- label -->
-                                <ColumnDefinition Width="*" />     <!-- path box -->
-                                <ColumnDefinition Width="Auto" />  <!-- count -->
-                                <ColumnDefinition Width="Auto" />  <!-- browse -->
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="8" />
-                                <RowDefinition Height="Auto" />
-                            </Grid.RowDefinitions>
+                    <Grid Visibility="{Binding FoldersExpanded, Converter={StaticResource BoolToVis}}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="90" />    <!-- label -->
+                            <ColumnDefinition Width="*" />     <!-- path box -->
+                            <ColumnDefinition Width="Auto" />  <!-- count -->
+                            <ColumnDefinition Width="Auto" />  <!-- browse -->
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="8" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
 
-                            <!-- Save game row -->
-                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Save game" VerticalAlignment="Center"
-                                       FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
-                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding SaveDir}" IsReadOnly="True"
-                                     VerticalContentAlignment="Center" Padding="8,6" FontSize="12"
-                                     Background="{DynamicResource InputBrush}" Foreground="{DynamicResource TextBrush}"
-                                     BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" />
-                            <Button Grid.Row="0" Grid.Column="3" Content="Browse" Style="{StaticResource OutlineButton}"
-                                    Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseSaveCommand}"
-                                    IsEnabled="{Binding ConfigEditable}" />
+                        <!-- Save game row -->
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Save game" VerticalAlignment="Center"
+                                   FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
+                        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding SaveDir}" IsReadOnly="True"
+                                 VerticalContentAlignment="Center" Padding="8,6" FontSize="12"
+                                 Background="{DynamicResource InputBrush}" Foreground="{DynamicResource TextBrush}"
+                                 BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" />
+                        <Button Grid.Row="0" Grid.Column="3" Content="Browse" Style="{StaticResource OutlineButton}"
+                                Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseSaveCommand}"
+                                IsEnabled="{Binding ConfigEditable}" />
 
-                            <!-- Backups row -->
-                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Backups" VerticalAlignment="Center"
-                                       FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
-                            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding BackupDir}" IsReadOnly="True"
-                                     VerticalContentAlignment="Center" Padding="8,6" FontSize="12"
-                                     Background="{DynamicResource InputBrush}" Foreground="{DynamicResource TextBrush}"
-                                     BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" />
-                            <TextBlock Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" Margin="10,0,0,0"
-                                       FontSize="12" Foreground="{DynamicResource TextHintBrush}"
-                                       Text="{Binding BackupCount, StringFormat={}{0} backups}" />
-                            <Button Grid.Row="2" Grid.Column="3" Content="Browse" Style="{StaticResource OutlineButton}"
-                                    Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseBackupCommand}"
-                                    IsEnabled="{Binding ConfigEditable}" />
-                        </Grid>
-                    </StackPanel>
-                </Border>
+                        <!-- Backups row -->
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Backups" VerticalAlignment="Center"
+                                   FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
+                        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding BackupDir}" IsReadOnly="True"
+                                 VerticalContentAlignment="Center" Padding="8,6" FontSize="12"
+                                 Background="{DynamicResource InputBrush}" Foreground="{DynamicResource TextBrush}"
+                                 BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" />
+                        <TextBlock Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" Margin="10,0,0,0"
+                                   FontSize="12" Foreground="{DynamicResource TextHintBrush}"
+                                   Text="{Binding BackupCount, StringFormat={}{0} backups}" />
+                        <Button Grid.Row="2" Grid.Column="3" Content="Browse" Style="{StaticResource OutlineButton}"
+                                Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseBackupCommand}"
+                                IsEnabled="{Binding ConfigEditable}" />
+                    </Grid>
+                </StackPanel>
+            </Border>
 
-                <!-- Autobackup -->
-                <Border Style="{StaticResource CardBorder}">
-                    <StackPanel>
-                        <TextBlock Text="Autobackup" Style="{StaticResource SectionTitle}" />
+            <!-- Autobackup -->
+            <Border Grid.Row="1" Style="{StaticResource CardBorder}">
+                <StackPanel>
+                    <Button Style="{StaticResource CardHeaderToggle}" Command="{Binding ToggleAutobackupSectionCommand}"
+                            ToolTip="Show or hide the autobackup settings">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{Binding AutobackupSectionCaret}" Style="{StaticResource SectionCaret}" />
+                            <TextBlock Text="Autobackup" Style="{StaticResource SectionTitle}" Margin="6,0,0,0" />
+                        </StackPanel>
+                    </Button>
 
+                    <StackPanel Visibility="{Binding AutobackupSectionExpanded, Converter={StaticResource BoolToVis}}">
                         <CheckBox Content="Back up automatically while Dragon's Dogma 2 is running"
                                   IsChecked="{Binding AutobackupEnabled}" Margin="0,2,0,0" />
 
@@ -234,42 +257,50 @@
                         <CheckBox Content="Also back up the instant the game saves"
                                   IsChecked="{Binding BackupOnSaveEnabled}" Margin="0,12,0,0" />
                     </StackPanel>
-                </Border>
+                </StackPanel>
+            </Border>
 
-                <!-- Backups -->
-                <Border Style="{StaticResource CardBorder}">
-                    <StackPanel>
-                        <!-- Header row: title on the left, actions on the right. -->
-                        <Grid Margin="0,0,0,10">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" Text="Backups" Style="{StaticResource SectionTitle}"
-                                       Margin="0" VerticalAlignment="Center" />
-                            <StackPanel Grid.Column="1" Orientation="Horizontal">
-                                <Button Content="Back up now" Style="{StaticResource PrimaryButton}"
-                                        Padding="14,7" Command="{Binding BackupCommand}" />
-                                <Button Content="Restore" Style="{StaticResource OutlineButton}"
-                                        Padding="14,7" Margin="8,0,0,0" Command="{Binding RestoreCommand}"
-                                        CommandParameter="{Binding SelectedItems, ElementName=BackupList}" />
-                                <Button Content="Delete" Style="{StaticResource DangerButton}"
-                                        Padding="14,7" Margin="8,0,0,0" Command="{Binding DeleteCommand}"
-                                        CommandParameter="{Binding SelectedItems, ElementName=BackupList}" />
-                            </StackPanel>
-                        </Grid>
+            <!-- Backups: the Border fills the remaining row; an inner grid lets the list (row 1) take all leftover
+                 height so the ListView's own scrollbar is the single scroll region. -->
+            <Border Grid.Row="2" Style="{StaticResource CardBorder}" Margin="0">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />   <!-- header row -->
+                        <RowDefinition Height="*" />      <!-- list fills the card -->
+                    </Grid.RowDefinitions>
 
-                        <!-- Backup list: dark, header-less, custom row template. Multi-select for delete. -->
-                        <ListView x:Name="BackupList" ItemsSource="{Binding Backups}"
-                                  SelectedItem="{Binding SelectedBackup, Mode=TwoWay}"
-                                  SelectionMode="Extended"
-                                  KeyDown="BackupList_KeyDown"
-                                  MouseDoubleClick="BackupList_MouseDoubleClick"
-                                  Background="{DynamicResource CardBrush}"
-                                  BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
-                                  Foreground="{DynamicResource TextBrush}"
-                                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                                  MinHeight="180" MaxHeight="320">
+                    <!-- Header row: title on the left, actions on the right. -->
+                    <Grid Grid.Row="0" Margin="0,0,0,10">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="Backups" Style="{StaticResource SectionTitle}"
+                                   Margin="0" VerticalAlignment="Center" />
+                        <StackPanel Grid.Column="1" Orientation="Horizontal">
+                            <Button Content="Back up now" Style="{StaticResource PrimaryButton}"
+                                    Padding="14,7" Command="{Binding BackupCommand}" />
+                            <Button Content="Restore" Style="{StaticResource OutlineButton}"
+                                    Padding="14,7" Margin="8,0,0,0" Command="{Binding RestoreCommand}"
+                                    CommandParameter="{Binding SelectedItems, ElementName=BackupList}" />
+                            <Button Content="Delete" Style="{StaticResource DangerButton}"
+                                    Padding="14,7" Margin="8,0,0,0" Command="{Binding DeleteCommand}"
+                                    CommandParameter="{Binding SelectedItems, ElementName=BackupList}" />
+                        </StackPanel>
+                    </Grid>
+
+                    <!-- Backup list: dark, header-less, custom row template. Multi-select for delete. Fills row 1; its
+                         own vertical scrollbar appears only when the rows overflow (no MinHeight/MaxHeight: the grid
+                         row drives the height). -->
+                    <ListView Grid.Row="1" x:Name="BackupList" ItemsSource="{Binding Backups}"
+                              SelectedItem="{Binding SelectedBackup, Mode=TwoWay}"
+                              SelectionMode="Extended"
+                              KeyDown="BackupList_KeyDown"
+                              MouseDoubleClick="BackupList_MouseDoubleClick"
+                              Background="{DynamicResource CardBrush}"
+                              BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
+                              Foreground="{DynamicResource TextBrush}"
+                              ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                             <ListView.Resources>
                                 <!-- No column headers: this is a single-template list, not a grid. -->
                                 <Style TargetType="GridViewColumnHeader">
@@ -378,11 +409,9 @@
                                 </DataTemplate>
                             </ListView.ItemTemplate>
                         </ListView>
-                    </StackPanel>
-                </Border>
-
-            </StackPanel>
-        </ScrollViewer>
+                </Grid>
+            </Border>
+        </Grid>
 
         <!-- ============================ STATUS BAR ============================ -->
         <Border Grid.Row="3" Background="{DynamicResource BarBrush}" CornerRadius="0,0,10,10" Padding="14,7">

--- a/Savedrake.App/Themes/Dark.xaml
+++ b/Savedrake.App/Themes/Dark.xaml
@@ -77,6 +77,44 @@
         <Setter Property="Margin" Value="0,0,0,8" />
     </Style>
 
+    <!-- Clickable card heading that folds the card body. Flat and transparent so it reads as the section title, with a
+         faint hover so it's discoverably clickable. Left-aligned, full-width; negative margins cancel the button's own
+         padding so the title sits exactly where a plain SectionTitle would. -->
+    <Style x:Key="CardHeaderToggle" TargetType="Button">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="Padding" Value="4,3" />
+        <Setter Property="Margin" Value="-4,-3,-4,5" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="bd" Background="{TemplateBinding Background}" CornerRadius="6"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter HorizontalAlignment="Left" VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource CardAltBrush}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- The fold caret (▾ open / ▸ closed) to the left of a collapsible card title. -->
+    <Style x:Key="SectionCaret" TargetType="TextBlock">
+        <Setter Property="Foreground" Value="{DynamicResource AccentGoldBrush}" />
+        <Setter Property="FontSize" Value="11" />
+        <Setter Property="Width" Value="14" />
+        <Setter Property="TextAlignment" Value="Center" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+
     <!-- Faint placeholder line for the empty card bodies in this shell. -->
     <Style x:Key="CardPlaceholder" TargetType="TextBlock">
         <Setter Property="FontSize" Value="13" />

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -71,6 +71,21 @@ namespace Savedrake.App.ViewModels
         [ObservableProperty]
         private bool backupOnSaveEnabled;
 
+        // ----- Collapsible config sections -----
+        // The Folders and Autobackup cards fold to just their title so the Backups list (the thing you actually work
+        // with) can fill the window. Default expanded so a first run shows everything; the choice is persisted. The
+        // caret string flips between "open" (▾) and "closed" (▸) for the clickable header.
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(FoldersCaret))]
+        private bool foldersExpanded = true;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(AutobackupSectionCaret))]
+        private bool autobackupSectionExpanded = true;
+
+        public string FoldersCaret => FoldersExpanded ? "▾" : "▸";
+        public string AutobackupSectionCaret => AutobackupSectionExpanded ? "▾" : "▸";
+
         // When on, minimizing hides the window to the system tray instead of the taskbar (persisted as CheckboxTray).
         [ObservableProperty]
         private bool minimizeToTray;
@@ -250,6 +265,8 @@ namespace Savedrake.App.ViewModels
                 IsLightTheme = string.Equals((string)root.Element("ThemeMode"), "Light", StringComparison.OrdinalIgnoreCase);
                 WindowWidth = ParseIntOr(root.Element("WindowWidth"), 0);
                 WindowHeight = ParseIntOr(root.Element("WindowHeight"), 0);
+                FoldersExpanded = ParseBoolOr(root.Element("FoldersExpanded"), true);
+                AutobackupSectionExpanded = ParseBoolOr(root.Element("AutobackupSectionExpanded"), true);
 
                 // Backup hotkey (nested <Hotkey> block + CheckboxHot), shared with the WinForms shape.
                 var hk = root.Element("Hotkey");
@@ -270,6 +287,11 @@ namespace Savedrake.App.ViewModels
 
         private static bool ParseBool(System.Xml.Linq.XElement el)
             => el != null && bool.TryParse(el.Value, out bool b) && b;
+
+        // Like ParseBool but returns the given default when the element is missing or unparseable (so a setting that
+        // defaults to true, e.g. a card starting expanded, is not forced false just by being absent on first run).
+        private static bool ParseBoolOr(System.Xml.Linq.XElement el, bool fallback)
+            => (el != null && bool.TryParse(el.Value, out bool b)) ? b : fallback;
 
         private static int ParseIntOr(System.Xml.Linq.XElement el, int fallback)
             => (el != null && int.TryParse(el.Value, out int n)) ? n : fallback;
@@ -309,6 +331,8 @@ namespace Savedrake.App.ViewModels
                 SetElement(root, "ThemeMode", IsLightTheme ? "Light" : "Dark");
                 if (WindowWidth > 0) SetElement(root, "WindowWidth", WindowWidth.ToString());
                 if (WindowHeight > 0) SetElement(root, "WindowHeight", WindowHeight.ToString());
+                SetElement(root, "FoldersExpanded", FoldersExpanded.ToString());
+                SetElement(root, "AutobackupSectionExpanded", AutobackupSectionExpanded.ToString());
 
                 // Backup hotkey (nested <Hotkey> block + CheckboxHot + the display string in Textbox3).
                 var hk = root.Element("Hotkey");
@@ -829,6 +853,10 @@ namespace Savedrake.App.ViewModels
 
         [RelayCommand] private void NameFormatRandom() => UseRandomName = true;
         [RelayCommand] private void NameFormatTimestamp() => UseRandomName = false;
+
+        // Fold / unfold the two config cards (persisted so the choice sticks across launches).
+        [RelayCommand] private void ToggleFolders() { FoldersExpanded = !FoldersExpanded; if (_loaded) SaveSettings(); }
+        [RelayCommand] private void ToggleAutobackupSection() { AutobackupSectionExpanded = !AutobackupSectionExpanded; if (_loaded) SaveSettings(); }
 
         // Persist the window size (called by the window on close so the next launch restores it).
         public void SaveWindowSize(int width, int height)


### PR DESCRIPTION
## What

Manual testing surfaced two UI issues, both fixed here.

### 1. Double scrollbar
The content area nested two vertical scroll regions: an outer `ScrollViewer` around all three cards, plus the Backups `ListView`'s own scrollbar (it had a fixed `MaxHeight`). A long backup list in a short window showed **both bars side by side** in the middle of the window.

**Fix:** replace the outer `ScrollViewer` with a fixed 3-row grid. The Folders and Autobackup cards size to content; the Backups list fills the remaining row as the **single scroll region** (its own scrollbar appears only when rows overflow).

### 2. Collapsible config cards (more room when needed)
The Folders and Autobackup cards now fold to just their title via a gold caret (▾ open / ▸ closed). Collapse them to hand the space to the backup list — a focus view for browsing/restoring. The expanded/collapsed choice **persists across launches** (`FoldersExpanded` / `AutobackupSectionExpanded` in settings).

## Files
- `MainWindow.xaml` — 3-row content grid; list fills + single scrollbar; collapsible card headers.
- `Themes/Dark.xaml` — `CardHeaderToggle` + `SectionCaret` styles.
- `ViewModels/MainViewModel.cs` — `FoldersExpanded` / `AutobackupSectionExpanded` + toggle commands + persistence.

## Verification
- Built Release (`Savedrake.exe`) and launched; window loads clean (valid XAML/BAML).
- No Core logic touched — harness unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)