### PR TITLE
feat(wpf): first-run setup welcome (auto-detect, then main window)

### DIFF
--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -24,6 +24,8 @@
     <Window.Resources>
         <!-- Folds the collapsible card bodies (Folders / Autobackup) on a bool. -->
         <BooleanToVisibilityConverter x:Key="BoolToVis" />
+        <!-- Inverse of the above: hides the normal Folders card while the first-run welcome panel is showing. -->
+        <vm:InverseBoolToVisibilityConverter x:Key="NotBoolToVis" />
         <!-- Display-only converters for the Backups list rows. -->
         <vm:PinnedToBrushConverter x:Key="PinDotBrush" OnKey="AccentGoldBrush" OffKey="TextSecondaryBrush" />
         <vm:PinnedToBrushConverter x:Key="PinNameBrush" OnKey="AccentGoldBrush" OffKey="TextBrush" />
@@ -153,8 +155,9 @@
                 <RowDefinition Height="*" />      <!-- Backups list: fills, the only scroll region -->
             </Grid.RowDefinitions>
 
-            <!-- Folders -->
-            <Border Grid.Row="0" Style="{StaticResource CardBorder}">
+            <!-- Folders (hidden on first run, while the welcome panel below takes the row instead) -->
+            <Border Grid.Row="0" Style="{StaticResource CardBorder}"
+                    Visibility="{Binding NeedsSetup, Converter={StaticResource NotBoolToVis}}">
                 <StackPanel>
                     <Button Style="{StaticResource CardHeaderToggle}" Command="{Binding ToggleFoldersCommand}"
                             ToolTip="Show or hide the folder paths">
@@ -205,8 +208,64 @@
                 </StackPanel>
             </Border>
 
-            <!-- Autobackup -->
-            <Border Grid.Row="1" Style="{StaticResource CardBorder}">
+            <!-- First-run welcome (replaces the Folders card until both folders are set; reuses the existing
+                 Detect/Browse commands). Shown only when NeedsSetup is true; the cards below stay disabled until
+                 IsConfigured. -->
+            <Border Grid.Row="0" Style="{StaticResource CardBorder}"
+                    Visibility="{Binding NeedsSetup, Converter={StaticResource BoolToVis}}">
+                <StackPanel>
+                    <TextBlock Text="Welcome to Savedrake"
+                               FontFamily="Georgia, Times New Roman" FontSize="20"
+                               Foreground="{DynamicResource AccentGoldBrush}" Margin="0,2,0,6" />
+                    <TextBlock Text="Let's find your Dragon's Dogma 2 saves and pick a safe place to keep your backups. This only takes a moment."
+                               Foreground="{DynamicResource TextSecondaryBrush}" FontSize="13"
+                               TextWrapping="Wrap" Margin="0,0,0,16" />
+
+                    <TextBlock Text="1. Your save game folder" FontSize="13" FontWeight="SemiBold"
+                               Foreground="{DynamicResource TextBrush}" Margin="0,0,0,6" />
+                    <Grid Margin="0,0,0,14">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBox Grid.Column="0" Text="{Binding SaveDir}" IsReadOnly="True"
+                                 VerticalContentAlignment="Center" Padding="8,6" FontSize="12"
+                                 Background="{DynamicResource InputBrush}" Foreground="{DynamicResource TextBrush}"
+                                 BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" />
+                        <Button Grid.Column="1" Content="Find it for me" Style="{StaticResource PrimaryButton}"
+                                Padding="14,6" Margin="8,0,0,0" Command="{Binding DetectSaveFolderCommand}" />
+                        <Button Grid.Column="2" Content="Browse" Style="{StaticResource OutlineButton}"
+                                Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseSaveCommand}" />
+                    </Grid>
+
+                    <TextBlock Text="2. Where to keep your backups" FontSize="13" FontWeight="SemiBold"
+                               Foreground="{DynamicResource TextBrush}" Margin="0,0,0,6" />
+                    <Grid Margin="0,0,0,16">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBox Grid.Column="0" Text="{Binding BackupDir}" IsReadOnly="True"
+                                 VerticalContentAlignment="Center" Padding="8,6" FontSize="12"
+                                 Background="{DynamicResource InputBrush}" Foreground="{DynamicResource TextBrush}"
+                                 BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" />
+                        <Button Grid.Column="1" Content="Choose folder" Style="{StaticResource OutlineButton}"
+                                Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseBackupCommand}" />
+                    </Grid>
+
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                        <Button Content="I'll do this later" Style="{StaticResource OutlineButton}"
+                                Padding="14,8" Margin="0,0,8,0" Command="{Binding SkipSetupCommand}" />
+                        <Button Content="Start using Savedrake" Style="{StaticResource PrimaryButton}"
+                                Padding="16,8" Command="{Binding CompleteSetupCommand}"
+                                IsEnabled="{Binding IsConfigured}" />
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- Autobackup (disabled until both folders are configured) -->
+            <Border Grid.Row="1" Style="{StaticResource CardBorder}" IsEnabled="{Binding IsConfigured}">
                 <StackPanel>
                     <Button Style="{StaticResource CardHeaderToggle}" Command="{Binding ToggleAutobackupSectionCommand}"
                             ToolTip="Show or hide the autobackup settings">
@@ -264,7 +323,7 @@
 
             <!-- Backups: the Border fills the remaining row; an inner grid lets the list (row 1) take all leftover
                  height so the ListView's own scrollbar is the single scroll region. -->
-            <Border Grid.Row="2" Style="{StaticResource CardBorder}" Margin="0">
+            <Border Grid.Row="2" Style="{StaticResource CardBorder}" Margin="0" IsEnabled="{Binding IsConfigured}">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />   <!-- header row -->

--- a/Savedrake.App/ViewModels/InverseBoolToVisibilityConverter.cs
+++ b/Savedrake.App/ViewModels/InverseBoolToVisibilityConverter.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Savedrake.App.ViewModels
+{
+    // True -> Collapsed, False -> Visible. The mirror of the framework BooleanToVisibilityConverter: it hides the
+    // normal Folders card while the first-run welcome panel (which uses BooleanToVisibilityConverter on the same
+    // NeedsSetup flag) is showing, so exactly one of the two ever occupies the card slot.
+    public sealed class InverseBoolToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            => (value is bool b && b) ? Visibility.Collapsed : Visibility.Visible;
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => throw new NotSupportedException();
+    }
+}

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -39,6 +39,7 @@ namespace Savedrake.App.ViewModels
         private bool _loaded;               // false during initial settings load so property hooks don't react
         private bool _inEnableChange;       // re-entrancy guard while the enable toggle is being processed/reverted
         private bool _isOperationInProgress; // a manual backup/restore (or an autobackup) is mid-flight
+        private bool _setupComplete;        // persisted "user finished first-run setup"; see NeedsSetup
 
         // ----- Folders -----
 
@@ -47,6 +48,15 @@ namespace Savedrake.App.ViewModels
 
         [ObservableProperty]
         private string backupDir;
+
+        // IsConfigured/NeedsSetup also depend on Directory.Exists, which can change while the path string does not
+        // (folder deleted in Explorer, drive disconnected). During first-run that window is narrow; these hooks
+        // re-raise on path-string change, which is sufficient for the welcome panel to update live.
+        partial void OnSaveDirChanged(string value)
+        { OnPropertyChanged(nameof(NeedsSetup)); OnPropertyChanged(nameof(IsConfigured)); }
+
+        partial void OnBackupDirChanged(string value)
+        { OnPropertyChanged(nameof(NeedsSetup)); OnPropertyChanged(nameof(IsConfigured)); }
 
         // ----- Autobackup config (bound to the Autobackup card) -----
 
@@ -121,6 +131,16 @@ namespace Savedrake.App.ViewModels
             new ObservableCollection<string> { "5 minutes", "15 minutes", "30 minutes", "1 hour", "2 hours" };
 
         public bool ConfigEditable => !AutobackupEnabled;
+
+        // Both folders point at real, existing directories. This is "ready to use".
+        public bool IsConfigured =>
+            !string.IsNullOrWhiteSpace(SaveDir) && Directory.Exists(SaveDir) &&
+            !string.IsNullOrWhiteSpace(BackupDir) && Directory.Exists(BackupDir);
+
+        // First-run welcome shows only when setup was never completed AND folders aren't already usable.
+        // An existing user (folders already in savedrake_settings.xml) is IsConfigured == true, so this is false for
+        // them on the very first launch of this build, before the flag is ever written.
+        public bool NeedsSetup => !_setupComplete && !IsConfigured;
 
         // The shipped version shown by the wordmark, from the assembly version (single source of truth, drives the
         // update check too) — so a version bump updates the UI automatically instead of via a hardcoded string.
@@ -251,6 +271,16 @@ namespace Savedrake.App.ViewModels
                 if (!string.IsNullOrWhiteSpace(t1)) SaveDir = t1;
                 if (!string.IsNullOrWhiteSpace(t2)) BackupDir = t2;
 
+                _setupComplete = ParseBool(root.Element("SetupComplete"));
+                // Self-heal: an existing user with folders already set but no flag is treated as already set up.
+                // NOTE: this intentionally checks the path STRINGS only, not Directory.Exists. It covers the existing
+                // user whose backup drive is disconnected at launch (folders set, dir missing -> IsConfigured == false);
+                // the string-only flag keeps them out of first-run. Do NOT make this existence-based or that user gets
+                // re-onboarded.
+                if (!_setupComplete &&
+                    !string.IsNullOrWhiteSpace(SaveDir) && !string.IsNullOrWhiteSpace(BackupDir))
+                    _setupComplete = true;
+
                 string limit = (string)root.Element("AutoBackupLimit");
                 if (!string.IsNullOrWhiteSpace(limit)) MaxBackupsText = limit;
 
@@ -341,6 +371,7 @@ namespace Savedrake.App.ViewModels
                 if (WindowHeight > 0) SetElement(root, "WindowHeight", WindowHeight.ToString());
                 SetElement(root, "FoldersExpanded", FoldersExpanded.ToString());
                 SetElement(root, "AutobackupSectionExpanded", AutobackupSectionExpanded.ToString());
+                SetElement(root, "SetupComplete", _setupComplete.ToString());
 
                 // Backup hotkey (nested <Hotkey> block + CheckboxHot + the display string in Textbox3).
                 var hk = root.Element("Hotkey");
@@ -872,6 +903,36 @@ namespace Savedrake.App.ViewModels
         // Fold / unfold the two config cards (persisted so the choice sticks across launches).
         [RelayCommand] private void ToggleFolders() { FoldersExpanded = !FoldersExpanded; if (_loaded) SaveSettings(); }
         [RelayCommand] private void ToggleAutobackupSection() { AutobackupSectionExpanded = !AutobackupSectionExpanded; if (_loaded) SaveSettings(); }
+
+        // ----- first-run setup (the welcome panel that replaces the Folders card on first launch) -----
+
+        // The user set both folders in the welcome panel: mark setup done so the normal UI takes over and the panel
+        // never returns. Guarded so it can't complete half-configured.
+        [RelayCommand]
+        private void CompleteSetup()
+        {
+            if (!IsConfigured)
+            {
+                _dialog.Info("Almost there", "Please set both your save folder and your backup folder first.");
+                return;
+            }
+            _setupComplete = true;
+            SaveSettings();
+            OnPropertyChanged(nameof(NeedsSetup));
+            _status.Set("Setup complete. You're ready to back up your saves.");
+        }
+
+        // "I'll do this later": dismiss the welcome panel without requiring both folders. IsConfigured stays false, so
+        // the Autobackup/Backups cards remain disabled until the user sets folders via the normal Folders card's Browse
+        // buttons.
+        [RelayCommand]
+        private void SkipSetup()
+        {
+            _setupComplete = true;
+            SaveSettings();
+            OnPropertyChanged(nameof(NeedsSetup));
+            _status.Set("You can set your folders any time from the Folders card.");
+        }
 
         // Persist the window size (called by the window on close so the next launch restores it).
         public void SaveWindowSize(int width, int height)


### PR DESCRIPTION
## Why

You set your save and backup folders once, yet the Folders config sat permanently at the top of the main window competing with the daily-use backup list. This adds a guided first-run setup so a new user is walked through auto-detect → confirm folders → main window, while existing users are never bothered.

## What (inline empty-state, no new window)

On first run, the Folders card is replaced in-place by a welcome panel:
- **"Find it for me"** runs the existing DD2 auto-detect (inherits the multiple-profile and none-found dialogs).
- **Browse / Choose folder** set the save and backup folders (Choose folder inherits the same-drive / cloud-sync / inside-save advisory).
- **"Start using Savedrake"** is enabled only once both folders are valid; it marks setup done and the normal UI takes over.
- **"I'll do this later"** dismisses without configuring.

The **Autobackup** and **Backups** cards are disabled (`IsConfigured`) until both folders are valid.

## Existing users are never re-onboarded
- A populated `savedrake_settings.xml` loads `SaveDir`/`BackupDir`, so `IsConfigured == true` → `NeedsSetup == false` before any flag is written.
- New persisted `SetupComplete` flag is the second guard. Its self-heal checks folder **strings only** (not `Directory.Exists`) on purpose, so a user whose backup drive is disconnected at launch sees the normal Folders card to re-point, not the welcome panel. (Documented in-code so it isn't "tidied" into a re-onboarding bug.)

## Design provenance
Approach and exact edits were produced and adversarially verified by a 10-agent design workflow run against the live code (it scored single-screen vs multi-step-wizard vs inline-empty-state, chose inline, and fixed three defects: dropped a bad backup-dir auto-seed, documented the self-heal asymmetry, added the skip escape hatch).

## Files
- `ViewModels/MainViewModel.cs` — `IsConfigured` / `NeedsSetup`, `SetupComplete` field + load/self-heal/persist, `OnSaveDirChanged`/`OnBackupDirChanged` hooks, `CompleteSetup` / `SkipSetup` commands.
- `ViewModels/InverseBoolToVisibilityConverter.cs` (new) — hides the normal Folders card while the welcome panel shows.
- `MainWindow.xaml` — welcome panel, visibility swap, `IsEnabled` gating on the other cards.

## Verification
- Build clean; harness **268/0** (Core untouched).
- Existing-user launch (real settings present): lands on the normal UI, no welcome.
- First-run launch (settings moved aside, then restored): welcome panel renders, no crash.

Out of scope (later phases): a dedicated Settings page, profiles/Characters, tabbed IA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)