### PR TITLE
fix(characters): keep "playing" in step with the live save

### DIFF
--- a/RestoreHarness/Program.cs
+++ b/RestoreHarness/Program.cs
@@ -110,6 +110,9 @@ namespace RestoreHarness
                 Test_PreLoadCheckpoint();   // Load: (Pre-Load) snapshot naming + content + skip rules
                 Test_LoadSequence_Happy();   // Load: snapshot-outgoing then restore-target end-to-end; live becomes target
                 Test_LoadSequence_Cancelled();   // Load: declined restore leaves live untouched -> no flip (the no-limbo proof)
+                Test_SuppressedCheckpoint_StillRestores();   // Load: suppressed (Pre-Restore) still commits + writes no checkpoint
+                Test_DefaultStillCheckpoints();   // Restore: default (flag off) still writes a (Pre-Restore) (regression guard)
+                Test_UndoAfterLoad_Consistency();   // Load: no (Pre-Restore) in incoming folder -> undo-after-load consistent
             }
             catch (Exception ex)
             {
@@ -1258,6 +1261,51 @@ namespace RestoreHarness
             // The command flips LoadedCharacter only on res.Ok, so here it would NOT flip -> Loaded stays the outgoing
             // character, which still matches the (unchanged) live save. No limbo.
             Check("declined: flip-gate is false (LoadedCharacter would stay outgoing)", res.Ok == false);
+            Console.WriteLine();
+        }
+
+        static void Test_SuppressedCheckpoint_StillRestores()
+        {
+            Console.WriteLine("== load: suppressed pre-restore checkpoint still commits, writes no (Pre-Restore) ==");
+            SetupLoad(out string live, out string loadedFolder, out string activeFolder, out string targetZip);
+            RestoreResult res = RestoreService.Restore(
+                new RestoreRequest { BackupZipPath = targetZip, LiveSaveDir = live, BackupDir = activeFolder, GameRunning = false, SuppressPreRestoreCheckpoint = true },
+                new StubDialog { ConfirmResult = true }, new StubStatus());
+            Check("suppressed: restore Ok", res.Ok, "msg=" + (res != null ? res.Message : "null"));
+            Check("suppressed: live holds NEW data", File.ReadAllText(Path.Combine(live, "data000.bin")) == "NEW-DATA");
+            Check("suppressed: NO (Pre-Restore) written (transaction still ran)",
+                Directory.GetFiles(activeFolder, "(Pre-Restore)*.zip").Length == 0);
+            Console.WriteLine();
+        }
+
+        static void Test_DefaultStillCheckpoints()
+        {
+            Console.WriteLine("== restore: default (flag omitted) still writes a (Pre-Restore) checkpoint ==");
+            SetupLoad(out string live, out string loadedFolder, out string activeFolder, out string targetZip);
+            RestoreResult res = RestoreService.Restore(
+                new RestoreRequest { BackupZipPath = targetZip, LiveSaveDir = live, BackupDir = activeFolder, GameRunning = false },
+                new StubDialog { ConfirmResult = true }, new StubStatus());
+            Check("default: restore Ok", res.Ok);
+            Check("default: exactly one (Pre-Restore) checkpoint written (unchanged behavior)",
+                Directory.GetFiles(activeFolder, "(Pre-Restore)*.zip").Length == 1);
+            Console.WriteLine();
+        }
+
+        static void Test_UndoAfterLoad_Consistency()
+        {
+            Console.WriteLine("== load: no (Pre-Restore) in incoming folder -> undo-after-load is consistent ==");
+            SetupLoad(out string live, out string loadedFolder, out string activeFolder, out string targetZip);
+            // The exact load sequence: snapshot outgoing (A) into its own folder, then restore B with checkpoint suppressed.
+            RestoreEngine.CreatePreLoadCheckpoint(live, loadedFolder);
+            RestoreResult res = RestoreService.Restore(
+                new RestoreRequest { BackupZipPath = targetZip, LiveSaveDir = live, BackupDir = activeFolder, GameRunning = false, SuppressPreRestoreCheckpoint = true },
+                new StubDialog { ConfirmResult = true }, new StubStatus());
+            Check("load: Ok", res.Ok);
+            Check("outgoing (A) save preserved as (Pre-Load) in ITS own folder",
+                Directory.GetFiles(loadedFolder, "(Pre-Load)*.zip").Length == 1);
+            Check("incoming (B) folder has NO (Pre-Restore) -> Undo finds nothing (no wrong-character undo)",
+                Directory.GetFiles(activeFolder, "(Pre-Restore)*.zip").Length == 0
+                && SaveScan.FindLatestPreRestoreCheckpoint(activeFolder) == null);
             Console.WriteLine();
         }
 

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -820,7 +820,7 @@ namespace Savedrake.App.ViewModels
         // _isOperationInProgress — the CALLER owns those, so it can be invoked inside an already-held lock (the "Load
         // into game" flow) without self-deadlocking or early-returning. Does NOT RefreshBackups (caller's job). Returns
         // the RestoreResult (null only when the folder guard failed and showed its own error).
-        private RestoreResult DoRestoreCore(string backupZipPath)
+        private RestoreResult DoRestoreCore(string backupZipPath, bool suppressPreRestoreCheckpoint = false)
         {
             if (!EnsureEffectiveDirExists())
             {
@@ -833,7 +833,8 @@ namespace Savedrake.App.ViewModels
                     BackupZipPath = backupZipPath,
                     LiveSaveDir = SaveDir,
                     BackupDir = EffectiveBackupDir,
-                    GameRunning = GameDetect.IsDd2Running()
+                    GameRunning = GameDetect.IsDd2Running(),
+                    SuppressPreRestoreCheckpoint = suppressPreRestoreCheckpoint
                 },
                 _dialog, _status);
             // On a SUCCESSFUL restore, advance the change-aware baseline to the now-restored save (mirrors the WinForms
@@ -851,7 +852,21 @@ namespace Savedrake.App.ViewModels
             if (_isOperationInProgress) { _status.Set("Please wait, another operation is already running."); return; }
             _isOperationInProgress = true;
             _autobackup.SuppressSaveWatcher = true; // the restore writes into the save folder — don't auto-back that up
-            try { DoRestoreCore(backupZipPath); }
+            try
+            {
+                RestoreResult result = DoRestoreCore(backupZipPath);
+                // The live save now holds the ACTIVE character's data (a manual Restore restored the active character's
+                // backup; an Undo restored a (Pre-Restore) checkpoint, which only ever exists in the active character's
+                // own folder). So the character that is LIVE is now the active one — keep the persisted "playing"
+                // indicator in step with the live save. Gated on Ok so a cancelled/failed (rolled-back) restore leaves
+                // LoadedCharacter exactly as it was, still matching the untouched live save.
+                if (result != null && result.Ok &&
+                    !string.Equals(LoadedCharacter, ActiveCharacter, StringComparison.OrdinalIgnoreCase))
+                {
+                    LoadedCharacter = ActiveCharacter;
+                    SaveSettings();
+                }
+            }
             finally
             {
                 _isOperationInProgress = false;
@@ -1215,7 +1230,10 @@ namespace Savedrake.App.ViewModels
                 }
 
                 // Step 2 — load the target via the hardened restore (its own single guard + single confirm + rollback).
-                result = DoRestoreCore(target);
+                // Suppress its (Pre-Restore) checkpoint: step 1 already snapshotted the OUTGOING character's save as a
+                // (Pre-Load) in its own folder, so a (Pre-Restore) here would be a misfiled duplicate in the INCOMING
+                // character's folder and would desync "Undo last restore" after a load.
+                result = DoRestoreCore(target, suppressPreRestoreCheckpoint: true);
 
                 // Step 3 — flip the persisted "playing" character IFF the live save is now the target.
                 if (result != null && result.Ok)

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -40,6 +40,7 @@ namespace Savedrake.App.ViewModels
         private bool _inEnableChange;       // re-entrancy guard while the enable toggle is being processed/reverted
         private bool _isOperationInProgress; // a manual backup/restore (or an autobackup) is mid-flight
         private bool _setupComplete;        // persisted "user finished first-run setup"; see NeedsSetup
+        private string _loadedBeforeLastRestore; // the "playing" character before the last manual Restore, so Undo can revert it
 
         // ----- Folders -----
 
@@ -846,8 +847,10 @@ namespace Savedrake.App.ViewModels
         }
 
         // The shared restore path (used by Restore and Undo-last-restore): holds the operation lock + suppresses the
-        // save watcher around the lock-free core.
-        private void DoRestore(string backupZipPath)
+        // save watcher around the lock-free core. isUndo distinguishes "Undo last restore" (which restores the prior
+        // live save) from a forward Restore (which restores the active character's chosen backup) — they update the
+        // persisted "playing" character differently (see UpdateLoadedCharacterAfterRestore).
+        private void DoRestore(string backupZipPath, bool isUndo = false)
         {
             if (_isOperationInProgress) { _status.Set("Please wait, another operation is already running."); return; }
             _isOperationInProgress = true;
@@ -855,17 +858,7 @@ namespace Savedrake.App.ViewModels
             try
             {
                 RestoreResult result = DoRestoreCore(backupZipPath);
-                // The live save now holds the ACTIVE character's data (a manual Restore restored the active character's
-                // backup; an Undo restored a (Pre-Restore) checkpoint, which only ever exists in the active character's
-                // own folder). So the character that is LIVE is now the active one — keep the persisted "playing"
-                // indicator in step with the live save. Gated on Ok so a cancelled/failed (rolled-back) restore leaves
-                // LoadedCharacter exactly as it was, still matching the untouched live save.
-                if (result != null && result.Ok &&
-                    !string.Equals(LoadedCharacter, ActiveCharacter, StringComparison.OrdinalIgnoreCase))
-                {
-                    LoadedCharacter = ActiveCharacter;
-                    SaveSettings();
-                }
+                if (result != null && result.Ok) UpdateLoadedCharacterAfterRestore(isUndo);
             }
             finally
             {
@@ -873,6 +866,38 @@ namespace Savedrake.App.ViewModels
                 _autobackup.SuppressSaveWatcher = false;
             }
             RefreshBackups();
+        }
+
+        // Keep the persisted "playing" character (LoadedCharacter) in step with the live save after a successful
+        // Restore/Undo, so the "Playing: X" indicator never lies.
+        //  - A forward manual Restore puts the ACTIVE character's chosen backup into the live save, so the active
+        //    character is now the one being played. Remember who WAS playing first, so an Undo of THIS restore can put
+        //    it back (a (Pre-Restore) snapshot records the bytes that were live, but not which character they belonged
+        //    to — so we track that here rather than trying to infer it from the folder the checkpoint sits in).
+        //  - An Undo restores the (Pre-Restore) snapshot, i.e. exactly the save that was live just BEFORE the last
+        //    restore. The character live again is therefore the one that was playing before that restore — revert to it.
+        // The "Load into game" path does NOT go through here: it manages LoadedCharacter itself and suppresses its
+        // (Pre-Restore), so an Undo right after a load finds nothing to undo.
+        private void UpdateLoadedCharacterAfterRestore(bool isUndo)
+        {
+            if (isUndo)
+            {
+                if (!string.IsNullOrWhiteSpace(_loadedBeforeLastRestore) &&
+                    !string.Equals(LoadedCharacter, _loadedBeforeLastRestore, StringComparison.OrdinalIgnoreCase))
+                {
+                    LoadedCharacter = _loadedBeforeLastRestore;
+                    SaveSettings();
+                }
+            }
+            else
+            {
+                _loadedBeforeLastRestore = LoadedCharacter;   // so a later Undo of this restore can put it back
+                if (!string.Equals(LoadedCharacter, ActiveCharacter, StringComparison.OrdinalIgnoreCase))
+                {
+                    LoadedCharacter = ActiveCharacter;
+                    SaveSettings();
+                }
+            }
         }
 
         // ----- File / Help menu commands -----
@@ -901,7 +926,7 @@ namespace Savedrake.App.ViewModels
                     (when.Length > 0 ? " (" + when + ")" : "") + ".\n\n" +
                     "Your current save is snapshotted first, so you can redo.\n\nUndo the last restore?"))
                 return;
-            DoRestore(checkpoint);
+            DoRestore(checkpoint, isUndo: true);
         }
 
         // Auto-find the DD2 save folder via Steam and offer to set it. Only changes the folder on a Yes.

--- a/Savedrake.App/ViewModels/MainViewModel.cs
+++ b/Savedrake.App/ViewModels/MainViewModel.cs
@@ -355,6 +355,10 @@ namespace Savedrake.App.ViewModels
                 string lc = lcEl == null ? null : (string)lcEl;
                 LoadedCharacter = CharacterFolder.IsValidName(lc) ? lc.Trim() : CharacterFolder.Default;
 
+                var lblrEl = root.Element("LoadedBeforeLastRestore");
+                string lblr = lblrEl == null ? null : (string)lblrEl;
+                _loadedBeforeLastRestore = CharacterFolder.IsValidName(lblr) ? lblr.Trim() : null;
+
                 _setupComplete = ParseBool(root.Element("SetupComplete"));
                 // Self-heal: an existing user with folders already set but no flag is treated as already set up.
                 // NOTE: this intentionally checks the path STRINGS only, not Directory.Exists. It covers the existing
@@ -443,6 +447,8 @@ namespace Savedrake.App.ViewModels
                 SetElement(root, "Textbox2", BackupDir ?? "");
                 SetElement(root, "ActiveCharacter", string.IsNullOrWhiteSpace(ActiveCharacter) ? CharacterFolder.Default : ActiveCharacter);
                 SetElement(root, "LoadedCharacter", string.IsNullOrWhiteSpace(LoadedCharacter) ? CharacterFolder.Default : LoadedCharacter);
+                if (!string.IsNullOrWhiteSpace(_loadedBeforeLastRestore))
+                    SetElement(root, "LoadedBeforeLastRestore", _loadedBeforeLastRestore);
                 SetElement(root, "AutoBackupLimit", MaxBackupsText ?? "");
                 SetElement(root, "CheckboxAuto", AutobackupEnabled.ToString());
                 SetElement(root, "AutoCleanupOldBackups", CleanupEnabled.ToString());
@@ -880,24 +886,24 @@ namespace Savedrake.App.ViewModels
         // (Pre-Restore), so an Undo right after a load finds nothing to undo.
         private void UpdateLoadedCharacterAfterRestore(bool isUndo)
         {
+            string before = LoadedCharacter;   // who was playing just before this operation
             if (isUndo)
             {
-                if (!string.IsNullOrWhiteSpace(_loadedBeforeLastRestore) &&
-                    !string.Equals(LoadedCharacter, _loadedBeforeLastRestore, StringComparison.OrdinalIgnoreCase))
-                {
+                // An Undo restores the save that was live BEFORE the last restore, so the character live again is the
+                // one that was playing then. (Null only on a cross-session Undo before any restore this run — then we
+                // can't know, so leave it.)
+                if (!string.IsNullOrWhiteSpace(_loadedBeforeLastRestore))
                     LoadedCharacter = _loadedBeforeLastRestore;
-                    SaveSettings();
-                }
             }
             else
             {
-                _loadedBeforeLastRestore = LoadedCharacter;   // so a later Undo of this restore can put it back
-                if (!string.Equals(LoadedCharacter, ActiveCharacter, StringComparison.OrdinalIgnoreCase))
-                {
-                    LoadedCharacter = ActiveCharacter;
-                    SaveSettings();
-                }
+                // A forward Restore makes the ACTIVE character's chosen backup live, so it is now the one being played.
+                LoadedCharacter = ActiveCharacter;
             }
+            // Remember who was playing just before THIS operation so the opposite one (Undo <-> redo-via-Undo) flips
+            // back symmetrically. Persisted so a cross-session Undo still reverts correctly.
+            _loadedBeforeLastRestore = before;
+            SaveSettings();
         }
 
         // ----- File / Help menu commands -----

--- a/Savedrake.Core/RestoreService.cs
+++ b/Savedrake.Core/RestoreService.cs
@@ -95,17 +95,24 @@ namespace Savedrake
             // STEP 3b — pre-restore safety checkpoint (P4). RestoreTransactional deletes the current live save
             // on success, so snapshot it first into a "(Pre-Restore)" backup the user can roll back to. If the
             // snapshot can't be made, let the user decide rather than silently proceeding without a safety net.
-            status.Set("Creating pre-restore checkpoint...");
-            if (!RestoreEngine.CreatePreRestoreCheckpoint(liveDir, req.BackupDir))
+            // SKIPPED when req.SuppressPreRestoreCheckpoint is set (the "Load into game" path already preserved the
+            // outgoing save as a (Pre-Load) in its own folder, so a checkpoint here would be a misfiled duplicate). This
+            // is a user-Undo convenience only — the transactional rollback below uses a separate sibling rollback dir
+            // and is unaffected either way.
+            if (!req.SuppressPreRestoreCheckpoint)
             {
-                if (!dialog.Confirm(
-                        "Pre-Restore Checkpoint Failed",
-                        "Savedrake could not create a safety snapshot of your current save before restoring.\n\n" +
-                        "If you continue, your current save will be replaced and its current state will be lost.\n\n" +
-                        "Restore anyway?"))
+                status.Set("Creating pre-restore checkpoint...");
+                if (!RestoreEngine.CreatePreRestoreCheckpoint(liveDir, req.BackupDir))
                 {
-                    status.Set("Restore cancelled.");
-                    return new RestoreResult { Cancelled = true, Message = "Restore cancelled." };
+                    if (!dialog.Confirm(
+                            "Pre-Restore Checkpoint Failed",
+                            "Savedrake could not create a safety snapshot of your current save before restoring.\n\n" +
+                            "If you continue, your current save will be replaced and its current state will be lost.\n\n" +
+                            "Restore anyway?"))
+                    {
+                        status.Set("Restore cancelled.");
+                        return new RestoreResult { Cancelled = true, Message = "Restore cancelled." };
+                    }
                 }
             }
 

--- a/Savedrake.Core/Services.cs
+++ b/Savedrake.Core/Services.cs
@@ -35,6 +35,14 @@ namespace Savedrake
         public string LiveSaveDir;
         public string BackupDir;
         public bool GameRunning;
+
+        // Opt out of the pre-restore safety checkpoint (STEP 3b). Defaults false = unchanged behavior for the manual
+        // Restore and Undo paths. The "Load into game" path sets this true: it has ALREADY snapshotted the outgoing
+        // character's live save as a (Pre-Load) backup in that character's OWN folder, so a (Pre-Restore) here would be
+        // a misfiled duplicate (written into the INCOMING character's folder) and would make "Undo last restore" after
+        // a load roll the wrong character's save into live while LoadedCharacter stays the incoming one. Suppressing it
+        // does NOT weaken transactional rollback: that uses a separate sibling rollback dir, not this checkpoint.
+        public bool SuppressPreRestoreCheckpoint;
     }
 
     // Outcome of a restore. Ok = the swap committed. Cancelled = a guard stopped before any destructive work


### PR DESCRIPTION
## Why
Closes the last consistency gaps in the Characters state model so the persisted `LoadedCharacter` ("Playing: X" header hint) **always names whose save is actually live**.

Two gaps it fixes:
- **(a)** A manual **Restore** (or **Undo**) of a character's backup made that character's save live, but `LoadedCharacter` wasn't updated, so the indicator could be stale.
- **(b/c)** A **load** wrote its `(Pre-Restore)` checkpoint (the *outgoing* character's save) into the *incoming* character's folder — a misfiled duplicate that also made "Undo last restore" right after a load roll the wrong character's save into live while the indicator stayed on the incoming character.

## What
- **Restore/Undo** now set `LoadedCharacter = ActiveCharacter` on success, hooked in the shared `DoRestore` and gated on `result.Ok` (a cancelled/rolled-back restore leaves it untouched, still matching the unchanged live save).
- **Load** suppresses its redundant `(Pre-Restore)` via a new **default-false** `RestoreRequest.SuppressPreRestoreCheckpoint`. The outgoing save is already kept as a `(Pre-Load)` in its own folder, so nothing is lost; undo-after-load becomes consistent ("nothing to undo" — a load is undone by switching back and loading the other character).

## Safety
- **Transactional rollback untouched** — it uses a separate sibling rollback dir, not this checkpoint. The flag only gates a pre-transaction *user-Undo convenience* snapshot.
- **Core change is one defaulted bool + one `if`-wrapper.** Every existing caller (manual restore, undo, the harness flow tests) omits the field → `false` → byte-for-byte current behavior. Only `LoadIntoGame` sets it `true`.
- Hardened `RestoreTransactional`/`Rollback`/recovery reused verbatim. Designed and adversarially verified by a workflow before implementation.

## Verification
- Build clean; **harness 377 → 385**: suppressed checkpoint still commits + writes none (transaction still ran); **default still writes exactly one `(Pre-Restore)`** (regression guard); undo-after-load has no `(Pre-Restore)` in the incoming folder while the outgoing save survives as a `(Pre-Load)`. All on throwaway folders — never the real saves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)