### PR TITLE
refactor(wpf): move folder config off the main window into File > Settings

### DIFF
--- a/Savedrake.App/MainWindow.xaml
+++ b/Savedrake.App/MainWindow.xaml
@@ -100,9 +100,7 @@
                     <Button Content="File" Style="{StaticResource HeaderMenuButton}" Click="HeaderMenu_Click">
                         <Button.ContextMenu>
                             <ContextMenu>
-                                <MenuItem Header="Detect save folder"
-                                          Command="{Binding PlacementTarget.DataContext.DetectSaveFolderCommand,
-                                                    RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                <MenuItem Header="Settings (folders)…" Click="Settings_Click" />
                                 <MenuItem Header="Undo last restore"
                                           Command="{Binding PlacementTarget.DataContext.UndoLastRestoreCommand,
                                                     RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
@@ -175,60 +173,10 @@
                 <RowDefinition Height="*" />      <!-- Backups list: fills, the only scroll region -->
             </Grid.RowDefinitions>
 
-            <!-- Folders (hidden on first run, while the welcome panel below takes the row instead) -->
-            <Border Grid.Row="0" Style="{StaticResource CardBorder}"
-                    Visibility="{Binding NeedsSetup, Converter={StaticResource NotBoolToVis}}">
-                <StackPanel>
-                    <Button Style="{StaticResource CardHeaderToggle}" Command="{Binding ToggleFoldersCommand}"
-                            ToolTip="Show or hide the folder paths">
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="{Binding FoldersCaret}" Style="{StaticResource SectionCaret}" />
-                            <TextBlock Text="Folders" Style="{StaticResource SectionTitle}" Margin="6,0,0,0" />
-                        </StackPanel>
-                    </Button>
+            <!-- Folder paths (save game + backups) now live in File > Settings, off the main screen since they are set
+                 once. Row 0 is taken by the first-run welcome panel until both folders are configured, then collapses. -->
 
-                    <Grid Visibility="{Binding FoldersExpanded, Converter={StaticResource BoolToVis}}">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="90" />    <!-- label -->
-                            <ColumnDefinition Width="*" />     <!-- path box -->
-                            <ColumnDefinition Width="Auto" />  <!-- count -->
-                            <ColumnDefinition Width="Auto" />  <!-- browse -->
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="8" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-
-                        <!-- Save game row -->
-                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Save game" VerticalAlignment="Center"
-                                   FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
-                        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding SaveDir}" IsReadOnly="True"
-                                 VerticalContentAlignment="Center" Padding="8,6" FontSize="12"
-                                 Background="{DynamicResource InputBrush}" Foreground="{DynamicResource TextBrush}"
-                                 BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" />
-                        <Button Grid.Row="0" Grid.Column="3" Content="Browse" Style="{StaticResource OutlineButton}"
-                                Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseSaveCommand}"
-                                IsEnabled="{Binding ConfigEditable}" />
-
-                        <!-- Backups row -->
-                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Backups" VerticalAlignment="Center"
-                                   FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
-                        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding BackupDir}" IsReadOnly="True"
-                                 VerticalContentAlignment="Center" Padding="8,6" FontSize="12"
-                                 Background="{DynamicResource InputBrush}" Foreground="{DynamicResource TextBrush}"
-                                 BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" />
-                        <TextBlock Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" Margin="10,0,0,0"
-                                   FontSize="12" Foreground="{DynamicResource TextHintBrush}"
-                                   Text="{Binding BackupCount, StringFormat={}{0} backups}" />
-                        <Button Grid.Row="2" Grid.Column="3" Content="Browse" Style="{StaticResource OutlineButton}"
-                                Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseBackupCommand}"
-                                IsEnabled="{Binding ConfigEditable}" />
-                    </Grid>
-                </StackPanel>
-            </Border>
-
-            <!-- First-run welcome (replaces the Folders card until both folders are set; reuses the existing
+            <!-- First-run welcome (shown until both folders are set; reuses the existing
                  Detect/Browse commands). Shown only when NeedsSetup is true; the cards below stay disabled until
                  IsConfigured. -->
             <Border Grid.Row="0" Style="{StaticResource CardBorder}"

--- a/Savedrake.App/MainWindow.xaml.cs
+++ b/Savedrake.App/MainWindow.xaml.cs
@@ -121,6 +121,13 @@ namespace Savedrake.App
             }
         }
 
+        // Open the folder Settings dialog (save game + backups paths). Shares the main window's view model so the
+        // path fields and Detect/Browse commands operate on the live state.
+        private void Settings_Click(object sender, RoutedEventArgs e)
+        {
+            new SettingsWindow { Owner = this, DataContext = DataContext }.ShowDialog();
+        }
+
         // Build the tray icon + its Show/Quit menu. Hidden until the window is minimized with "minimize to tray" on.
         private void InitTray()
         {

--- a/Savedrake.App/SettingsWindow.xaml
+++ b/Savedrake.App/SettingsWindow.xaml
@@ -1,0 +1,69 @@
+<Window x:Class="Savedrake.App.SettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Settings"
+        WindowStyle="None" AllowsTransparency="True" Background="Transparent"
+        SizeToContent="WidthAndHeight" ResizeMode="NoResize"
+        WindowStartupLocation="CenterOwner" ShowInTaskbar="False">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis" />
+    </Window.Resources>
+    <!-- Folder configuration, moved off the main window into this dialog (File > Settings) because the save and backup
+         folders are set once. DataContext is the MainViewModel, so the path fields + Detect/Browse commands bind to the
+         same state the main window uses. Themed like HotkeyDialog (DynamicResource brushes + the app's shared styles). -->
+    <Border Background="{DynamicResource ShellBrush}" BorderBrush="{DynamicResource AccentGoldBrush}"
+            BorderThickness="1" CornerRadius="12" Padding="24" Width="580">
+        <StackPanel>
+            <TextBlock Text="Settings" FontSize="18" FontWeight="SemiBold"
+                       Foreground="{DynamicResource AccentGoldBrush}" Margin="0,0,0,4" />
+            <TextBlock Text="Where Savedrake finds your Dragon's Dogma 2 save and keeps your backups. You usually set these once."
+                       Foreground="{DynamicResource TextSecondaryBrush}" FontSize="13" TextWrapping="Wrap" Margin="0,0,0,18" />
+
+            <TextBlock Text="Save game folder" FontSize="13" FontWeight="SemiBold"
+                       Foreground="{DynamicResource TextBrush}" Margin="0,0,0,6" />
+            <Grid Margin="0,0,0,16">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBox Grid.Column="0" Text="{Binding SaveDir}" IsReadOnly="True"
+                         VerticalContentAlignment="Center" Padding="8,6" FontSize="12"
+                         Background="{DynamicResource InputBrush}" Foreground="{DynamicResource TextBrush}"
+                         BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" />
+                <Button Grid.Column="1" Content="Find it for me" Style="{StaticResource OutlineButton}"
+                        Padding="14,6" Margin="8,0,0,0" Command="{Binding DetectSaveFolderCommand}"
+                        IsEnabled="{Binding ConfigEditable}" />
+                <Button Grid.Column="2" Content="Browse" Style="{StaticResource OutlineButton}"
+                        Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseSaveCommand}"
+                        IsEnabled="{Binding ConfigEditable}" />
+            </Grid>
+
+            <TextBlock Text="Backups folder" FontSize="13" FontWeight="SemiBold"
+                       Foreground="{DynamicResource TextBrush}" Margin="0,0,0,6" />
+            <Grid Margin="0,0,0,6">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBox Grid.Column="0" Text="{Binding BackupDir}" IsReadOnly="True"
+                         VerticalContentAlignment="Center" Padding="8,6" FontSize="12"
+                         Background="{DynamicResource InputBrush}" Foreground="{DynamicResource TextBrush}"
+                         BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" />
+                <Button Grid.Column="1" Content="Browse" Style="{StaticResource OutlineButton}"
+                        Padding="14,6" Margin="8,0,0,0" Command="{Binding BrowseBackupCommand}"
+                        IsEnabled="{Binding ConfigEditable}" />
+            </Grid>
+            <TextBlock Text="{Binding BackupCount, StringFormat={}{0} backups for the current character}"
+                       FontSize="11" Foreground="{DynamicResource TextHintBrush}" Margin="0,0,0,18" />
+
+            <TextBlock Text="Folders are locked while automatic backup is turned on. Turn it off to change them."
+                       FontSize="11" Foreground="{DynamicResource TextHintBrush}" TextWrapping="Wrap"
+                       Margin="0,0,0,18" Visibility="{Binding AutobackupEnabled, Converter={StaticResource BoolToVis}}" />
+
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="Done" Style="{StaticResource PrimaryButton}" Padding="18,7" Click="Done_Click" />
+            </StackPanel>
+        </StackPanel>
+    </Border>
+</Window>

--- a/Savedrake.App/SettingsWindow.xaml.cs
+++ b/Savedrake.App/SettingsWindow.xaml.cs
@@ -1,0 +1,19 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace Savedrake.App
+{
+    // The folder Settings dialog. The caller sets DataContext to the MainViewModel so the path fields and the
+    // Detect/Browse commands bind to the same live state the main window uses. Esc or the Done button closes it; the
+    // folder changes are already persisted by the Browse/Detect commands themselves.
+    public partial class SettingsWindow : Window
+    {
+        public SettingsWindow()
+        {
+            InitializeComponent();
+            PreviewKeyDown += (s, e) => { if (e.Key == Key.Escape) Close(); };
+        }
+
+        private void Done_Click(object sender, RoutedEventArgs e) => Close();
+    }
+}


### PR DESCRIPTION
## Why
You flagged it: the **Folders** config sat on the main screen even though save/backup paths are set once. It belongs out of the daily-use view.

## What
- **Removed the Folders card** from the main window. The main window is now the Autobackup card + the per-character Backups list (and the first-run welcome panel still handles initial setup).
- **Added File → "Settings (folders)…"** → a themed dialog (modeled on the existing Hotkey dialog) holding **Save game folder** (Find it for me / Browse) and **Backups folder** (Browse), reusing the same `MainViewModel` commands so behavior is identical.

## Verified live
- Main window no longer shows the Folders card.
- File menu leads with **Settings (folders)…**; it opens the themed dialog with the real paths and working Detect/Browse.

Pure WPF (XAML + a new dialog window + one click handler); no Core/VM logic change, harness unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)