### PR TITLE
fix(wpf): show the Savedrake dragon in the header brand mark

### DIFF
--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -53,12 +53,14 @@
                     <ColumnDefinition Width="Auto" />   <!-- right controls -->
                 </Grid.ColumnDefinitions>
 
-                <!-- 40px circular brand token: card-filled ellipse, thin gold-alpha stroke, gold serif 'S'. -->
+                <!-- 40px circular brand mark: the Savedrake dragon clipped into a thin gold-ringed disc. -->
                 <Grid Grid.Column="0" Width="40" Height="40" VerticalAlignment="Center">
-                    <Ellipse Fill="{DynamicResource CardBrush}" Stroke="{DynamicResource GoldRuleBrush}" StrokeThickness="1" />
-                    <TextBlock Text="S" FontFamily="Georgia, Times New Roman" FontSize="22" FontWeight="SemiBold"
-                               Foreground="{DynamicResource WordmarkBrush}"
-                               HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    <Ellipse Fill="{DynamicResource CardBrush}" Stroke="{DynamicResource GoldRuleBrush}" StrokeThickness="1.5" />
+                    <Ellipse Margin="1.5">
+                        <Ellipse.Fill>
+                            <ImageBrush ImageSource="savedrake.ico" Stretch="UniformToFill" />
+                        </Ellipse.Fill>
+                    </Ellipse>
                 </Grid>
 
                 <!-- Wordmark in serif gold + small version. -->


### PR DESCRIPTION
## What
The header brand mark showed a placeholder gold **"S"** instead of the Savedrake **dragon**. This fills the gold-ringed disc with the dragon (`savedrake.ico` — already bundled as a `Resource` and used for the window/taskbar icon), so the brand is consistent everywhere.

## Icon status (verified live)
- **Header brand mark** — was "S", now the dragon ✅ (this PR)
- **Taskbar / running window icon** (`Window.Icon`) — already the dragon ✅
- **Exe file icon** (`ApplicationIcon`) — already the dragon ✅ (an earlier "no icon" reading was a transient glitch; the embedded icon is the 32×32 dragon)

## Window size
Confirmed **850×760** is well-proportioned in real use — all cards + the backups list fit, list scrolls, nothing cut off. No change needed.

Pure XAML; no Core/VM change, harness unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)