### PR TITLE
docs: README update-check wording matches post-#89 behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Windows only. Built on .NET Framework 4.8 (WinForms).
   Bin, and the last deletion can be undone.
 - Sound feedback on every backup (manual, hotkey, and autobackup).
 - Minimize to the system tray.
-- Update checks. Savedrake can check GitHub for new releases and notify you. Downloading and
-  installing an update is manual: you choose when, and confirm before any file is replaced.
+- Update checks. Savedrake checks GitHub for new releases and tells you when one is out. It does not
+  download or install anything itself; it points you to the Nexus Mods page to update by hand.
 
 ## Install
 


### PR DESCRIPTION
The self-updater was removed in [#89](https://github.com/sammorrison9800/Savedrake/pull/89). The app no longer downloads or installs updates; it checks GitHub for a version and points to the Nexus page. The README still said "Downloading and installing an update is manual... confirm before any file is replaced," which now misdescribes the app.

This also matters because Nexus Mods support is actively reviewing the file and explicitly does not allow mods that pull files from external sources, so the public wording should accurately say the app does not download or install anything itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)