### PR TITLE
feat(characters): load a character's most-recent state, not its older backup

### DIFF
--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -1134,24 +1134,29 @@ namespace RestoreHarness
 
         static void Test_FindLatestRealBackup()
         {
-            Console.WriteLine("== load: newest real backup (excludes checkpoints, CreationTime order) ==");
+            Console.WriteLine("== load: newest loadable backup (includes (Pre-Load), excludes (Pre-Restore)) ==");
             string dir = NewDir("flrb");
             string older = Path.Combine(dir, "backup_old.zip");
             string newer = Path.Combine(dir, "backup_new.zip");
-            string preR = Path.Combine(dir, "(Pre-Restore) 240101000000.zip");
             string preL = Path.Combine(dir, "(Pre-Load) 240101000000.zip");
-            foreach (string p in new[] { older, newer, preR, preL }) File.WriteAllText(p, "z");
-            // Make the CHECKPOINTS the newest by CreationTime — they must STILL be excluded.
+            string preR = Path.Combine(dir, "(Pre-Restore) 240101000000.zip");
+            foreach (string p in new[] { older, newer, preL, preR }) File.WriteAllText(p, "z");
             File.SetCreationTimeUtc(older, new DateTime(2024, 1, 1));
             File.SetCreationTimeUtc(newer, new DateTime(2024, 1, 2));
-            File.SetCreationTimeUtc(preR, new DateTime(2024, 1, 9));
-            File.SetCreationTimeUtc(preL, new DateTime(2024, 1, 9));
-            Check("returns newest real backup, checkpoints excluded even when newer",
-                SaveScan.FindLatestRealBackup(dir) == newer);
+            File.SetCreationTimeUtc(preL, new DateTime(2024, 1, 5));   // a (Pre-Load) of more-recent live progress
+            File.SetCreationTimeUtc(preR, new DateTime(2024, 1, 9));   // an undo-checkpoint, newest file of all
+            // (Pre-Load) IS the character's most-recent state -> it wins over older normal backups; the (Pre-Restore)
+            // undo-checkpoint is excluded even though it is the newest file.
+            Check("(Pre-Load) loads as newest state; (Pre-Restore) excluded even when newest",
+                SaveScan.FindLatestRealBackup(dir) == preL);
 
-            string onlyCheckpoints = NewDir("flrb_ck");
-            File.WriteAllText(Path.Combine(onlyCheckpoints, "(Pre-Restore) 1.zip"), "z");
-            Check("only checkpoints -> null", SaveScan.FindLatestRealBackup(onlyCheckpoints) == null);
+            string normalOnly = NewDir("flrb_n");
+            string nb = Path.Combine(normalOnly, "backup_x.zip"); File.WriteAllText(nb, "z");
+            Check("normal backup returned when no snapshots", SaveScan.FindLatestRealBackup(normalOnly) == nb);
+
+            string onlyPreR = NewDir("flrb_ck");
+            File.WriteAllText(Path.Combine(onlyPreR, "(Pre-Restore) 1.zip"), "z");
+            Check("only (Pre-Restore) undo-checkpoint -> null (nothing to load)", SaveScan.FindLatestRealBackup(onlyPreR) == null);
             Check("missing folder -> null (no throw)", SaveScan.FindLatestRealBackup(Path.Combine(dir, "nope")) == null);
             Console.WriteLine();
         }
@@ -1168,7 +1173,8 @@ namespace RestoreHarness
             string[] zips = Directory.GetFiles(target, "*.zip");
             Check("exactly one zip written", zips.Length == 1, "found " + zips.Length);
             Check("name starts with (Pre-Load)", zips.Length == 1 && Path.GetFileName(zips[0]).StartsWith("(Pre-Load)"));
-            Check("snapshot is excluded by FindLatestRealBackup", SaveScan.FindLatestRealBackup(target) == null);
+            Check("snapshot IS loadable as the character's most-recent state",
+                zips.Length == 1 && SaveScan.FindLatestRealBackup(target) == zips[0]);
             Check("no .savedrake.tmp left", Directory.GetFiles(target, "*.savedrake.tmp").Length == 0);
 
             // No save data in live -> justified skip, true, no zip.

--- a/Savedrake.Core/SaveScan.cs
+++ b/Savedrake.Core/SaveScan.cs
@@ -120,21 +120,20 @@ namespace Savedrake
             catch { return false; }
         }
 
-        // The newest REAL backup zip in a character's folder, by CreationTime (matching RefreshBackups' "newest
-        // first"), EXCLUDING (Pre-Restore) and (Pre-Load) snapshots so a load never targets its own safety checkpoint
-        // (a checkpoint's CreationTime is "now", so it would otherwise win). Null when the folder is missing/empty or
-        // holds only checkpoints. Never throws.
+        // The newest backup to LOAD for a character, by CreationTime (matching RefreshBackups' "newest first").
+        // EXCLUDES (Pre-Restore) undo-checkpoints (a restore's "before" snapshot — never the thing you mean to load as
+        // "newest"), but INCLUDES (Pre-Load) snapshots: a (Pre-Load) captures a character's live save at the moment you
+        // last switched away from it, so it IS that character's most-recent state and SHOULD load when you return to it
+        // (otherwise loading the character would silently drop the progress made since its last ordinary backup). This
+        // is safe because the only time a load could re-target a just-taken (Pre-Load) is loading the same character
+        // whose save is already live, which the A==B guard refuses. Null when the folder is missing/empty or holds only
+        // undo-checkpoints. Never throws.
         public static string FindLatestRealBackup(string backupDir)
         {
             try
             {
                 return Directory.GetFiles(backupDir, "*.zip")
-                    .Where(f =>
-                    {
-                        string n = Path.GetFileName(f);
-                        return !n.StartsWith("(Pre-Restore)", StringComparison.OrdinalIgnoreCase)
-                            && !n.StartsWith("(Pre-Load)", StringComparison.OrdinalIgnoreCase);
-                    })
+                    .Where(f => !Path.GetFileName(f).StartsWith("(Pre-Restore)", StringComparison.OrdinalIgnoreCase))
                     .OrderByDescending(f => File.GetCreationTimeUtc(f))
                     .FirstOrDefault();
             }


### PR DESCRIPTION
## Why
A refinement to the "Load into game" save-swap. When you switch away from a character, Savedrake snapshots its live save as a `(Pre-Load)` (so its most-recent progress is kept). But `FindLatestRealBackup` excluded `(Pre-Load)`, so when you later *loaded* that character back, it restored the character's older *ordinary* backup, silently dropping the progress made since then (the `(Pre-Load)` was preserved on disk but never auto-loaded). That's a round-trip trap.

## What
`SaveScan.FindLatestRealBackup` now **includes `(Pre-Load)` snapshots** as load candidates (they're a genuine save state — the character's state when you last left it) and still **excludes `(Pre-Restore)` undo-checkpoints** (you never want to load your undo-point as "newest"). One clause removed; the method is used only by `LoadIntoGame`.

## Why it's safe
- In an A→B load, the `(Pre-Load)` is written to the **outgoing** (A's) folder; the target is picked from the **active** (B's) folder, before the snapshot is even written — so a load can never re-target the snapshot it just created.
- Loading the character whose save is already live (which is the only case that could re-target a fresh `(Pre-Load)`) is refused by the existing **A==B guard**.
- `RestoreService` validates the chosen zip (CRC + manifest + staged-dir check) and takes its own fail-closed pre-restore checkpoint **before** any swap, so even a bad `(Pre-Load)` fails safe.
- Adversarially reviewed against all six load/recovery scenarios — no way to load the wrong save or lose progress.

## Verification
- Build clean; **harness 376 → 377**: a `(Pre-Load)` beats older normal backups by CreationTime, while a `(Pre-Restore)` is excluded even when it's the newest file; only-`(Pre-Restore)` → null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)