### PR TITLE
feat(characters): rename a character (non-destructive)

### DIFF
--- a/Savedrake.App/MainWindow.xaml.cs
+++ b/Savedrake.App/MainWindow.xaml.cs
@@ -306,6 +306,7 @@ namespace Savedrake.App
             }
             menu.Items.Add(new Separator());
             menu.Items.Add(new MenuItem { Header = "New character…", Command = vm.NewCharacterCommand });
+            menu.Items.Add(new MenuItem { Header = "Rename current character…", Command = vm.RenameCharacterCommand });
             menu.IsOpen = true;
         }
 

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -1053,6 +1053,51 @@ namespace Savedrake.App.ViewModels
             SwitchCharacter(input.Trim());
         }
 
+        // Rename the active character (non-destructive: moves its folder, so all of its backups move with it).
+        [RelayCommand]
+        private void RenameCharacter()
+        {
+            if (string.IsNullOrWhiteSpace(BackupDir))
+            {
+                _dialog.Info("Rename character", "Please set your backup folder first.");
+                return;
+            }
+            string current = CharacterFolder.SafeName(ActiveCharacter);
+            string input = Microsoft.VisualBasic.Interaction.InputBox(
+                "Rename character \"" + current + "\". Its backups move with it.", "Rename character", current);
+            if (string.IsNullOrWhiteSpace(input)) return;                                    // cancelled
+            string target = input.Trim();
+            if (string.Equals(target, current, StringComparison.OrdinalIgnoreCase)) return;  // unchanged
+            if (!CharacterFolder.IsValidName(target))
+            {
+                _dialog.Error("Rename character",
+                    "That name can't be used for a folder. Try letters, numbers, spaces, and dashes (up to 40 characters).");
+                return;
+            }
+            string from = Path.Combine(BackupDir, current);
+            string to = Path.Combine(BackupDir, target);
+            if (Directory.Exists(to))
+            {
+                _dialog.Error("Rename character", "A character named \"" + target + "\" already exists.");
+                return;
+            }
+            try
+            {
+                if (Directory.Exists(from)) Directory.Move(from, to);
+                else Directory.CreateDirectory(to);   // current character has no folder yet (never backed up): adopt the new name
+            }
+            catch (Exception ex)
+            {
+                _dialog.Error("Rename character", "Could not rename this character: " + ex.Message);
+                return;
+            }
+            ActiveCharacter = target;
+            SaveSettings();
+            _autobackup.OnActiveCharacterChanged();
+            RefreshBackups();
+            _status.Set("Renamed to " + target + ".");
+        }
+
         // The characters available to switch to: each subfolder of the backup location, plus the active one (so a
         // just-created, still-empty character still shows). Count is "*.zip files" (includes checkpoints/manual zips).
         public IReadOnlyList<(string Name, int FileCount)> EnumerateCharacters()


### PR DESCRIPTION
## What
Increment 2 of the Characters feature: **rename a character**.

Adds **"Rename current character…"** to the `Character: <name> ▾` switcher menu. It prompts for a new name, validates it (same `CharacterFolder.IsValidName` rules as New character), and **moves the folder** (`Directory.Move`) so all of that character's backups move with it. Then it updates the active character, persists it, re-baselines the autobackup engine, and refreshes the list.

Guards:
- refuses a name that already exists (no merge/overwrite),
- no-op on an unchanged name,
- rejects an invalid name with a clear message,
- surfaces any move failure (e.g. a file locked open in the folder) instead of throwing,
- if the character never had a folder yet (never backed up), it just adopts the new name.

Non-destructive: a rename never deletes a backup; `Directory.Move` within the same Backups parent is an instant rename.

## Verification
- Build clean; harness **353/0** (Core untouched).
- The command is driven by an input dialog, so it isn't headless-runtime-tested; the logic is a guarded `Directory.Move` reusing the increment-1 name validation.

Roadmap: increment 3 ("load this character into the game" save-swap) is in design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)