### PR TITLE
feat(characters): per-character backup folders + safe migration + switcher

### DIFF
--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -103,6 +103,8 @@ namespace RestoreHarness
                 Test_GameDetect();   // Phase 5: DD2 running-state registry read returns a bool and never throws
                 Test_SaveReadiness();   // "back up after the save settles": defer while a save file is exclusively locked
                 Test_UpdateCheck();   // Phase 6i: update version parsing (strip v, 2-4 numeric parts) + comparison
+                Test_CharacterFolder();   // Characters: safe single-segment folder-name validation + SafeName clamp
+                Test_CharacterMigration();   // Characters: non-destructive, idempotent, resumable loose->Default migration
             }
             catch (Exception ex)
             {
@@ -976,6 +978,132 @@ namespace RestoreHarness
             bool threw = false;
             try { SaveReadiness.IsSaveSettled(null); } catch { threw = true; }
             Check("IsSaveSettled(null) never throws", !threw);
+            Console.WriteLine();
+        }
+
+        static void Test_CharacterFolder()
+        {
+            Console.WriteLine("== characters: name validation ==");
+            foreach (string ok in new[] { "Aldric", "My Hero 2", "a-b_c", "Default", new string('x', 40) })
+                Check("valid name: '" + ok + "'",
+                    CharacterFolder.IsValidName(ok) && CharacterFolder.SafeName(ok) == ok.Trim());
+
+            string[] bad = { null, "", "   ", "a/b", "a\\b", "a:b", ".", "..", " leading", "trailing ", "trailing.",
+                             "con", "CON", "nul", "COM1", "LPT9", new string('y', 41) };
+            foreach (string b in bad)
+                Check("invalid name: '" + (b ?? "<null>") + "'",
+                    !CharacterFolder.IsValidName(b) && CharacterFolder.SafeName(b) == "Default");
+
+            foreach (char c in Path.GetInvalidFileNameChars())
+                Check("invalid filename char rejected: U+" + ((int)c).ToString("X4"),
+                    !CharacterFolder.IsValidName("a" + c + "b"));
+            Console.WriteLine();
+        }
+
+        static void Test_CharacterMigration()
+        {
+            Console.WriteLine("== characters: non-destructive migration ==");
+
+            // loose -> Default, plus idempotent re-run
+            {
+                string bd = NewDir("mig_loose");
+                File.WriteAllText(Path.Combine(bd, "a.zip"), "A");
+                File.WriteAllText(Path.Combine(bd, "b.zip"), "B");
+                File.WriteAllText(Path.Combine(bd, "c.zip"), "C");
+                File.WriteAllText(Path.Combine(bd, "notes.txt"), "keep");
+                var r = CharacterMigration.MigrateLooseToDefault(bd);
+                string def = Path.Combine(bd, "Default");
+                Check("loose->Default: Ran with 3 moved", r.Ran && r.MovedZips == 3);
+                Check("loose->Default: all 3 zips under Default", Directory.GetFiles(def, "*.zip").Length == 3);
+                Check("loose->Default: none left loose", Directory.GetFiles(bd, "*.zip").Length == 0);
+                Check("loose->Default: notes.txt untouched", File.Exists(Path.Combine(bd, "notes.txt")));
+                var r2 = CharacterMigration.MigrateLooseToDefault(bd);
+                Check("idempotent: second run does nothing", !r2.Ran && Directory.GetFiles(def, "*.zip").Length == 3);
+            }
+
+            // real second character -> hands off
+            {
+                string bd = NewDir("mig_handsoff");
+                File.WriteAllText(Path.Combine(bd, "loose.zip"), "x");
+                Directory.CreateDirectory(Path.Combine(bd, "Bjorn"));
+                Check("second char: NeedsMigration false", !CharacterMigration.NeedsMigration(bd));
+                var r = CharacterMigration.MigrateLooseToDefault(bd);
+                Check("second char: hands off (loose stays)", !r.Ran && File.Exists(Path.Combine(bd, "loose.zip")));
+            }
+
+            // interrupted-migration resume: pre-existing Default + leftover loose zips
+            {
+                string bd = NewDir("mig_resume");
+                Directory.CreateDirectory(Path.Combine(bd, "Default"));
+                File.WriteAllText(Path.Combine(bd, "Default", "old.zip"), "old");
+                File.WriteAllText(Path.Combine(bd, "left1.zip"), "1");
+                File.WriteAllText(Path.Combine(bd, "left2.zip"), "2");
+                Check("resume: NeedsMigration true", CharacterMigration.NeedsMigration(bd));
+                var r = CharacterMigration.MigrateLooseToDefault(bd);
+                string def = Path.Combine(bd, "Default");
+                Check("resume: leftovers finished (3 total)", r.Ran && Directory.GetFiles(def, "*.zip").Length == 3);
+                Check("resume: no loose left", Directory.GetFiles(bd, "*.zip").Length == 0);
+            }
+
+            // name collision: never overwrite
+            {
+                string bd = NewDir("mig_collide");
+                Directory.CreateDirectory(Path.Combine(bd, "Default"));
+                File.WriteAllText(Path.Combine(bd, "Default", "dup.zip"), "ORIGINAL");
+                File.WriteAllText(Path.Combine(bd, "dup.zip"), "LOOSE");
+                var r = CharacterMigration.MigrateLooseToDefault(bd);
+                Check("collision: skipped not moved", r.SkippedZips == 1);
+                Check("collision: existing copy unchanged", File.ReadAllText(Path.Combine(bd, "Default", "dup.zip")) == "ORIGINAL");
+                Check("collision: loose copy left in place", File.Exists(Path.Combine(bd, "dup.zip")));
+            }
+
+            // parent .savedrake.tmp swept
+            {
+                string bd = NewDir("mig_tmp");
+                File.WriteAllText(Path.Combine(bd, "a.zip"), "A");
+                File.WriteAllText(Path.Combine(bd, "stale.savedrake.tmp"), "junk");
+                CharacterMigration.MigrateLooseToDefault(bd);
+                Check("orphan .savedrake.tmp swept", !File.Exists(Path.Combine(bd, "stale.savedrake.tmp")));
+            }
+
+            // legacy global count file pulled into Default
+            {
+                string bd = NewDir("mig_count");
+                File.WriteAllText(Path.Combine(bd, "a.zip"), "A");
+                string legacy = Path.Combine(bd, "legacy_count.txt");
+                File.WriteAllText(legacy, "7");
+                var r = CharacterMigration.MigrateLooseToDefault(bd, legacy);
+                string destCount = Path.Combine(bd, "Default", "count_of_autobackups.txt");
+                Check("legacy count moved into Default", r.MovedCountFile && File.Exists(destCount));
+                Check("legacy count gone from origin", !File.Exists(legacy));
+                Check("legacy count bytes preserved", File.ReadAllText(destCount) == "7");
+            }
+
+            // locked file: skipped, rest move, resumable after unlock
+            {
+                string bd = NewDir("mig_lock");
+                File.WriteAllText(Path.Combine(bd, "free.zip"), "F");
+                string locked = Path.Combine(bd, "locked.zip");
+                File.WriteAllText(locked, "L");
+                using (new FileStream(locked, FileMode.Open, FileAccess.Read, FileShare.None))
+                {
+                    var r = CharacterMigration.MigrateLooseToDefault(bd);
+                    Check("locked: free moved, locked skipped",
+                        Directory.GetFiles(Path.Combine(bd, "Default"), "*.zip").Length == 1 && r.SkippedZips == 1);
+                    Check("locked: still loose at root", File.Exists(locked));
+                }
+                CharacterMigration.MigrateLooseToDefault(bd);
+                Check("locked: resumes after unlock", Directory.GetFiles(Path.Combine(bd, "Default"), "*.zip").Length == 2);
+            }
+
+            // empty / nonexistent: no-op, no throw
+            {
+                var r1 = CharacterMigration.MigrateLooseToDefault("");
+                var r2 = CharacterMigration.MigrateLooseToDefault(Path.Combine(work, "nope_" + Guid.NewGuid().ToString("N")));
+                Check("empty/nonexistent: Ran false, no throw", !r1.Ran && !r2.Ran);
+                Check("empty/null: NeedsMigration false",
+                    !CharacterMigration.NeedsMigration("") && !CharacterMigration.NeedsMigration(null));
+            }
             Console.WriteLine();
         }
 

--- a/Savedrake.App/AutobackupController.cs
+++ b/Savedrake.App/AutobackupController.cs
@@ -13,6 +13,7 @@ namespace Savedrake.App
     {
         string SaveDir { get; }
         string BackupDir { get; }
+        string EffectiveBackupDir { get; }   // BackupDir\<active character>: where this character's backups actually live
         bool AutobackupEnabled { get; }
         TimeSpan AutobackupInterval { get; }   // already validated to the >= 5 min floor by the host
         bool IntervalValid { get; }
@@ -104,6 +105,16 @@ namespace Savedrake.App
                 StartSaveWatcher();
             else
                 StopSaveWatcher();
+        }
+
+        // The active character (the backup destination) changed. The live save folder is unchanged, so the watcher
+        // keeps running, but drop any save-write that is mid-debounce so it cannot land in the newly selected
+        // character's folder, and re-baseline to the current save so the switch itself never triggers a backup.
+        public void OnActiveCharacterChanged()
+        {
+            if (_disposed) return;
+            try { _quiesceTimer?.Stop(); } catch { }
+            AdvanceBaselineToCurrentSave();
         }
 
         // The interval text changed while autobackup is on. If DD2 is running (the timer is live), re-arm it with the
@@ -286,7 +297,7 @@ namespace Savedrake.App
                             _lastFingerprint = Fingerprint.ComputeSaveFingerprint(_host.SaveDir);
                             if (_host.CleanupEnabled)
                             {
-                                int removed = AutobackupCleanup.Run(_host.BackupDir, _host.MaxAutobackups, _host.RecycleEnabled, DateTime.UtcNow.Ticks);
+                                int removed = AutobackupCleanup.Run(_host.EffectiveBackupDir, _host.MaxAutobackups, _host.RecycleEnabled, DateTime.UtcNow.Ticks);
                                 if (removed > 0)
                                     _host.Status.Set(removed == 1 ? "Removed 1 old autobackup." : ("Removed " + removed + " old autobackups."));
                             }

--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -48,6 +48,7 @@
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />   <!-- brand token -->
                     <ColumnDefinition Width="Auto" />   <!-- wordmark + version -->
+                    <ColumnDefinition Width="Auto" />   <!-- character switcher -->
                     <ColumnDefinition Width="*" />      <!-- drag spacer -->
                     <ColumnDefinition Width="Auto" />   <!-- right controls -->
                 </Grid.ColumnDefinitions>
@@ -74,8 +75,20 @@
                                VerticalAlignment="Bottom" Margin="8,0,0,5" />
                 </StackPanel>
 
+                <!-- Character switcher: which character's backups you're managing. Clickable (opt out of caption drag). -->
+                <Button Grid.Column="2" Style="{StaticResource HeaderMenuButton}" Margin="18,0,0,0"
+                        shell:WindowChrome.IsHitTestVisibleInChrome="True"
+                        Click="CharacterMenu_Click" ToolTip="Switch character — each keeps its own backups">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="Character:" Foreground="{DynamicResource TextSecondaryBrush}" VerticalAlignment="Center" />
+                        <TextBlock Text="{Binding ActiveCharacter}" Foreground="{DynamicResource WordmarkBrush}"
+                                   FontWeight="SemiBold" Margin="6,0,4,0" VerticalAlignment="Center" />
+                        <TextBlock Text="&#x25BE;" FontSize="10" Foreground="{DynamicResource TextSecondaryBrush}" VerticalAlignment="Center" />
+                    </StackPanel>
+                </Button>
+
                 <!-- Right-side controls: clickable (opt out of caption drag). -->
-                <StackPanel Grid.Column="3" Orientation="Horizontal" VerticalAlignment="Center"
+                <StackPanel Grid.Column="4" Orientation="Horizontal" VerticalAlignment="Center"
                             shell:WindowChrome.IsHitTestVisibleInChrome="True">
                     <Button Content="File" Style="{StaticResource HeaderMenuButton}" Click="HeaderMenu_Click">
                         <Button.ContextMenu>
@@ -336,7 +349,7 @@
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" Text="Backups" Style="{StaticResource SectionTitle}"
+                        <TextBlock Grid.Column="0" Text="{Binding BackupsTitle}" Style="{StaticResource SectionTitle}"
                                    Margin="0" VerticalAlignment="Center" />
                         <StackPanel Grid.Column="1" Orientation="Horizontal">
                             <Button Content="Back up now" Style="{StaticResource PrimaryButton}"

--- a/Savedrake.App/MainWindow.xaml.cs
+++ b/Savedrake.App/MainWindow.xaml.cs
@@ -285,6 +285,30 @@ namespace Savedrake.App
             }
         }
 
+        // Build + open the character switcher: one checkable row per character (switch on click), then "New character".
+        private void CharacterMenu_Click(object sender, RoutedEventArgs e)
+        {
+            if (!(sender is Button b) || !(DataContext is ViewModels.MainViewModel vm)) return;
+            var menu = new ContextMenu
+            {
+                PlacementTarget = b,
+                Placement = System.Windows.Controls.Primitives.PlacementMode.Bottom
+            };
+            foreach (var c in vm.EnumerateCharacters())
+            {
+                menu.Items.Add(new MenuItem
+                {
+                    Header = c.Name + "   (" + c.FileCount + (c.FileCount == 1 ? " file)" : " files)"),
+                    IsChecked = string.Equals(c.Name, vm.ActiveCharacter, System.StringComparison.OrdinalIgnoreCase),
+                    Command = vm.SwitchCharacterCommand,
+                    CommandParameter = c.Name
+                });
+            }
+            menu.Items.Add(new Separator());
+            menu.Items.Add(new MenuItem { Header = "New character…", Command = vm.NewCharacterCommand });
+            menu.IsOpen = true;
+        }
+
         private void MinimizeButton_Click(object sender, RoutedEventArgs e)
         {
             WindowState = WindowState.Minimized;

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -49,14 +49,30 @@ namespace Savedrake.App.ViewModels
         [ObservableProperty]
         private string backupDir;
 
+        // The active character: the subfolder of BackupDir whose backups are shown and where new backups land. DD2 has
+        // one save slot, so a "character" is a named backup history. Persisted; defaults to "Default".
+        [ObservableProperty]
+        private string activeCharacter = CharacterFolder.Default;
+
         // IsConfigured/NeedsSetup also depend on Directory.Exists, which can change while the path string does not
         // (folder deleted in Explorer, drive disconnected). During first-run that window is narrow; these hooks
-        // re-raise on path-string change, which is sufficient for the welcome panel to update live.
+        // re-raise on path-string change, which is sufficient for the welcome panel to update live. BackupDir also
+        // feeds the per-character routing, so it re-raises those computed paths too.
         partial void OnSaveDirChanged(string value)
         { OnPropertyChanged(nameof(NeedsSetup)); OnPropertyChanged(nameof(IsConfigured)); }
 
         partial void OnBackupDirChanged(string value)
-        { OnPropertyChanged(nameof(NeedsSetup)); OnPropertyChanged(nameof(IsConfigured)); }
+        {
+            OnPropertyChanged(nameof(NeedsSetup)); OnPropertyChanged(nameof(IsConfigured));
+            OnPropertyChanged(nameof(EffectiveBackupDir)); OnPropertyChanged(nameof(CountFilePath));
+            OnPropertyChanged(nameof(BackupsTitle));
+        }
+
+        partial void OnActiveCharacterChanged(string value)
+        {
+            OnPropertyChanged(nameof(EffectiveBackupDir)); OnPropertyChanged(nameof(CountFilePath));
+            OnPropertyChanged(nameof(BackupsTitle));
+        }
 
         // ----- Autobackup config (bound to the Autobackup card) -----
 
@@ -177,6 +193,13 @@ namespace Savedrake.App.ViewModels
             _autobackup = new AutobackupController(this);
 
             LoadSettings();
+            // One-time, non-destructive migration to the folder-per-character layout: move any backups loose directly
+            // under the Backups folder into a "Default" character. Move-only, idempotent, resumable; a no-op once done
+            // or on first run (no folder yet). Runs before the first RefreshBackups so the list is already per-character.
+            var legacyCount = Path.Combine(AppDataDir, "count_of_autobackups.txt");
+            var migration = CharacterMigration.MigrateLooseToDefault(BackupDir, legacyCount);
+            if (migration.Ran) { ActiveCharacter = CharacterFolder.Default; SaveSettings(); }
+            EnsureEffectiveDirExists();
             RefreshBackups();
             _loaded = true;
             // The WMI watcher and any saved-on autobackup re-engage are deferred to Activate(), which the window calls
@@ -206,7 +229,35 @@ namespace Savedrake.App.ViewModels
         // immediately self-disable with a nonsensical "maximum number of 0 autobackups reached" message.
         public bool MaxAutobackupsValid => int.TryParse(MaxBackupsText, out int n) && n >= 1;
 
-        public string CountFilePath => Path.Combine(AppDataDir, "count_of_autobackups.txt");
+        // BackupDir is the parent folder the user picked; EffectiveBackupDir is the ACTIVE CHARACTER's subfolder, which
+        // is where that character's backups actually live. Every Core call routes through EffectiveBackupDir so each
+        // character keeps its own history. The empty-guard returns BackupDir unchanged on first run so every existing
+        // string.IsNullOrWhiteSpace(BackupDir) check keeps firing exactly as before.
+        public string EffectiveBackupDir =>
+            string.IsNullOrWhiteSpace(BackupDir)
+                ? BackupDir
+                : Path.Combine(BackupDir, CharacterFolder.SafeName(ActiveCharacter));
+
+        // The autobackup count cache lives inside the active character's folder (per-character retention). On first run
+        // (no BackupDir yet) it falls back to AppData, which is harmless since nothing reads it until a backup runs.
+        public string CountFilePath =>
+            string.IsNullOrWhiteSpace(BackupDir)
+                ? Path.Combine(AppDataDir, "count_of_autobackups.txt")
+                : Path.Combine(EffectiveBackupDir, "count_of_autobackups.txt");
+
+        // The Backups card title shows which character you are managing.
+        public string BackupsTitle => "Backups — " + CharacterFolder.SafeName(ActiveCharacter);
+
+        // Make sure the active character's backup folder exists before a backup/restore writes into it. Returns false
+        // (never throws) if there is no parent yet or it cannot be created; callers decide how to surface that (a modal
+        // for a manual action, a status line for the autobackup engine) so a valid parent is never mistaken for "no
+        // backup location selected" by BackupService.
+        private bool EnsureEffectiveDirExists()
+        {
+            if (string.IsNullOrWhiteSpace(BackupDir)) return false;
+            try { Directory.CreateDirectory(EffectiveBackupDir); return true; }
+            catch { return false; }
+        }
 
         public string IntervalDisplay => string.IsNullOrWhiteSpace(IntervalText) ? "the set interval" : IntervalText.Trim();
 
@@ -225,8 +276,9 @@ namespace Savedrake.App.ViewModels
             _isOperationInProgress = true;
             try
             {
+                if (!EnsureEffectiveDirExists()) { _status.Set("Autobackup paused: backup folder unavailable."); return false; }
                 BackupResult r = BackupService.Backup(
-                    new BackupRequest { LiveSaveDir = SaveDir, BackupDir = BackupDir, IsAutoBackup = true, RandomName = UseRandomName },
+                    new BackupRequest { LiveSaveDir = SaveDir, BackupDir = EffectiveBackupDir, IsAutoBackup = true, RandomName = UseRandomName },
                     _dialog, _status);
                 if (r.Ok) _sound.Success(); else _sound.Error();
                 return r.Ok;
@@ -270,6 +322,11 @@ namespace Savedrake.App.ViewModels
                 string t2 = (string)root.Element("Textbox2");
                 if (!string.IsNullOrWhiteSpace(t1)) SaveDir = t1;
                 if (!string.IsNullOrWhiteSpace(t2)) BackupDir = t2;
+
+                // Active character: clamp an absent/garbled value to "Default" (IsValidName null-guards first).
+                var acEl = root.Element("ActiveCharacter");
+                string ac = acEl == null ? null : (string)acEl;
+                ActiveCharacter = CharacterFolder.IsValidName(ac) ? ac.Trim() : CharacterFolder.Default;
 
                 _setupComplete = ParseBool(root.Element("SetupComplete"));
                 // Self-heal: an existing user with folders already set but no flag is treated as already set up.
@@ -357,6 +414,7 @@ namespace Savedrake.App.ViewModels
 
                 SetElement(root, "Textbox1", SaveDir ?? "");
                 SetElement(root, "Textbox2", BackupDir ?? "");
+                SetElement(root, "ActiveCharacter", string.IsNullOrWhiteSpace(ActiveCharacter) ? CharacterFolder.Default : ActiveCharacter);
                 SetElement(root, "AutoBackupLimit", MaxBackupsText ?? "");
                 SetElement(root, "CheckboxAuto", AutobackupEnabled.ToString());
                 SetElement(root, "AutoCleanupOldBackups", CleanupEnabled.ToString());
@@ -547,6 +605,12 @@ namespace Savedrake.App.ViewModels
                 try { Directory.CreateDirectory(BackupDir); }
                 catch (Exception ex) { _dialog.Error("Error", "Could not create the backup location: " + ex.Message); return false; }
             }
+            // The active character's subfolder is where autobackups actually land; make sure it exists too.
+            if (!EnsureEffectiveDirExists())
+            {
+                if (!silent) _dialog.Error("Error", "Could not create this character's backup folder under the backup location.");
+                return false;
+            }
             if (!IntervalValid)
             {
                 if (!silent) _dialog.Error("Error", "Please choose an autobackup interval of at least 5 minutes.");
@@ -569,14 +633,13 @@ namespace Savedrake.App.ViewModels
         {
             Backups.Clear();
 
-            string dir = BackupDir;
+            string dir = EffectiveBackupDir;
             if (string.IsNullOrWhiteSpace(dir) || !Directory.Exists(dir))
             {
                 BackupCount = "0";
                 SelectedBackup = null;
-                // No valid backup folder -> the on-disk autobackup count is zero. Keep the count file honest so a
-                // later re-point doesn't inherit a stale count.
-                AutobackupCountStore.Write(CountFilePath, 0);
+                // No valid (character) backup folder yet -> nothing to count. AutobackupCountStore.Read already returns
+                // 0 for a missing count file, so there is nothing to write here (and the dir may not exist yet).
                 return;
             }
 
@@ -614,7 +677,9 @@ namespace Savedrake.App.ViewModels
 
             // Recompute and persist the autobackup count (non-pinned "(Auto)"/"auto" zips) so the "Keep at most N"
             // limit is enforced against the real files on disk. This is the writer the autobackup engine reads back;
-            // without it the limit never triggers. Mirrors WinForms LoadBackupHistory.
+            // without it the limit never triggers. Mirrors WinForms LoadBackupHistory. Ensure the character folder
+            // exists first so the per-character cache actually lands.
+            EnsureEffectiveDirExists();
             AutobackupCountStore.RecomputeAndWrite(dir, CountFilePath);
         }
 
@@ -684,10 +749,17 @@ namespace Savedrake.App.ViewModels
             _isOperationInProgress = true;
             try
             {
-                result = BackupService.Backup(
-                    new BackupRequest { LiveSaveDir = SaveDir, BackupDir = BackupDir, IsAutoBackup = false, RandomName = UseRandomName },
-                    _dialog, _status);
-                if (result.Ok) _sound.Success(); else _sound.Error();
+                if (!EnsureEffectiveDirExists())
+                {
+                    _dialog.Error("Backup", "Savedrake could not create this character's backup folder. Check the Backups location.");
+                }
+                else
+                {
+                    result = BackupService.Backup(
+                        new BackupRequest { LiveSaveDir = SaveDir, BackupDir = EffectiveBackupDir, IsAutoBackup = false, RandomName = UseRandomName },
+                        _dialog, _status);
+                    if (result.Ok) _sound.Success(); else _sound.Error();
+                }
             }
             finally { _isOperationInProgress = false; }
 
@@ -728,15 +800,22 @@ namespace Savedrake.App.ViewModels
             _autobackup.SuppressSaveWatcher = true; // the restore writes into the save folder — don't auto-back that up
             try
             {
-                result = RestoreService.Restore(
-                    new RestoreRequest
-                    {
-                        BackupZipPath = backupZipPath,
-                        LiveSaveDir = SaveDir,
-                        BackupDir = BackupDir,
-                        GameRunning = GameDetect.IsDd2Running()
-                    },
-                    _dialog, _status);
+                if (!EnsureEffectiveDirExists())
+                {
+                    _dialog.Error("Restore", "Savedrake could not access this character's backup folder.");
+                }
+                else
+                {
+                    result = RestoreService.Restore(
+                        new RestoreRequest
+                        {
+                            BackupZipPath = backupZipPath,
+                            LiveSaveDir = SaveDir,
+                            BackupDir = EffectiveBackupDir,
+                            GameRunning = GameDetect.IsDd2Running()
+                        },
+                        _dialog, _status);
+                }
             }
             finally
             {
@@ -760,12 +839,12 @@ namespace Savedrake.App.ViewModels
         [RelayCommand]
         private void UndoLastRestore()
         {
-            if (string.IsNullOrWhiteSpace(BackupDir) || !Directory.Exists(BackupDir))
+            if (string.IsNullOrWhiteSpace(EffectiveBackupDir) || !Directory.Exists(EffectiveBackupDir))
             {
                 _dialog.Info("Undo last restore", "Please set your backup folder first.");
                 return;
             }
-            string checkpoint = SaveScan.FindLatestPreRestoreCheckpoint(BackupDir);
+            string checkpoint = SaveScan.FindLatestPreRestoreCheckpoint(EffectiveBackupDir);
             if (checkpoint == null)
             {
                 _dialog.Info("Nothing to undo",
@@ -932,6 +1011,67 @@ namespace Savedrake.App.ViewModels
             SaveSettings();
             OnPropertyChanged(nameof(NeedsSetup));
             _status.Set("You can set your folders any time from the Folders card.");
+        }
+
+        // ----- characters (per-character backup folders) -----
+
+        // Switch which character's backups are shown and where new backups land. NON-DESTRUCTIVE: it never touches the
+        // live DD2 save. Creates the character's folder if needed, re-baselines the autobackup engine, and refreshes.
+        [RelayCommand]
+        private void SwitchCharacter(string name)
+        {
+            if (!CharacterFolder.IsValidName(name)) return;
+            string safe = name.Trim();
+            if (string.Equals(safe, ActiveCharacter, StringComparison.OrdinalIgnoreCase)) return;
+            ActiveCharacter = safe;
+            SaveSettings();
+            if (!EnsureEffectiveDirExists())
+            {
+                _dialog.Error("Characters", "Savedrake could not create this character's backup folder.");
+                return;
+            }
+            _autobackup.OnActiveCharacterChanged();
+            RefreshBackups();
+            _status.Set("Now managing " + safe + "'s backups.");
+        }
+
+        // Prompt for a new character name and switch to it (its folder is created on first use).
+        [RelayCommand]
+        private void NewCharacter()
+        {
+            string input = Microsoft.VisualBasic.Interaction.InputBox(
+                "Name this character (for example, your in-game character's name). " +
+                "Savedrake keeps each character's backups in its own folder.",
+                "New character", "");
+            if (string.IsNullOrWhiteSpace(input)) return;   // cancelled
+            if (!CharacterFolder.IsValidName(input))
+            {
+                _dialog.Error("New character",
+                    "That name can't be used for a folder. Try letters, numbers, spaces, and dashes (up to 40 characters).");
+                return;
+            }
+            SwitchCharacter(input.Trim());
+        }
+
+        // The characters available to switch to: each subfolder of the backup location, plus the active one (so a
+        // just-created, still-empty character still shows). Count is "*.zip files" (includes checkpoints/manual zips).
+        public IReadOnlyList<(string Name, int FileCount)> EnumerateCharacters()
+        {
+            var list = new List<(string Name, int FileCount)>();
+            if (!string.IsNullOrWhiteSpace(BackupDir) && Directory.Exists(BackupDir))
+            {
+                string[] dirs;
+                try { dirs = Directory.GetDirectories(BackupDir); } catch { dirs = new string[0]; }
+                foreach (string d in dirs)
+                {
+                    string nm = Path.GetFileName(d);
+                    int n = 0; try { n = Directory.GetFiles(d, "*.zip").Length; } catch { }
+                    list.Add((nm, n));
+                }
+            }
+            if (!list.Any(x => string.Equals(x.Name, ActiveCharacter, StringComparison.OrdinalIgnoreCase)))
+                list.Insert(0, (ActiveCharacter, 0));
+            return list;
         }
 
         // Persist the window size (called by the window on close so the next launch restores it).

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -1065,6 +1065,9 @@ namespace Savedrake.App.ViewModels
                 foreach (string d in dirs)
                 {
                     string nm = Path.GetFileName(d);
+                    // Skip a subfolder whose name we couldn't switch to anyway (e.g. an externally-created folder
+                    // longer than the 40-char limit), so the menu never shows a row that does nothing when clicked.
+                    if (!CharacterFolder.IsValidName(nm)) continue;
                     int n = 0; try { n = Directory.GetFiles(d, "*.zip").Length; } catch { }
                     list.Add((nm, n));
                 }

--- a/Savedrake.Core/CharacterFolder.cs
+++ b/Savedrake.Core/CharacterFolder.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+
+namespace Savedrake
+{
+    // A "character" is a named subfolder of the user's Backups location that holds that character's own backup history.
+    // DD2 has a single save slot, so this lets a player keep multiple playthroughs side by side. This helper validates a
+    // character name as a safe single-segment folder name and clamps an untrusted/settings value to a usable one. No I/O.
+    public static class CharacterFolder
+    {
+        public const string Default = "Default";
+
+        private static readonly string[] ReservedNames =
+        {
+            "CON", "PRN", "AUX", "NUL",
+            "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+            "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+        };
+
+        // A valid character name is a safe single-segment Windows folder name: non-empty, no path separators or invalid
+        // filename characters, not "." / "..", no leading/trailing whitespace or trailing dot, not a reserved device
+        // name, and <= 40 chars (so the per-character "(Pre-Restore)....zip.savedrake.tmp" path stays clear of MAX_PATH
+        // on systems without long-path support).
+        public static bool IsValidName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name)) return false;   // legacy null/empty path must never NRE
+            if (name != name.Trim()) return false;               // no leading/trailing whitespace
+            if (name.Length > 40) return false;
+            if (name == "." || name == "..") return false;
+            if (name.EndsWith(".")) return false;                // Windows silently strips a trailing dot
+            if (name.IndexOf('\\') >= 0 || name.IndexOf('/') >= 0 || name.IndexOf(':') >= 0) return false;
+            if (name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0) return false;
+
+            // Reserved device names are reserved with or without an extension (CON, CON.zip, ...).
+            int dot = name.IndexOf('.');
+            string baseName = dot >= 0 ? name.Substring(0, dot) : name;
+            foreach (string r in ReservedNames)
+                if (string.Equals(name, r, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(baseName, r, StringComparison.OrdinalIgnoreCase))
+                    return false;
+
+            return true;
+        }
+
+        // The guard used wherever a character name becomes a path segment: a valid name (trimmed), or "Default"
+        // otherwise, so a corrupted settings value can never produce an unsafe or empty path segment.
+        public static string SafeName(string name)
+            => IsValidName(name) ? name.Trim() : Default;
+    }
+}

--- a/Savedrake.Core/CharacterMigration.cs
+++ b/Savedrake.Core/CharacterMigration.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Savedrake
+{
+    // The outcome of a one-time flat -> folder-per-character migration.
+    public sealed class CharacterMigrationResult
+    {
+        public bool Ran;            // false = nothing to do (skipped)
+        public int MovedZips;
+        public int SkippedZips;     // locked or name-collision: left in place, never overwritten
+        public bool MovedCountFile;
+        public string DefaultDir;
+    }
+
+    // One-time, NON-DESTRUCTIVE migration from the legacy flat layout (backups loose directly under the Backups folder)
+    // to the folder-per-character layout, by moving the loose backups into a "Default" character. Move-only (never
+    // deletes a backup), idempotent, and resumable (an interrupted run finishes on the next launch). Never throws.
+    public static class CharacterMigration
+    {
+        // True when the Backups folder still holds the legacy flat layout: it exists, has at least one loose top-level
+        // *.zip, and has no character subfolders other than (possibly) "Default". Any other subfolder means a real
+        // second character already exists -> already organized -> hands off. Allowing a pre-existing "Default" is what
+        // makes an interrupted migration resumable: leftover loose zips still trigger the finish on the next launch.
+        public static bool NeedsMigration(string backupDir)
+        {
+            if (string.IsNullOrWhiteSpace(backupDir) || !Directory.Exists(backupDir)) return false;
+            try
+            {
+                bool hasLooseZip = Directory.EnumerateFiles(backupDir, "*.zip", SearchOption.TopDirectoryOnly).Any();
+                if (!hasLooseZip) return false;
+                string[] subs = Directory.GetDirectories(backupDir);
+                if (subs.Length == 0) return true;
+                return subs.Length == 1 &&
+                       string.Equals(Path.GetFileName(subs[0]), CharacterFolder.Default, StringComparison.OrdinalIgnoreCase);
+            }
+            catch { return false; }
+        }
+
+        // Move every loose top-level *.zip into BackupDir\Default. A locked file or a name collision is skipped and left
+        // in place (never overwritten), so it is retried on the next launch. Best-effort: pull a legacy global count
+        // cache into Default, and reclaim any orphaned *.savedrake.tmp at the parent root. Returns Ran=false if there is
+        // nothing to migrate. Never throws.
+        public static CharacterMigrationResult MigrateLooseToDefault(string backupDir, string legacyCountFile = null)
+        {
+            var r = new CharacterMigrationResult();
+            if (!NeedsMigration(backupDir)) return r;
+            try
+            {
+                string defaultDir = Path.Combine(backupDir, CharacterFolder.Default);
+                r.DefaultDir = defaultDir;
+                Directory.CreateDirectory(defaultDir);
+
+                foreach (string zip in Directory.EnumerateFiles(backupDir, "*.zip", SearchOption.TopDirectoryOnly).ToList())
+                {
+                    string dest = Path.Combine(defaultDir, Path.GetFileName(zip));
+                    if (File.Exists(dest)) { r.SkippedZips++; continue; }     // collision: never overwrite an existing backup
+                    try { File.Move(zip, dest); r.MovedZips++; }
+                    catch { r.SkippedZips++; }                                // locked: leave in place, retry next launch
+                }
+
+                // Bring the legacy global count cache into Default, but only if Default has none yet.
+                if (!string.IsNullOrWhiteSpace(legacyCountFile) && File.Exists(legacyCountFile))
+                {
+                    string destCount = Path.Combine(defaultDir, "count_of_autobackups.txt");
+                    if (!File.Exists(destCount))
+                    {
+                        try { File.Move(legacyCountFile, destCount); r.MovedCountFile = true; } catch { }
+                    }
+                }
+
+                // Reclaim any orphaned temp from a legacy hard-killed backup at the parent root (per-character sweeps
+                // will never look here again).
+                try
+                {
+                    foreach (string tmp in Directory.EnumerateFiles(backupDir, "*.savedrake.tmp", SearchOption.TopDirectoryOnly).ToList())
+                        File.Delete(tmp);
+                }
+                catch { }
+
+                r.Ran = true;
+            }
+            catch { /* never throw out of migration */ }
+            return r;
+        }
+    }
+}


### PR DESCRIPTION
## Why
DD2 gives each Steam account one save slot, so players can't keep multiple playthroughs. This is **increment 1** of the Characters feature: each "character" is a named backup history you can switch between.

## What
- **A character = the active subfolder of your Backups location.** The view model routes every backup/restore/scan/retention call through `EffectiveBackupDir = BackupDir\<active character>`, so the **Core engine is untouched** — two new pure Core helpers only (`CharacterFolder`, `CharacterMigration`).
- **Header switcher** (`Character: <name> ▾`) shows the active character; the dropdown switches between them and creates new ones. Switching is **non-destructive** — it changes which backups you see and where new backups land; it never touches your live DD2 save. (The "load this character into the game" save-swap is a deferred increment.)
- **Backups card title** shows the active character; the autobackup engine's count/retention are now per-character.

## Existing users: safe migration
On first launch, any backups sitting **loose directly under** your Backups folder move into a `Default` character. The migration is:
- **move-only** (never deletes a backup),
- **idempotent** (re-running does nothing),
- **resumable** (an interrupted run finishes on the next launch instead of splitting history),
- **collision-safe** (never overwrites an existing file; a locked file is skipped and retried),
- a **no-op** once organized or on a fresh install.

Reversal is mechanical (move the zips back out of `Default`, delete the empty folder).

## Design + review provenance
Built from a 9-agent design workflow (chose folder-per-character + `EffectiveBackupDir` routing; designed the safe migration) and folded in 5 adversarial-review fixes: surfacing real dir-create errors (H1), resumable migration (H4), `RefreshBackups` ordering (H3), null-guarded name validation (M2), and quiesce-disarm on switch (M3).

## Verification
- **Harness 353/0** (+85): name validation + every migration case (loose→Default, idempotent, interrupted-resume, name-collision-never-overwrite, locked-file-skip, legacy-count-move, hands-off when a real second character exists, empty/null no-throw). Migration tests run only on throwaway temp folders.
- Built Release; **end-to-end runtime test on a throwaway settings file + temp folders**: the running app migrated loose zips into `Default\`, recomputed the count, and persisted `ActiveCharacter=Default`. Never run against the real backup location.

## Roadmap (later increments)
2. Rename / manage characters (still non-destructive).
3. "Load this character into the game" — switch + restore that character's latest backup through the existing transactional restore + pre-restore checkpoint, with a heavy confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)