### PR TITLE
feat(characters): load a character into the game (save-swap)

### DIFF
--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -105,6 +105,11 @@ namespace RestoreHarness
                 Test_UpdateCheck();   // Phase 6i: update version parsing (strip v, 2-4 numeric parts) + comparison
                 Test_CharacterFolder();   // Characters: safe single-segment folder-name validation + SafeName clamp
                 Test_CharacterMigration();   // Characters: non-destructive, idempotent, resumable loose->Default migration
+                Test_LiveFolderHasRealSave();   // Load: detect real DD2 save data in the live folder (fail-open)
+                Test_FindLatestRealBackup();   // Load: newest real backup by CreationTime, excluding (Pre-Restore)/(Pre-Load)
+                Test_PreLoadCheckpoint();   // Load: (Pre-Load) snapshot naming + content + skip rules
+                Test_LoadSequence_Happy();   // Load: snapshot-outgoing then restore-target end-to-end; live becomes target
+                Test_LoadSequence_Cancelled();   // Load: declined restore leaves live untouched -> no flip (the no-limbo proof)
             }
             catch (Exception ex)
             {
@@ -1104,6 +1109,149 @@ namespace RestoreHarness
                 Check("empty/null: NeedsMigration false",
                     !CharacterMigration.NeedsMigration("") && !CharacterMigration.NeedsMigration(null));
             }
+            Console.WriteLine();
+        }
+
+        static void Test_LiveFolderHasRealSave()
+        {
+            Console.WriteLine("== load: live-folder save detection ==");
+            string withSave = NewDir("lhrs_yes");
+            Directory.CreateDirectory(Path.Combine(withSave, "win64_save"));
+            File.WriteAllText(Path.Combine(withSave, "win64_save", "data000.bin"), "x");
+            Check("has data*.bin (nested) -> true", SaveScan.LiveFolderHasRealSave(withSave));
+
+            string sysOnly = NewDir("lhrs_sys");
+            File.WriteAllText(Path.Combine(sysOnly, "system.bin"), "x");
+            Check("has system.bin -> true", SaveScan.LiveFolderHasRealSave(sysOnly));
+
+            string noSave = NewDir("lhrs_no");
+            File.WriteAllText(Path.Combine(noSave, "readme.txt"), "x");
+            Check("no save data -> false", !SaveScan.LiveFolderHasRealSave(noSave));
+            Check("missing folder -> false (no throw)", !SaveScan.LiveFolderHasRealSave(Path.Combine(noSave, "nope")));
+            Check("null -> false (no throw)", !SaveScan.LiveFolderHasRealSave(null));
+            Console.WriteLine();
+        }
+
+        static void Test_FindLatestRealBackup()
+        {
+            Console.WriteLine("== load: newest real backup (excludes checkpoints, CreationTime order) ==");
+            string dir = NewDir("flrb");
+            string older = Path.Combine(dir, "backup_old.zip");
+            string newer = Path.Combine(dir, "backup_new.zip");
+            string preR = Path.Combine(dir, "(Pre-Restore) 240101000000.zip");
+            string preL = Path.Combine(dir, "(Pre-Load) 240101000000.zip");
+            foreach (string p in new[] { older, newer, preR, preL }) File.WriteAllText(p, "z");
+            // Make the CHECKPOINTS the newest by CreationTime — they must STILL be excluded.
+            File.SetCreationTimeUtc(older, new DateTime(2024, 1, 1));
+            File.SetCreationTimeUtc(newer, new DateTime(2024, 1, 2));
+            File.SetCreationTimeUtc(preR, new DateTime(2024, 1, 9));
+            File.SetCreationTimeUtc(preL, new DateTime(2024, 1, 9));
+            Check("returns newest real backup, checkpoints excluded even when newer",
+                SaveScan.FindLatestRealBackup(dir) == newer);
+
+            string onlyCheckpoints = NewDir("flrb_ck");
+            File.WriteAllText(Path.Combine(onlyCheckpoints, "(Pre-Restore) 1.zip"), "z");
+            Check("only checkpoints -> null", SaveScan.FindLatestRealBackup(onlyCheckpoints) == null);
+            Check("missing folder -> null (no throw)", SaveScan.FindLatestRealBackup(Path.Combine(dir, "nope")) == null);
+            Console.WriteLine();
+        }
+
+        static void Test_PreLoadCheckpoint()
+        {
+            Console.WriteLine("== load: (Pre-Load) outgoing snapshot ==");
+            string live = NewDir("plc_live");
+            File.WriteAllText(Path.Combine(live, "data000.bin"), "OUTGOING");
+            File.WriteAllText(Path.Combine(live, "system.bin"), "SYS");
+            string target = NewDir("plc_target");
+
+            Check("CreatePreLoadCheckpoint returns true", RestoreEngine.CreatePreLoadCheckpoint(live, target));
+            string[] zips = Directory.GetFiles(target, "*.zip");
+            Check("exactly one zip written", zips.Length == 1, "found " + zips.Length);
+            Check("name starts with (Pre-Load)", zips.Length == 1 && Path.GetFileName(zips[0]).StartsWith("(Pre-Load)"));
+            Check("snapshot is excluded by FindLatestRealBackup", SaveScan.FindLatestRealBackup(target) == null);
+            Check("no .savedrake.tmp left", Directory.GetFiles(target, "*.savedrake.tmp").Length == 0);
+
+            // No save data in live -> justified skip, true, no zip.
+            string emptyLive = NewDir("plc_empty");
+            File.WriteAllText(Path.Combine(emptyLive, "readme.txt"), "x");
+            string target2 = NewDir("plc_target2");
+            Check("no-save-data live -> skip (true, no zip)",
+                RestoreEngine.CreatePreLoadCheckpoint(emptyLive, target2) && Directory.GetFiles(target2, "*.zip").Length == 0);
+            // live == target -> skip, true.
+            Check("live == target -> skip (true)", RestoreEngine.CreatePreLoadCheckpoint(live, live));
+            Console.WriteLine();
+        }
+
+        // Build a real DD2-style live folder + a valid target backup zip + character folders; returns the pieces.
+        static void SetupLoad(out string live, out string loadedFolder, out string activeFolder, out string targetZip)
+        {
+            string remote = NewDir("load_remote");
+            live = Path.Combine(remote, "win64_save");
+            Directory.CreateDirectory(live);
+            File.WriteAllText(Path.Combine(live, "data000.bin"), "OLD-DATA");   // outgoing character A's live save
+            File.WriteAllText(Path.Combine(live, "system.bin"), "OLD-SYS");
+
+            loadedFolder = NewDir("load_A");   // character A (currently loaded) backup folder
+            activeFolder = NewDir("load_B");   // character B (being loaded) backup folder
+
+            string src = NewDir("load_src");
+            File.WriteAllText(Path.Combine(src, "data000.bin"), "NEW-DATA");
+            File.WriteAllText(Path.Combine(src, "system.bin"), "NEW-SYS");
+            string manifest = (string)CM("Manifest", "BuildBackupManifest").Invoke(null, new object[] { src });
+            targetZip = Path.Combine(activeFolder, "newsave.zip");
+            MakeZip(targetZip, z =>
+            {
+                z.AddEntry("data000.bin", B("NEW-DATA"));
+                z.AddEntry("system.bin", B("NEW-SYS"));
+                z.AddEntry("_savedrake/manifest.json", B(manifest));
+            });
+        }
+
+        static void Test_LoadSequence_Happy()
+        {
+            Console.WriteLine("== load: full sequence (snapshot outgoing, restore target) ==");
+            SetupLoad(out string live, out string loadedFolder, out string activeFolder, out string targetZip);
+
+            // Step 1: snapshot the outgoing (A) live save into A's folder.
+            bool snapped = RestoreEngine.CreatePreLoadCheckpoint(live, loadedFolder);
+            Check("step 1: outgoing snapshot ok", snapped);
+            Check("step 1: (Pre-Load) of OLD save in loaded folder",
+                Directory.GetFiles(loadedFolder, "(Pre-Load)*.zip").Length == 1);
+
+            // Step 2: restore B's newest into the live folder (the exact call DoRestoreCore makes).
+            var dialog = new StubDialog { ConfirmResult = true };
+            RestoreResult res = RestoreService.Restore(
+                new RestoreRequest { BackupZipPath = targetZip, LiveSaveDir = live, BackupDir = activeFolder, GameRunning = false },
+                dialog, new StubStatus());
+
+            Check("step 2: restore Ok", res.Ok, "msg=" + res.Message);
+            Check("step 3: live now holds NEW (B) data",
+                File.ReadAllText(Path.Combine(live, "data000.bin")) == "NEW-DATA");
+            Check("(Pre-Restore) checkpoint of OLD save landed in active (B) folder",
+                Directory.GetFiles(activeFolder, "(Pre-Restore)*.zip").Length == 1);
+            Console.WriteLine();
+        }
+
+        static void Test_LoadSequence_Cancelled()
+        {
+            Console.WriteLine("== load: declined restore -> live untouched, no flip (no-limbo proof) ==");
+            SetupLoad(out string live, out string loadedFolder, out string activeFolder, out string targetZip);
+
+            // Step 1 still runs (silent snapshot).
+            RestoreEngine.CreatePreLoadCheckpoint(live, loadedFolder);
+
+            // Step 2: user declines the Steam-Cloud confirm.
+            var dialog = new StubDialog { ConfirmResult = false };
+            RestoreResult res = RestoreService.Restore(
+                new RestoreRequest { BackupZipPath = targetZip, LiveSaveDir = live, BackupDir = activeFolder, GameRunning = false },
+                dialog, new StubStatus());
+
+            Check("declined: result not Ok", !res.Ok);
+            Check("declined: live save UNCHANGED (still OLD)",
+                File.ReadAllText(Path.Combine(live, "data000.bin")) == "OLD-DATA");
+            // The command flips LoadedCharacter only on res.Ok, so here it would NOT flip -> Loaded stays the outgoing
+            // character, which still matches the (unchanged) live save. No limbo.
+            Check("declined: flip-gate is false (LoadedCharacter would stay outgoing)", res.Ok == false);
             Console.WriteLine();
         }
 

--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -87,6 +87,11 @@
                     </StackPanel>
                 </Button>
 
+                <!-- "Playing: X" hint, shown only while you're viewing a different character than the one that's live.
+                     Empty string renders as nothing (no converter needed). Sits in the draggable spacer column. -->
+                <TextBlock Grid.Column="3" Text="{Binding PlayingIndicator}" FontSize="11" FontWeight="SemiBold"
+                           Foreground="{DynamicResource SuccessBrush}" VerticalAlignment="Center" Margin="12,0,0,0" />
+
                 <!-- Right-side controls: clickable (opt out of caption drag). -->
                 <StackPanel Grid.Column="4" Orientation="Horizontal" VerticalAlignment="Center"
                             shell:WindowChrome.IsHitTestVisibleInChrome="True">
@@ -354,6 +359,9 @@
                         <StackPanel Grid.Column="1" Orientation="Horizontal">
                             <Button Content="Back up now" Style="{StaticResource PrimaryButton}"
                                     Padding="14,7" Command="{Binding BackupCommand}" />
+                            <Button Content="Load into game" Style="{StaticResource PrimaryButton}"
+                                    Padding="14,7" Margin="8,0,0,0" Command="{Binding LoadIntoGameCommand}"
+                                    ToolTip="Replace your live DD2 save with this character's newest backup (your current character is backed up first)" />
                             <Button Content="Restore" Style="{StaticResource OutlineButton}"
                                     Padding="14,7" Margin="8,0,0,0" Command="{Binding RestoreCommand}"
                                     CommandParameter="{Binding SelectedItems, ElementName=BackupList}" />

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -50,9 +50,18 @@ namespace Savedrake.App.ViewModels
         private string backupDir;
 
         // The active character: the subfolder of BackupDir whose backups are shown and where new backups land. DD2 has
-        // one save slot, so a "character" is a named backup history. Persisted; defaults to "Default".
+        // one save slot, so a "character" is a named backup history. Persisted; defaults to "Default". This is the
+        // character you are VIEWING/managing; switching it never touches the live save.
         [ObservableProperty]
         private string activeCharacter = CharacterFolder.Default;
+
+        // Which character's save is currently LIVE in the DD2 save folder (the one you are PLAYING), as opposed to the
+        // active/viewed character. Persisted; defaults to "Default" (the migrated character). Flips only when a
+        // "Load into game" restore commits, so it always agrees with the live save.
+        [ObservableProperty]
+        private string loadedCharacter = CharacterFolder.Default;
+
+        partial void OnLoadedCharacterChanged(string value) => OnPropertyChanged(nameof(PlayingIndicator));
 
         // IsConfigured/NeedsSetup also depend on Directory.Exists, which can change while the path string does not
         // (folder deleted in Explorer, drive disconnected). During first-run that window is narrow; these hooks
@@ -71,7 +80,7 @@ namespace Savedrake.App.ViewModels
         partial void OnActiveCharacterChanged(string value)
         {
             OnPropertyChanged(nameof(EffectiveBackupDir)); OnPropertyChanged(nameof(CountFilePath));
-            OnPropertyChanged(nameof(BackupsTitle));
+            OnPropertyChanged(nameof(BackupsTitle)); OnPropertyChanged(nameof(PlayingIndicator));
         }
 
         // ----- Autobackup config (bound to the Autobackup card) -----
@@ -248,6 +257,19 @@ namespace Savedrake.App.ViewModels
         // The Backups card title shows which character you are managing.
         public string BackupsTitle => "Backups — " + CharacterFolder.SafeName(ActiveCharacter);
 
+        // The LOADED (currently-playing) character's backup folder, where the outgoing "(Pre-Load)" snapshot is filed.
+        // Mirrors EffectiveBackupDir but keyed on LoadedCharacter, not ActiveCharacter.
+        public string LoadedBackupDir =>
+            string.IsNullOrWhiteSpace(BackupDir)
+                ? BackupDir
+                : Path.Combine(BackupDir, CharacterFolder.SafeName(LoadedCharacter));
+
+        // Header hint shown only while you are viewing a different character than the one that's actually live, so it's
+        // always clear which character the game would load. Empty (and thus collapsed) when viewing == playing.
+        public string PlayingIndicator =>
+            string.Equals(ActiveCharacter, LoadedCharacter, StringComparison.OrdinalIgnoreCase)
+                ? "" : "Playing: " + CharacterFolder.SafeName(LoadedCharacter);
+
         // Make sure the active character's backup folder exists before a backup/restore writes into it. Returns false
         // (never throws) if there is no parent yet or it cannot be created; callers decide how to surface that (a modal
         // for a manual action, a status line for the autobackup engine) so a valid parent is never mistaken for "no
@@ -327,6 +349,10 @@ namespace Savedrake.App.ViewModels
                 var acEl = root.Element("ActiveCharacter");
                 string ac = acEl == null ? null : (string)acEl;
                 ActiveCharacter = CharacterFolder.IsValidName(ac) ? ac.Trim() : CharacterFolder.Default;
+
+                var lcEl = root.Element("LoadedCharacter");
+                string lc = lcEl == null ? null : (string)lcEl;
+                LoadedCharacter = CharacterFolder.IsValidName(lc) ? lc.Trim() : CharacterFolder.Default;
 
                 _setupComplete = ParseBool(root.Element("SetupComplete"));
                 // Self-heal: an existing user with folders already set but no flag is treated as already set up.
@@ -415,6 +441,7 @@ namespace Savedrake.App.ViewModels
                 SetElement(root, "Textbox1", SaveDir ?? "");
                 SetElement(root, "Textbox2", BackupDir ?? "");
                 SetElement(root, "ActiveCharacter", string.IsNullOrWhiteSpace(ActiveCharacter) ? CharacterFolder.Default : ActiveCharacter);
+                SetElement(root, "LoadedCharacter", string.IsNullOrWhiteSpace(LoadedCharacter) ? CharacterFolder.Default : LoadedCharacter);
                 SetElement(root, "AutoBackupLimit", MaxBackupsText ?? "");
                 SetElement(root, "CheckboxAuto", AutobackupEnabled.ToString());
                 SetElement(root, "AutoCleanupOldBackups", CleanupEnabled.ToString());
@@ -788,47 +815,48 @@ namespace Savedrake.App.ViewModels
             DoRestore(SelectedBackup.FullPath);
         }
 
-        // The shared restore path (used by Restore and Undo-last-restore): runs the full transactional restore against
-        // a specific backup zip, holding the operation lock + suppressing the save watcher, and advances the
-        // change-aware baseline on success.
+        // The LOCK-FREE restore core: the backup-folder guard + the transactional restore + the change-aware baseline
+        // advance on success. Holds NO operation lock and does NOT touch SuppressSaveWatcher or re-check
+        // _isOperationInProgress — the CALLER owns those, so it can be invoked inside an already-held lock (the "Load
+        // into game" flow) without self-deadlocking or early-returning. Does NOT RefreshBackups (caller's job). Returns
+        // the RestoreResult (null only when the folder guard failed and showed its own error).
+        private RestoreResult DoRestoreCore(string backupZipPath)
+        {
+            if (!EnsureEffectiveDirExists())
+            {
+                _dialog.Error("Restore", "Savedrake could not access this character's backup folder.");
+                return null;
+            }
+            RestoreResult result = RestoreService.Restore(
+                new RestoreRequest
+                {
+                    BackupZipPath = backupZipPath,
+                    LiveSaveDir = SaveDir,
+                    BackupDir = EffectiveBackupDir,
+                    GameRunning = GameDetect.IsDd2Running()
+                },
+                _dialog, _status);
+            // On a SUCCESSFUL restore, advance the change-aware baseline to the now-restored save (mirrors the WinForms
+            // reference). With the baseline now equal to the restored content, a trailing FileSystemWatcher event from
+            // the restore's own writes resolves to SkipNoChange instead of capturing a redundant autobackup. Gated on Ok
+            // so the baseline only moves when the save actually changed (on failure the restore rolled back).
+            if (result != null && result.Ok) _autobackup.NotifyExternalRestore();
+            return result;
+        }
+
+        // The shared restore path (used by Restore and Undo-last-restore): holds the operation lock + suppresses the
+        // save watcher around the lock-free core.
         private void DoRestore(string backupZipPath)
         {
             if (_isOperationInProgress) { _status.Set("Please wait, another operation is already running."); return; }
-
-            RestoreResult result = null;
             _isOperationInProgress = true;
             _autobackup.SuppressSaveWatcher = true; // the restore writes into the save folder — don't auto-back that up
-            try
-            {
-                if (!EnsureEffectiveDirExists())
-                {
-                    _dialog.Error("Restore", "Savedrake could not access this character's backup folder.");
-                }
-                else
-                {
-                    result = RestoreService.Restore(
-                        new RestoreRequest
-                        {
-                            BackupZipPath = backupZipPath,
-                            LiveSaveDir = SaveDir,
-                            BackupDir = EffectiveBackupDir,
-                            GameRunning = GameDetect.IsDd2Running()
-                        },
-                        _dialog, _status);
-                }
-            }
+            try { DoRestoreCore(backupZipPath); }
             finally
             {
                 _isOperationInProgress = false;
                 _autobackup.SuppressSaveWatcher = false;
             }
-            // On a SUCCESSFUL restore, advance the change-aware baseline to the now-restored save (mirrors the WinForms
-            // reference, which set _lastAutoBackupFingerprint after a successful RestoreTransactional). SuppressSaveWatcher
-            // is cleared in the finally above, so a trailing FileSystemWatcher event from the restore's own writes can
-            // still arrive and, ~4s later, run the change-aware gate; with the baseline now equal to the restored
-            // content that gate resolves to SkipNoChange instead of capturing a redundant autobackup. Gated on Ok so the
-            // baseline only moves when the save actually changed (on failure the restore rolled back to the original).
-            if (result != null && result.Ok) _autobackup.NotifyExternalRestore();
             RefreshBackups();
         }
 
@@ -1120,6 +1148,86 @@ namespace Savedrake.App.ViewModels
             if (!list.Any(x => string.Equals(x.Name, ActiveCharacter, StringComparison.OrdinalIgnoreCase)))
                 list.Insert(0, (ActiveCharacter, 0));
             return list;
+        }
+
+        // Load the ACTIVE (viewed) character's newest backup into the live DD2 save, making it the character you play.
+        // Snapshots the OUTGOING character's live save first (retention-exempt "(Pre-Load)" in its own folder), then
+        // reuses the hardened transactional restore VERBATIM (its own single game-running guard + single Steam-Cloud
+        // confirm + rollback). LoadedCharacter flips to the active character only when the restore commits, so the
+        // persisted "playing" character and the live save always agree — a cancelled or failed load leaves both as they
+        // were, with no limbo.
+        [RelayCommand]
+        private void LoadIntoGame()
+        {
+            if (!IsConfigured)
+            {
+                _dialog.Info("Load into game", "Please set your save folder and backup folder first.");
+                return;
+            }
+
+            // Computed ONCE: the A==B guard and the snapshot decision must agree on the same reading.
+            bool liveHasSave = SaveScan.LiveFolderHasRealSave(SaveDir);
+
+            // Loading the character whose save is already live is a rollback, which Restore handles — not Load. (When
+            // the live save is gone, fall through so a deleted save can be recovered by reloading the loaded character.)
+            if (string.Equals(ActiveCharacter, LoadedCharacter, StringComparison.OrdinalIgnoreCase) && liveHasSave)
+            {
+                _dialog.Info("Load into game",
+                    CharacterFolder.SafeName(ActiveCharacter) + " is already loaded. To roll back to an older backup, use Restore.");
+                return;
+            }
+
+            string target = SaveScan.FindLatestRealBackup(EffectiveBackupDir);
+            if (target == null)
+            {
+                _dialog.Info("Load into game",
+                    "No backups yet for " + CharacterFolder.SafeName(ActiveCharacter) + ". Play and back up first.");
+                return;
+            }
+
+            if (_isOperationInProgress) { _status.Set("Please wait, another operation is already running."); return; }
+
+            RestoreResult result = null;
+            _isOperationInProgress = true;
+            _autobackup.SuppressSaveWatcher = true;
+            try
+            {
+                // Step 1 — preserve the OUTGOING character's progress in ITS own folder (only when it differs from the
+                // target). CreatePreLoadCheckpoint applies its own fail-closed no-save skip; abort only if there was
+                // provably a save to keep and the snapshot failed (status only, no state change, no live-save touch).
+                if (!string.Equals(LoadedCharacter, ActiveCharacter, StringComparison.OrdinalIgnoreCase))
+                {
+                    try { Directory.CreateDirectory(LoadedBackupDir); } catch { }
+                    bool snapped = RestoreEngine.CreatePreLoadCheckpoint(SaveDir, LoadedBackupDir);
+                    if (!snapped && liveHasSave)
+                    {
+                        _status.Set("Load cancelled: could not save a snapshot of " +
+                            CharacterFolder.SafeName(LoadedCharacter) + "'s current progress.");
+                        return;
+                    }
+                }
+
+                // Step 2 — load the target via the hardened restore (its own single guard + single confirm + rollback).
+                result = DoRestoreCore(target);
+
+                // Step 3 — flip the persisted "playing" character IFF the live save is now the target.
+                if (result != null && result.Ok)
+                {
+                    LoadedCharacter = ActiveCharacter;
+                    SaveSettings();
+                    _sound.Success();
+                    _status.Set("Now playing as " + CharacterFolder.SafeName(ActiveCharacter) +
+                        ". Your previous character's progress was saved.");
+                }
+                else if (result != null) _sound.Error();
+                // result == null (folder guard) already showed an error; no state change on any failure path.
+            }
+            finally
+            {
+                _isOperationInProgress = false;
+                _autobackup.SuppressSaveWatcher = false;
+            }
+            RefreshBackups();
         }
 
         // Persist the window size (called by the window on close so the next launch restores it).

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -1119,6 +1119,10 @@ namespace Savedrake.App.ViewModels
                 _dialog.Error("Rename character", "Could not rename this character: " + ex.Message);
                 return;
             }
+            // Keep the "playing" character in sync if we just renamed the folder of the currently-loaded character,
+            // so LoadedCharacter/LoadedBackupDir don't point at the old (now-moved) folder.
+            if (string.Equals(LoadedCharacter, current, StringComparison.OrdinalIgnoreCase))
+                LoadedCharacter = target;
             ActiveCharacter = target;
             SaveSettings();
             _autobackup.OnActiveCharacterChanged();
@@ -1165,7 +1169,10 @@ namespace Savedrake.App.ViewModels
                 return;
             }
 
-            // Computed ONCE: the A==B guard and the snapshot decision must agree on the same reading.
+            // Computed ONCE: the A==B guard and the snapshot-abort decision must agree on the same reading. If the
+            // live folder changes between this read and the actual snapshot, the (Pre-Load) abort gate may be slightly
+            // stale, but that is not a data path: the destructive restore below takes its OWN fail-closed pre-restore
+            // checkpoint of whatever is actually live before the swap, so the outgoing save is captured regardless.
             bool liveHasSave = SaveScan.LiveFolderHasRealSave(SaveDir);
 
             // Loading the character whose save is already live is a rollback, which Restore handles — not Load. (When

--- a/Savedrake.Core/RestoreEngine.cs
+++ b/Savedrake.Core/RestoreEngine.cs
@@ -60,6 +60,56 @@ namespace Savedrake
             }
         }
 
+        // Snapshot the live save into targetFolder as a retention-exempt "(Pre-Load) <ts>" backup, taken before a
+        // "Load into game" replaces the live save with a DIFFERENT character's backup, so the outgoing character's
+        // progress is preserved in ITS own folder. Byte-for-byte identical to CreatePreRestoreCheckpoint above except
+        // the file-name prefix: same live==target guard, same fail-CLOSED no-save-data skip, same temp-build +
+        // verify-on-create (CRC + manifest) + atomic publish. The "(Pre-Load) " prefix makes it identifiable AND keeps
+        // it out of the autobackup count + cleanup (both match only "(Auto)"/"auto"), so no retention change is needed.
+        // Kept as a separate clone (not a shared parameterized method) so this safety-critical path stays auditable.
+        public static bool CreatePreLoadCheckpoint(string liveDir, string targetFolder)
+        {
+            if (string.Equals(Path.GetFullPath(liveDir), Path.GetFullPath(targetFolder), StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            bool hasSaveData;
+            try
+            {
+                hasSaveData = Directory
+                    .EnumerateFiles(liveDir, "*", SearchOption.AllDirectories)
+                    .Any(p => SaveScan.IsRealSaveEntry(Path.GetFileName(p)));
+            }
+            catch (UnauthorizedAccessException) { hasSaveData = true; } // can't scan -> err toward making a checkpoint
+            catch (System.IO.IOException) { hasSaveData = true; }
+            if (!hasSaveData) return true;
+
+            string checkpointPath = BackupNaming.MakeUniquePath(Path.Combine(targetFolder, $"(Pre-Load) {DateTime.Now:yyMMddHHmmss}.zip"));
+            string tempZip = checkpointPath + ".savedrake.tmp";
+            try
+            {
+                try { foreach (string stale in Directory.GetFiles(targetFolder, "*.savedrake.tmp")) File.Delete(stale); } catch { }
+                using (Ionic.Zip.ZipFile zip = new Ionic.Zip.ZipFile())
+                {
+                    zip.AddDirectory(liveDir);
+                    zip.AddEntry(Manifest.ManifestEntryName, System.Text.Encoding.UTF8.GetBytes(Manifest.BuildBackupManifest(liveDir)));
+                    zip.Comment = "SamMorrison9800";
+                    zip.Save(tempZip);
+                }
+                if (!Manifest.VerifyZipRestorable(tempZip, out _) || !Manifest.VerifyZipAgainstManifest(tempZip, out _))
+                {
+                    try { File.Delete(tempZip); } catch { }
+                    return false;
+                }
+                File.Move(tempZip, checkpointPath); // atomically publish the completed checkpoint
+                return true;
+            }
+            catch (Exception)
+            {
+                try { if (File.Exists(tempZip)) File.Delete(tempZip); } catch { }
+                return false;
+            }
+        }
+
         public static bool Rollback(string liveDir, string rollbackDir, bool stagingStarted)
         {
             try

--- a/Savedrake.Core/SaveScan.cs
+++ b/Savedrake.Core/SaveScan.cs
@@ -106,6 +106,41 @@ namespace Savedrake
             catch { return null; }
         }
 
+        // True if the live save folder currently holds real DD2 save data (data*.bin / system.bin), searched
+        // recursively. Fail-OPEN: an unreadable folder returns false (never blocks a load; the (Pre-Load) snapshot
+        // path applies its own fail-CLOSED skip). Never throws.
+        public static bool LiveFolderHasRealSave(string liveDir)
+        {
+            if (string.IsNullOrWhiteSpace(liveDir)) return false;
+            try
+            {
+                return Directory.EnumerateFiles(liveDir, "*", SearchOption.AllDirectories)
+                    .Any(p => IsRealSaveEntry(Path.GetFileName(p)));
+            }
+            catch { return false; }
+        }
+
+        // The newest REAL backup zip in a character's folder, by CreationTime (matching RefreshBackups' "newest
+        // first"), EXCLUDING (Pre-Restore) and (Pre-Load) snapshots so a load never targets its own safety checkpoint
+        // (a checkpoint's CreationTime is "now", so it would otherwise win). Null when the folder is missing/empty or
+        // holds only checkpoints. Never throws.
+        public static string FindLatestRealBackup(string backupDir)
+        {
+            try
+            {
+                return Directory.GetFiles(backupDir, "*.zip")
+                    .Where(f =>
+                    {
+                        string n = Path.GetFileName(f);
+                        return !n.StartsWith("(Pre-Restore)", StringComparison.OrdinalIgnoreCase)
+                            && !n.StartsWith("(Pre-Load)", StringComparison.OrdinalIgnoreCase);
+                    })
+                    .OrderByDescending(f => File.GetCreationTimeUtc(f))
+                    .FirstOrDefault();
+            }
+            catch { return null; }
+        }
+
         public static bool IsRealSaveEntry(string entryFileName)
         {
             string leaf = Path.GetFileName(entryFileName.Replace('/', Path.DirectorySeparatorChar));


### PR DESCRIPTION
## Why
DD2 has one save slot. This is the headline of the Characters feature: a one-click **"Load into game"** that puts the character you're viewing into your live save, so you can play multiple characters.

## Model: viewing vs playing
- **ActiveCharacter** = the character whose backups you're *viewing* (the increment-1 switcher; non-destructive).
- **LoadedCharacter** (new, persisted) = the character whose save is currently *live*.
- A `Playing: X` hint appears in the header only when viewing ≠ playing, so it's always clear which character the game would load.

## "Load into game" flow (loads the active character)
1. Guards: not configured / already-loaded (A==B → "use Restore to roll back") / empty target.
2. Compute `LiveFolderHasRealSave` once.
3. **Snapshot the outgoing character** — `RestoreEngine.CreatePreLoadCheckpoint` writes the current live save into the *loaded* character's own folder as a retention-exempt `(Pre-Load)` backup (a verbatim clone of the pre-restore checkpoint, so it's verified, atomic, and never auto-pruned). Abort (status only, no mutation) only if there was provably a save to keep and the snapshot failed.
4. **Restore the target** via the hardened `RestoreService.Restore` verbatim — its own single game-running guard, single Steam-Cloud confirm, transactional swap, rollback.
5. **Flip `LoadedCharacter` only if the restore commits.**

**Invariant:** `LoadedCharacter` flips to the target iff the target is now the live save. A cancelled/failed load leaves live + LoadedCharacter as the outgoing character — **no limbo**.

## Why the design took three workflow passes
The first design flipped the active character before the restore committed → it could strand you "viewing B, playing A," plus an A==B trap and a double Steam-Cloud prompt. The adversarial reviews caught all of it; the shipped model (separate viewing/playing state + flip-only-on-commit + one lock-free `DoRestoreCore`) structurally removes those.

## Core changes (minimal, additive)
- `SaveScan.LiveFolderHasRealSave`, `SaveScan.FindLatestRealBackup` (newest by CreationTime, excludes `(Pre-Restore)`/`(Pre-Load)`).
- `RestoreEngine.CreatePreLoadCheckpoint` (prefix-only clone of `CreatePreRestoreCheckpoint`).
- `MainViewModel`: lock-free `DoRestoreCore` extracted from `DoRestore` (Restore/Undo behavior unchanged); `LoadedCharacter` state + persistence + `PlayingIndicator`; the `LoadIntoGame` command.
- `MainWindow.xaml`: "Load into game" button + the "Playing:" hint.

## Verification
- Build clean; **harness 376/0** (+23): live-save detection, newest-real-backup ordering with checkpoint exclusion, `(Pre-Load)` naming/skip rules, the full load sequence (live becomes target; `(Pre-Load)` of old save in the outgoing folder; `(Pre-Restore)` in the target folder), and the **no-limbo proof** (declined restore → live byte-unchanged → flip-gate false).
- Throwaway-settings launch (two characters, viewing ≠ playing) renders the new UI cleanly.
- **The save-swap was never run against real DD2 saves** — all restore tests use throwaway folders, per the project's real-saves safety rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)