### PR TITLE
feat(wpf): back up on game close + settle-before-capture gate

### DIFF
--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -101,6 +101,7 @@ namespace RestoreHarness
                 Test_AutobackupCountStore();   // Phase 5: forgiving read of the autobackup count file (missing/garbled -> 0)
                 Test_AutobackupCleanup();   // Phase 5: auto-thinning excludes manual/pre-restore/pinned, removes surplus autos
                 Test_GameDetect();   // Phase 5: DD2 running-state registry read returns a bool and never throws
+                Test_SaveReadiness();   // "back up after the save settles": defer while a save file is exclusively locked
                 Test_UpdateCheck();   // Phase 6i: update version parsing (strip v, 2-4 numeric parts) + comparison
             }
             catch (Exception ex)
@@ -939,6 +940,42 @@ namespace RestoreHarness
             try { result = GameDetect.IsDd2Running(); } catch { threw = true; }
             Check("IsDd2Running() does not throw on a box without DD2", !threw);
             Check("IsDd2Running() reports not-running when the key is absent", result == false);
+            Console.WriteLine();
+        }
+
+        static void Test_SaveReadiness()
+        {
+            // "back up only after the save settles": IsSaveSettled defers a capture while the game holds a save file
+            // open exclusively (mid-write), and reports settled once writing has finished / the file is shared.
+            Console.WriteLine("== save readiness (settled-before-capture gate) ==");
+            string dir = Path.Combine(work, "readiness_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+
+            Check("missing folder is not settled (nothing to capture yet)",
+                SaveReadiness.IsSaveSettled(Path.Combine(dir, "nope")) == false);
+            Check("empty existing folder is settled (no writes in flight)",
+                SaveReadiness.IsSaveSettled(dir) == true);
+
+            string save = Path.Combine(dir, "data0000.bin");
+            File.WriteAllBytes(save, new byte[] { 1, 2, 3, 4 });
+            Check("a normal closed save file is settled",
+                SaveReadiness.IsSaveSettled(dir) == true);
+
+            using (new FileStream(save, FileMode.Open, FileAccess.Write, FileShare.None))
+                Check("an exclusively-locked save (game mid-write) is NOT settled",
+                    SaveReadiness.IsSaveSettled(dir) == false);
+
+            Check("settled again once the lock is released",
+                SaveReadiness.IsSaveSettled(dir) == true);
+
+            // A handle the game keeps open but shares for reading is still readable, so we must not over-defer on it.
+            using (new FileStream(save, FileMode.Open, FileAccess.Write, FileShare.Read))
+                Check("a save file open WITH read-sharing is still settled (not over-deferred)",
+                    SaveReadiness.IsSaveSettled(dir) == true);
+
+            bool threw = false;
+            try { SaveReadiness.IsSaveSettled(null); } catch { threw = true; }
+            Check("IsSaveSettled(null) never throws", !threw);
             Console.WriteLine();
         }
 

--- a/Savedrake.App/AutobackupController.cs
+++ b/Savedrake.App/AutobackupController.cs
@@ -21,6 +21,7 @@ namespace Savedrake.App
         bool CleanupEnabled { get; }
         bool RecycleEnabled { get; }
         bool BackupOnSaveEnabled { get; }
+        bool BackupOnGameCloseEnabled { get; }  // take one final backup when DD2 exits (the safest capture moment)
         string CountFilePath { get; }
         string IntervalDisplay { get; }        // the interval as the user typed it, for status text ("30 minutes")
         bool IsOperationInProgress { get; }    // a manual backup/restore is mid-flight
@@ -197,22 +198,44 @@ namespace Savedrake.App
             }
             else
             {
+                // Game just closed: take one final, change-aware backup of the now fully-flushed save BEFORE tearing
+                // the timers down. This is the safest possible capture moment — the game has released the save file, so
+                // it is guaranteed fully written. It is the trigger every leading manager (GBM, Steam Cloud, GOG) uses
+                // by default. Gated on the user's opt-in and the change fingerprint, so it never duplicates a state the
+                // save watcher or the last interval tick already captured; runs with the running-gate bypassed
+                // precisely because the game is no longer running.
+                if (_host.BackupOnGameCloseEnabled)
+                    RunChangeAwareAutobackup(bypassChangeGate: false, onGameClose: true);
                 StopIntervalTimer();
                 StopSaveWatcher();
-                _host.Status.Set("Game not running. Autobackup paused.");
+                if (_host.AutobackupEnabled) // the on-close backup may have hit the limit and disabled the feature
+                    _host.Status.Set("Game not running. Autobackup paused.");
             }
         }
 
         // ----- one change-aware attempt (mirror of RunChangeAwareAutobackup) -----
 
-        private void RunChangeAwareAutobackup(bool bypassChangeGate = false)
+        private void RunChangeAwareAutobackup(bool bypassChangeGate = false, bool onGameClose = false)
         {
             if (_autoBackupInProgress) return;          // re-entrancy guard
             if (_host.IsOperationInProgress) return;    // a manual backup/restore is mid-flight
             _autoBackupInProgress = true;
             try
             {
-                bool running = GameDetect.IsDd2Running();
+                // Only ever capture a fully-written save. If the game still holds a save file open for writing
+                // (mid-save), defer to the next quiet window / interval tick rather than risk zipping a half-written
+                // file. BackupService also fails closed on a locked file and verifies every zip against a SHA-256
+                // manifest, so this is defence in depth — but it makes "back up only after the save settles" explicit
+                // and skips a pointless attempt mid-write. (At game close the file is already released, so this passes.)
+                if (!SaveReadiness.IsSaveSettled(_host.SaveDir))
+                {
+                    _host.Status.Set("Autobackup: the game is still saving, will retry shortly.");
+                    return;
+                }
+
+                // The game-close backup runs precisely because DD2 just exited, so the live running read is false here;
+                // force the running gate open for that one case (every other trigger requires the game to be running).
+                bool running = onGameClose || GameDetect.IsDd2Running();
                 int count = AutobackupCountStore.Read(_host.CountFilePath);
                 string currentFp = bypassChangeGate ? null : Fingerprint.ComputeSaveFingerprint(_host.SaveDir);
 

--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -256,6 +256,8 @@
                                   Margin="26,8,0,0" />
                         <CheckBox Content="Also back up the instant the game saves"
                                   IsChecked="{Binding BackupOnSaveEnabled}" Margin="0,12,0,0" />
+                        <CheckBox Content="Back up once more when I close the game"
+                                  IsChecked="{Binding BackupOnGameCloseEnabled}" Margin="0,8,0,0" />
                     </StackPanel>
                 </StackPanel>
             </Border>

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -71,6 +71,12 @@ namespace Savedrake.App.ViewModels
         [ObservableProperty]
         private bool backupOnSaveEnabled;
 
+        // Take one final backup when DD2 closes (the safest capture moment — the game has released the save file).
+        // Default on: it is the trigger every leading manager uses by default, and it is change-gated so it never
+        // duplicates a state already captured during the session.
+        [ObservableProperty]
+        private bool backupOnGameCloseEnabled = true;
+
         // ----- Collapsible config sections -----
         // The Folders and Autobackup cards fold to just their title so the Backups list (the thing you actually work
         // with) can fill the window. Default expanded so a first run shows everything; the choice is persisted. The
@@ -260,6 +266,7 @@ namespace Savedrake.App.ViewModels
                 CleanupEnabled = ParseBool(root.Element("AutoCleanupOldBackups"));
                 RecycleEnabled = CleanupEnabled && ParseBool(root.Element("RemovedToRecycleBin"));
                 BackupOnSaveEnabled = ParseBool(root.Element("BackupOnSaveChange"));
+                BackupOnGameCloseEnabled = ParseBoolOr(root.Element("BackupOnGameClose"), true);
                 MinimizeToTray = ParseBool(root.Element("CheckboxTray"));
                 UseRandomName = !ParseBool(root.Element("BackupFileName2")); // BackupFileName2 = time-stamped; default random
                 IsLightTheme = string.Equals((string)root.Element("ThemeMode"), "Light", StringComparison.OrdinalIgnoreCase);
@@ -325,6 +332,7 @@ namespace Savedrake.App.ViewModels
                 SetElement(root, "AutoCleanupOldBackups", CleanupEnabled.ToString());
                 SetElement(root, "RemovedToRecycleBin", RecycleEnabled.ToString());
                 SetElement(root, "BackupOnSaveChange", BackupOnSaveEnabled.ToString());
+                SetElement(root, "BackupOnGameClose", BackupOnGameCloseEnabled.ToString());
                 SetElement(root, "CheckboxTray", MinimizeToTray.ToString());
                 SetElement(root, "BackupFileName1", UseRandomName.ToString());
                 SetElement(root, "BackupFileName2", (!UseRandomName).ToString());
@@ -468,6 +476,13 @@ namespace Savedrake.App.ViewModels
             if (!_loaded) return;
             SaveSettings();
             _autobackup.OnBackupOnSaveChanged();
+        }
+
+        // No live controller call: this only changes what happens the next time DD2 closes, so persisting is enough.
+        partial void OnBackupOnGameCloseEnabledChanged(bool value)
+        {
+            if (!_loaded) return;
+            SaveSettings();
         }
 
         partial void OnMinimizeToTrayChanged(bool value)

--- a/Savedrake.Core/SaveReadiness.cs
+++ b/Savedrake.Core/SaveReadiness.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+
+namespace Savedrake
+{
+    // "Is the save safe to capture right now?" An autobackup must only ever zip a save the game has finished writing,
+    // never one it is in the middle of writing. The save watcher already debounces a burst of writes into one backup
+    // after a quiet window; this is the final gate immediately before the capture: if any save file is still held open
+    // for writing without sharing (the game mid-save), defer this round and let the next quiet window / interval tick
+    // (or the on-close backup) retry once the write has finished.
+    //
+    // Mechanism: try to open every file under the save folder for reading. We declare FileShare.ReadWrite, so the open
+    // succeeds whenever a read is actually possible — which is exactly the condition the zip step needs. If the game
+    // holds a file exclusively (FileShare.None, i.e. writing without sharing), the open throws and we report "not
+    // settled". A file the game merely keeps open but shares is still readable, so it counts as settled (we never
+    // over-defer just because a handle is open).
+    //
+    // Fail direction mirrors BackupService's "don't block a legitimate backup": a folder that can't be enumerated
+    // (a permission quirk on an unusual path) returns settled (true) — the backup path's own verify-on-create against
+    // the SHA-256 manifest is the backstop. A missing or absent folder returns false (nothing meaningful to capture
+    // yet). This method never throws.
+    public static class SaveReadiness
+    {
+        public static bool IsSaveSettled(string saveDir)
+        {
+            if (string.IsNullOrWhiteSpace(saveDir) || !Directory.Exists(saveDir)) return false;
+            try
+            {
+                foreach (string path in Directory.EnumerateFiles(saveDir, "*", SearchOption.AllDirectories))
+                {
+                    try
+                    {
+                        using (File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)) { }
+                    }
+                    catch (IOException) { return false; }           // locked / being written without sharing
+                    catch (UnauthorizedAccessException) { }         // a permission quirk, not a write lock — keep going
+                }
+                return true;
+            }
+            catch { return true; } // can't enumerate the folder — fail open, never block a legitimate backup
+        }
+    }
+}


### PR DESCRIPTION
## Why

Research into how leading save managers trigger backups (GBM, Ludusavi, Steam Cloud, GOG, GameSave Manager) showed the dominant, safest trigger is **on game close** — not real-time file-watching, not a timer. Savedrake had on-save, interval, on-start, and hotkey, but **not on-close**. This adds it, plus an explicit "only capture a fully-written save" gate that directly answers "back up after the game has saved so it doesn't corrupt."

## What

### 1. Back up on game close (the missing trigger)
When DD2 exits, the engine takes one final **change-aware** backup before tearing down the timers. The game has released the save file by then, so it's the safest capture moment. It's change-gated, so if the on-save watcher or last interval tick already captured that exact state it resolves to "no change" and writes nothing — never a duplicate. Runs with the running-gate bypassed precisely because the game just exited.

- New option **"Back up once more when I close the game"** in the Autobackup card, **default on**, persisted as `BackupOnGameClose`.
- `AutobackupController.OnGameStatusChanged` (game-stopped branch) now fires the on-close backup; `RunChangeAwareAutobackup` gains an `onGameClose` flag that forces the running gate open for that one case.

### 2. Settle-before-capture gate (`SaveReadiness.IsSaveSettled`)
Before any autobackup zips, it now checks the save is fully written: if the game still holds a save file open **exclusively** (mid-write), the round is **deferred** to the next quiet window / interval tick. A file the game merely keeps open *with read sharing* still counts as settled, so we never over-defer.

This is defence in depth — `BackupService` already fails closed on a locked file and verifies every zip against an in-zip SHA-256 manifest before publishing, and a backup only ever **reads** the live save (it can never corrupt it). The gate just makes "capture only a settled save" explicit and skips a pointless mid-write attempt.

## Trigger model after this PR
on game start (resume point) · on each in-game save (debounced + settled) · every N minutes (crash/power-loss net) · **on game close (final clean state)** · hotkey / manual. All change-aware, all multi-version retained. This is a superset of every tool surveyed.

## Tests
- New Core helper covered by **+7 harness assertions** (locked vs shared vs closed vs missing vs empty; null-safe). Full suite **268 passed, 0 failed**.
- Built Release; app launches clean with the new option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)